### PR TITLE
Implementation of the Magnitude Kernel and the RSD Kernel in jax_cosmo

### DIFF
--- a/docs/notebooks/CCL_comparison.ipynb
+++ b/docs/notebooks/CCL_comparison.ipynb
@@ -20,6 +20,17 @@
      "text": [
       "Populating the interactive namespace from numpy and matplotlib\n"
      ]
+    },
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'pyccl'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-774402300861>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menviron\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'JAX_ENABLE_X64'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'True'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mpyccl\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mccl\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mjax\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mjax_cosmo\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCosmology\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbackground\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'pyccl'"
+     ]
     }
    ],
    "source": [
@@ -34,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,21 +585,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "flowpm2",
    "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "name": "flowpm2"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/CCL_comparison.ipynb
+++ b/docs/notebooks/CCL_comparison.ipynb
@@ -588,6 +588,18 @@
    "display_name": "flowpm2",
    "language": "python",
    "name": "flowpm2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/jax-cosmo-intro.ipynb
+++ b/docs/notebooks/jax-cosmo-intro.ipynb
@@ -1,1198 +1,1224 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.2"
-    },
-    "colab": {
-      "name": "jax-cosmo-intro.ipynb",
-      "provenance": [],
-      "toc_visible": true,
-      "include_colab_link": true
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/DifferentiableUniverseInitiative/jax_cosmo/blob/master/docs/notebooks/jax-cosmo-intro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/DifferentiableUniverseInitiative/jax_cosmo/blob/master/docs/notebooks/jax-cosmo-intro.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "lpIJcb3tcFkC"
+   },
+   "source": [
+    "# Introduction to jax-cosmo\n",
+    "\n",
+    "Authors:\n",
+    "  - [@EiffL](https://github.com/EiffL) (Francois Lanusse)\n",
+    "\n",
+    "### Overview\n",
+    "\n",
+    "`jax-cosmo` brings the power of automatic differentiation and XLA execution\n",
+    "to cosmological computations, all the while preserving the readability and human\n",
+    "friendliness of Python / NumPy.\n",
+    "\n",
+    "This is made possible by the [JAX](https://jax.readthedocs.io/en/latest/index.html) framework, which can be summarised as JAX = NumPy + autograd + GPU/TPU. We\n",
+    "encourage the interested reader to follow this [introduction to JAX](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) but it will not be necessary to follow this notebook.\n",
+    "\n",
+    "\n",
+    "### Learning objectives\n",
+    "\n",
+    "In this short introduction we will cover:\n",
+    "  - How to define computations of **2pt functions**\n",
+    "  - How to execute these computations on **GPU** (spoiler alert, you actually don't need to do anything, it happens automatically)\n",
+    "  - How to **take derivatives** of any quantities by automatic differentation\n",
+    "  - And finally, how to piece all of this together for efficient and reliable **Fisher matrices**.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Dlb7kXPYEf6Z"
+   },
+   "source": [
+    "## Installing and importing jax-cosmo\n",
+    "\n",
+    "One of the important aspects of `jax-cosmo` is that it is entirely Python-based\n",
+    "so it can trivially be installed without compiling or downloading any third-party tools.\n",
+    "\n",
+    "Here is how to install the current release on your system:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 51
     },
+    "colab_type": "code",
+    "id": "yZWz-yxPcG6q",
+    "outputId": "b315e257-1cb3-4654-c8ff-2b319ab27b13"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "lpIJcb3tcFkC",
-        "colab_type": "text"
-      },
-      "source": [
-        "# Introduction to jax-cosmo\n",
-        "\n",
-        "Authors:\n",
-        "  - [@EiffL](https://github.com/EiffL) (Francois Lanusse)\n",
-        "\n",
-        "### Overview\n",
-        "\n",
-        "`jax-cosmo` brings the power of automatic differentiation and XLA execution\n",
-        "to cosmological computations, all the while preserving the readability and human\n",
-        "friendliness of Python / NumPy.\n",
-        "\n",
-        "This is made possible by the [JAX](https://jax.readthedocs.io/en/latest/index.html) framework, which can be summarised as JAX = NumPy + autograd + GPU/TPU. We\n",
-        "encourage the interested reader to follow this [introduction to JAX](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html) but it will not be necessary to follow this notebook.\n",
-        "\n",
-        "\n",
-        "### Learning objectives\n",
-        "\n",
-        "In this short introduction we will cover:\n",
-        "  - How to define computations of **2pt functions**\n",
-        "  - How to execute these computations on **GPU** (spoiler alert, you actually don't need to do anything, it happens automatically)\n",
-        "  - How to **take derivatives** of any quantities by automatic differentation\n",
-        "  - And finally, how to piece all of this together for efficient and reliable **Fisher matrices**.\n",
-        "\n",
-        "\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Dlb7kXPYEf6Z",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Installing and importing jax-cosmo\n",
-        "\n",
-        "One of the important aspects of `jax-cosmo` is that it is entirely Python-based\n",
-        "so it can trivially be installed without compiling or downloading any third-party tools.\n",
-        "\n",
-        "Here is how to install the current release on your system:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "yZWz-yxPcG6q",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        },
-        "outputId": "b315e257-1cb3-4654-c8ff-2b319ab27b13"
-      },
-      "source": [
-        "# Installing jax-cosmo\n",
-        "!pip install --quiet jax-cosmo"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "\u001b[?25l\r\u001b[K     |█▌                              | 10kB 28.3MB/s eta 0:00:01\r\u001b[K     |███                             | 20kB 3.0MB/s eta 0:00:01\r\u001b[K     |████▍                           | 30kB 4.0MB/s eta 0:00:01\r\u001b[K     |█████▉                          | 40kB 4.3MB/s eta 0:00:01\r\u001b[K     |███████▎                        | 51kB 3.5MB/s eta 0:00:01\r\u001b[K     |████████▊                       | 61kB 3.9MB/s eta 0:00:01\r\u001b[K     |██████████▏                     | 71kB 4.3MB/s eta 0:00:01\r\u001b[K     |███████████▋                    | 81kB 4.5MB/s eta 0:00:01\r\u001b[K     |█████████████                   | 92kB 4.9MB/s eta 0:00:01\r\u001b[K     |██████████████▌                 | 102kB 4.8MB/s eta 0:00:01\r\u001b[K     |████████████████                | 112kB 4.8MB/s eta 0:00:01\r\u001b[K     |█████████████████▌              | 122kB 4.8MB/s eta 0:00:01\r\u001b[K     |███████████████████             | 133kB 4.8MB/s eta 0:00:01\r\u001b[K     |████████████████████▍           | 143kB 4.8MB/s eta 0:00:01\r\u001b[K     |█████████████████████▉          | 153kB 4.8MB/s eta 0:00:01\r\u001b[K     |███████████████████████▎        | 163kB 4.8MB/s eta 0:00:01\r\u001b[K     |████████████████████████▊       | 174kB 4.8MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▏     | 184kB 4.8MB/s eta 0:00:01\r\u001b[K     |███████████████████████████▋    | 194kB 4.8MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████   | 204kB 4.8MB/s eta 0:00:01\r\u001b[K     |██████████████████████████████▌ | 215kB 4.8MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 225kB 4.8MB/s \n",
-            "\u001b[?25h  Building wheel for jax-cosmo (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xvIGKcbXFEFO",
-        "colab_type": "text"
-      },
-      "source": [
-        "For efficient computation on GPU (if you have one), you might want to make sure that JAX itself is installed with the proper GPU-enabled backend. See [here](https://github.com/google/jax#installation) for more instructions.\n",
-        "\n",
-        "Now that `jax-cosmo` is installed, let's import it along with JAX tools:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "AZkSj6XNcFkE",
-        "colab_type": "code",
-        "outputId": "6a325574-7540-4d62-bbfc-fcfaf00f009d",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "%pylab inline\n",
-        "import jax\n",
-        "import jax_cosmo as jc\n",
-        "import jax.numpy as np"
-      ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Populating the interactive namespace from numpy and matplotlib\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bKuyf8bzFmSR",
-        "colab_type": "text"
-      },
-      "source": [
-        "**Note that we import the JAX version of NumPy here**. That's all that you have to do, any numpy functions you will use afterwards will be JAX-accelerated and differentiable.\n",
-        "\n",
-        "And for the purpose of this tutorial we also define a few plotting functions in the cell bellow, please run it."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "8yvBIf1mm_h-",
-        "colab_type": "code",
-        "cellView": "form",
-        "colab": {}
-      },
-      "source": [
-        "#@title Defining some plotting functions [run me]\n",
-        "\n",
-        "import matplotlib.pyplot as plt\n",
-        "from matplotlib.patches import Ellipse\n",
-        "\n",
-        "def plot_contours(fisher, pos,  nstd=1., ax=None, **kwargs):\n",
-        "  \"\"\"\n",
-        "  Plot 2D parameter contours given a Hessian matrix of the likelihood\n",
-        "  \"\"\"\n",
-        "  \n",
-        "  def eigsorted(cov):\n",
-        "    vals, vecs = linalg.eigh(cov)\n",
-        "    order = vals.argsort()[::-1]\n",
-        "    return vals[order], vecs[:, order]\n",
-        "\n",
-        "  mat = fisher\n",
-        "  cov = np.linalg.inv(mat)\n",
-        "  sigma_marg = lambda i: np.sqrt(cov[i, i])\n",
-        "\n",
-        "  if ax is None:\n",
-        "      ax = plt.gca()\n",
-        "\n",
-        "  vals, vecs = eigsorted(cov)\n",
-        "  theta = degrees(np.arctan2(*vecs[:, 0][::-1]))\n",
-        "\n",
-        "  # Width and height are \"full\" widths, not radius\n",
-        "  width, height = 2 * nstd * sqrt(vals)\n",
-        "  ellip = Ellipse(xy=pos, width=width,\n",
-        "                  height=height, angle=theta, **kwargs)\n",
-        "\n",
-        "  ax.add_artist(ellip)\n",
-        "  sz = max(width, height)\n",
-        "  s1 = 1.5*nstd*sigma_marg(0)\n",
-        "  s2 = 1.5*nstd*sigma_marg(1)\n",
-        "  ax.set_xlim(pos[0] - s1, pos[0] + s1)\n",
-        "  ax.set_ylim(pos[1] - s2, pos[1] + s2)\n",
-        "  plt.draw()\n",
-        "  return ellip"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "nXjimh6KGFWm",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Defining a Cosmology and computing background quantities\n",
-        "\n",
-        "We'll beginning with the basics, let's define a cosmology:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "R0wxmnuBG9EC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Create a cosmology with default parameters\n",
-        "cosmo = jc.Planck15()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "by_0gcYKG9Ag",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Alternatively we can override some of the defaults\n",
-        "cosmo_modified = jc.Planck15(h=0.7)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "d-VI1BFuI3w1",
-        "colab_type": "code",
-        "outputId": "8ed049c5-20bc-4874-87a2-db3e4ed49a4e",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "# Parameters can be easily accessed from the cosmology object\n",
-        "cosmo.h"
-      ],
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "0.6774"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 6
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "8RhqkfHjHgTT",
-        "colab_type": "text"
-      },
-      "source": [
-        "All background quantities can be computed from the `jax_cosmo.background` module, they typically take the cosmology as first argument, and a scale factor\n",
-        "argument if they are not constant."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "bdcm_oReG89o",
-        "colab_type": "code",
-        "outputId": "07e4ff00-3bfb-4bfd-bc61-70350a062435",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 403
-        }
-      },
-      "source": [
-        "# Let's define a range of scale factors\n",
-        "a = np.linspace(0.01, 1.)\n",
-        "\n",
-        "# And compute the comoving distance for these scale factors \n",
-        "chi = jc.background.radial_comoving_distance(cosmo, a)\n",
-        "\n",
-        "# We can now plot the results:\n",
-        "plot(a, chi)\n",
-        "xlabel(r'scale factor $a$')\n",
-        "ylabel(r'radial comoving distance $\\chi$');"
-      ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAEICAYAAACnL3iHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3xV9f348dc7CWEESAgZhJAQ9t5hCbIURLSi1l0VFcU6aq2d/tp+1ba2djhrW0cduGvVChUHiEyZYW8SNpgdCCMEMt6/P+6JRhrgHnJHbvJ+Ph7nce/53DPeR9Q35zNFVTHGGGPcCAt2AMYYY0KPJQ9jjDGuWfIwxhjjmiUPY4wxrlnyMMYY41pEsAMIhLi4OE1LSwt2GMYYE1JWrVpVoKrxNf3WIJJHWloaGRkZwQ7DGGNCiojsOd1vVm1ljDHGNUsexhhjXLPkYYwxxjVLHsYYY1yz5GGMMcY1Sx7GGGNcs+RhjDHGNUseZ3Dg0HH++OlWsouPBzsUY4ypUyx5nMGxE+X8Y/4O5m3ND3YoxhhTp1jyOIMuCc1JjmnKF1vzgh2KMcbUKQFLHiLSTUTWVtsOi8j9IhIrInNEJNP5bOUcLyLyjIhkich6ERlY7VpTnOMzRWSKH2NmbPd4vswq4ER5hb9uY4wxISdgyUNVt6lqf1XtDwwCSoD/AL8A5qpqF2Cusw9wMdDF2aYB/wAQkVjgIWAoMAR4qCrh+MO47gkcL6tg+c4if93CGGNCTrCqrS4AdqjqHmAyMN0pnw5c7nyfDLymHsuAGBFJAi4C5qhqkaoeBOYAE/0V6PCOcTSOCGPeNqu6MsaYKsFKHtcBbzvfE1U12/meAyQ635OBfdXO2e+Una78W0RkmohkiEhGfv65N3g3jQxneKfWzLN2D2OM+VrAk4eIRAKXAf8+9TdVVUB9cR9VfUFV01U1PT6+xunovTa2WwK7C0vYVXDMF6EZY0zIC8abx8XAalXNdfZzneoonM+qv+IfAFKqndfOKTtdud+M7ZYAYL2ujDHGEYzkcT3fVFkBzASqekxNAWZUK7/Z6XU1DCh2qrc+AyaISCunoXyCU+Y3qa2b0Sk+ivnW7mGMMUCAk4eIRAHjgQ+qFT8GjBeRTOBCZx/gY2AnkAW8CNwNoKpFwG+Blc72G6fMr8Z1T2D5ziKOnSj3962MMabOC+gytKp6DGh9Slkhnt5Xpx6rwD2nuc7LwMv+iPF0xnZL4MVFu/gyq4AJvdoE8tbGGFPn2AhzL6WnxdK8cQTzttlUJcYYY8nDS5ERYYzsHMf8bXl4XoqMMabhsuThwrjuCWQXl7I150iwQzHGmKCy5OHCmG6e8SLWZdcY09BZ8nAhoWUTeie3tC67xpgGz5KHS+O6JbBqz0EOlZwMdijGGBM0ljxcGtM9gUqFhZkFwQ7FGGOCxpKHS/3axRAbFWkTJRpjGjRLHi6Fhwmju8azYHs+FZXWZdcY0zBZ8jgHY7snUHTsJOv2Hwp2KMYYExSWPM7BqC5xhIcJn27MCXYoxhgTFJY8zkFMs0gm9EzkXyv3UXLSJko0xjQ8ljzO0W0jO1B8vIwPVvt1KRFjjKmTLHmco/T2reiTHM0rX+6i0hrOjTENjCWPcyQi3DYyjR35x1iYaTPtGmMaFksetXBJn7bEt2jMK1/uDnYoxhgTUJY8aiEyIoybhrVnwfZ8svJspl1jTMNhyaOWbhiaSmREmL19GGMalECvYR4jIu+JyFYR2SIiw0UkVkTmiEim89nKOVZE5BkRyRKR9SIysNp1pjjHZ4rIlEA+w6nimjfm8v5teX/1fpss0RjTYAT6zeNp4FNV7Q70A7YAvwDmqmoXYK6zD3Ax0MXZpgH/ABCRWOAhYCgwBHioKuEEy60jOlBaVsk7K/cFMwxjjAmYgCUPEYkGRgEvAajqSVU9BEwGpjuHTQcud75PBl5Tj2VAjIgkARcBc1S1SFUPAnOAiYF6jpr0SGrJ8I6tmb5kN2UVlcEMxRhjAiKQbx4dgHzgFRFZIyL/FJEoIFFVs51jcoBE53syUP2v8vudstOVf4uITBORDBHJyM/3f1fa20Z2ILu4lM822ZQlxpj6z+vkISKRtbxXBDAQ+IeqDgCO8U0VFQCqqoBPRtyp6guqmq6q6fHx8b645BmN655A+9bNeHnxLr/fyxhjgs3Nm8cyEelTi3vtB/ar6nJn/z08ySTXqY7C+axaKOMAkFLt/HZO2enKgyo8TLjlvDRW7z3E2n02264xpn5zkzzuBN4UkZ+c+oOIfHq2k1U1B9gnIt2coguAzcBMoKrH1BRghvN9JnCz0+tqGFDsVG99BkwQkVZOQ/kEpyzorhrUjuaNI3hx4c5gh2KMMX4V4e2BqrpSRIYCL4nIXOB9PD2mzgOyz3jyN36AJwFFAjuBW/EksHdFZCqwB7jGOfZjYBKQBZQ4x6KqRSLyW2Clc9xvVLXI2+fwpxZNGnHLeWk8Oy+LafsO0S8lJtghGWOMX4inmcGLA0V+B1wPHAfWA2PxdK39uaoGvdroTNLT0zUjIyMg9zpSWsaYP8+nU0Jz/jVtGCISkPsaY4yvicgqVU2v6Tc31Va3AINVtbeq3gD0BVoAfxGRlrUPs35o0aQR94/vyopdRXy+xdY5N8bUT26SR9fq1UOqmq+qk4H5wDJfBxbKrhucQsf4KP7wyRYb92GMqZe8Th6qWnKa8ueBy3wWUT3QKDyMBy/uwc78Yzbq3BhTL/lkkKCqZvniOvXJhT0SGNIhlqfmbOdIaVmwwzHGGJ+yWXX9RET45aQeFB47yfMLrOuuMaZ+seThR/1SYrisX1teXLST7OLjwQ7HGGN8xs30JCIiN4rI/zn7qSIyxH+h1Q8/vagbqvD47O3BDsUYY3zGzZvH34HheMZ6ABwB/ubziOqZlNhm3DIijfdX72fzV4eDHY4xxviEm+QxVFXvAUoBnOnQaztZYoNwz5jORDdtxKMfb8bbQZnGGFOXuUkeZSISjjPrrYjEAzaIwQvRzRrxwPiufJlVyH/W1OnB+MYY4xU3yeMZ4D9Agog8CiwG/uCXqOqhG4e2J719Kx7572byDpcGOxxjjKkVN4ME3wR+hidhZAOXq+q7/gqsvgkLE/50VV9Kyyr41YcbrfrKGBPS3PS2mg7kqOrfVPVZIEdEXvZfaPVPx/jmPDC+K7M35zJrg7cTERtjTN3jptqqr7PmOPB1g/kA34dUv00d2YF+7aJ5aMYmCo+eCHY4xhhzTtwkjzBn8SUARCQWF+uBGI+I8DD+dFU/DpeW8ch/Nwc7HGOMOSduksfjwFIR+a2zGNMS4E/+Cat+69amBT8Y14WZ675i9qacYIdjjDGuuWkwfw24Esh1titV9XV/BVbf3TWmEz2SWvKrDzdSXGITJxpjQourua1UdbOqPutsVudSC43Cw/jzVX0pPHaS386yf5TGmNDidZuFiDQGvgukVT9PVX/j+7Aaht7J0dw1uhPPzsvigu4JXNwnKdghGWOMV9y8ecwAJgPlwLFqm9dEZLeIbBCRtSKS4ZTFisgcEcl0Pls55SIiz4hIloisF5GB1a4zxTk+U0SmuImhrrnvgi70S4nhZ++tZ29hjettGWNMneMmebRT1WtV9U+q+njVdg73HKuq/astqv4LYK6qdgHmOvsAFwNdnG0a8A/4upfXQ8BQYAjwUPVeYKEmMiKMZ68fgAjc89ZqTpRXBDskY4w5KzfJY4mI9PFDDJOB6c736cDl1cpfU49lQIyIJAEXAXNUtcgZazIHmOiHuAImJbYZj1/Tnw0Hinl01pZgh2OMMWflJnmMBFaJyDanGmmDiKx3eT8FZovIKhGZ5pQlqmrVcOscINH5ngxUXwB8v1N2uvJvEZFpIpIhIhn5+fkuwwy88T0TueP8Dry2dA8frf8q2OEYY8wZuRnkd7EP7jdSVQ+ISAIwR0S2Vv9RVVVEfDLpk6q+ALwAkJ6eHhITSf1sYndW7TnIL97fQK+20XSIiwp2SMYYUyM34zz2AIfxvBm0r7Z5TVUPOJ95eGboHQLkOtVROJ95zuEHgJRqp7dzyk5XHvIahYfx7A0DiQgX7nlzNaVl1v5hjKmb3EyMeDuwEPgMeMT5fNjF+VEi0qLqOzAB2AjMBKp6TE3B06sLp/xmp9fVMKDYqd76DJggIq2chvIJTlm90DamKU9e05/N2Yf5zUc2/sMYUze5afP4ITAY2KOqY/FMinjozKd8SyKwWETWASuAWar6KfAYMF5EMoELnX2Aj4GdQBbwInA3gKoWAb8FVjrbb5yyemNs9wS+P7oTby3fy3ur9gc7HGOM+R9u2jxKVbVURBCRxqq6VUS6eXuyqu4E+tVQXghcUEO5Avec5lovA/V6OvifTOjKhgOHePCD9aTGNmNIh9hgh2SMMV9z8+axX0RigA/xNHbPAPb4JywTER7G328YREpsM+58PYM9ha7GYxpjjF+5aTC/QlUPqerDwK+Bl/CMxTB+Et2sES9PGYwCt726kuLjNoGiMaZucNNg/seq76q6QFVnAr/zS1Tma2lxUTx/4yD2FpVwz5urKauoDHZIxhjjqtpqfA1lvhj7Yc5iaMfW/P6KPizOKuChmZts/XNjTNCdtcFcRO7C09OpU7UR5QK0AL70Y2ymmqvTU9hZcIx/zN9Bp/jmTB3ZIdghGWMaMG96W70FfAL8gW8mLQQ4Ut+6yNZ1P53QjV35x/jdrM2kxjZjfM/Es59kjDF+cNZqK1UtVtXdwAdAkTPS/CbgnyIywM/xmWrCwoQnr+1P3+Ro7n1rNct2FgY7JGNMA+WmzePXqnpEREbiGcz3EvCcf8Iyp9M0MpxXbh1Camwzbp+ewfr9bsZpGmOMb7hJHlUTLV0CvKCqs4BI34dkziY2KpLXpw4lplkjpry8gszcI8EOyRjTwLhJHgdE5HngWuBjZ1laV2ugG99pE92EN28fSkR4GDe+tJx9RbYKoTEmcNz8z/8aPBMQXqSqh4BY4Kd+icp4pX3rKF6fOoTSskpufGk5eYdLgx2SMaaBcDPCvERVP1DVTGc/W1Vn+y80443ubVry6q2DyT9ygpteWsGhkpPBDskY0wCcNXmIyGLn84iIHD710/8hmrMZkNqKF29OZ1fBMaa8vILiEpvGxBjjX9501R3pfLZQ1Zanfvo/ROONEZ3j+Pv3BrIl+wjfe2kZB4/ZG4gxxn/kbFNdiMgDZ/pdVZ/waUR+kJ6erhkZGcEOIyDmbcvjztdX0TEuijdvH0rr5o2DHZIxJkSJyCpVTa/pN2/aPFo4WzpwF5DsbN8HBvoqSOMbY7sl8NIUTxXW9S8uI//IiWCHZIyph7yptnpEVR/Bs1b4QFX9sar+GBgEpPo7QOPe+V3ieeXWwewrOs51Lyy1XljGGJ9z01U3EahekX7SKTN10Hmd4ph+2xByiku59oVlZBcfD3ZIxph6xE3yeA1YISIPi8jDwHLgVbc3FJFwEVkjIh85+x1EZLmIZInIv0Qk0ilv7OxnOb+nVbvGg075NhG5yG0MDcWQDrG8NnUI+UdOcM3zS9ldYKsRGmN8w804j0eBW4GDznarqv7hHO75Q2BLtf0/Ak+qamfnulOd8qnAQaf8Sec4RKQncB3QC5gI/F1Ews8hjgZhUPtY3rx9KEdLy7nquSVsPFAc7JCMMfWAq+lFVHW1qj7tbGvc3kxE2uGZG+ufzr4A44D3nEOmA5c73yc7+zi/X+AcPxl4R1VPqOouIAsY4jaWhqRfSgzv3XUejSPCufb5pSzOLAh2SMaYEBfouameAn4GVK2l2ho4pKrlzv5+PD25cD73ATi/FzvHf11ewznmNDrFN+eDu88jJbYZt766gpnrvgp2SMaYEBaw5CEilwJ5qroqQPebJiIZIpKRn58fiFvWeYktm/CvO4czILUV9729hpcX7wp2SMaYEBXIN48RwGUisht4B0911dNAjIhUrWjYDjjgfD8ApAA4v0cDhdXLazjna6r6gqqmq2p6fHy8758mREU3bcRrtw3hol6J/OajzTz2yVZbE90Y45o3y9ACpx1pXgysUtW1ZztfVR8EHnSuNQb4iap+T0T+DVyFJ6FMAWY4p8x09pc6v3+hqioiM4G3ROQJoC3QBVjh7XMYaNIonL9/bxC/nrGR5xbsYP/BEv5ydT+aNLJ+B8YY73idPPCMME8H/uvsXwqsB74vIv9W1T+dYww/B94Rkd8Ba/CsUIjz+bqIZAFFeHpYoaqbRORdYDNQDtyjqhX/e1lzJuFhwqOX9yY1thl//HQr+w4e58WbBpHQskmwQzPGhICzzm319YEiC4FJqnrU2W8OzMLTXXaVqvb0W5S11JDmtjoXn23K4f531hLTrBH/nJJOr7bRwQ7JGFMH1HZuqyoJQPWJksqARFU9fkq5CTEX9WrDv78/HICrn1vK7E05QY7IGFPXuUkebwLLReQhZ4T5EjxtD1F4qpBMCOudHM2Me0bQJaE5d76xiucW7LCGdGPMaXldbQUgIul4ek0psERVQ6IuyKqtvHf8ZAU/eW8ds9Znc3n/tvzhyr40jbSGdGMaIp9UW4lIY6ArEAXEAJNE5P98E6KpK5pGhvPX6wbwwPiuzFj3FVf+Ywl7C0uCHZYxpo5xU201A8/UIOXAsWqbqWfCwoT7LujCy7cM5sDBEi796yLmbc0LdljGmDrETW+rjara28/x+IVVW527vYUl3PnGKrbmHOb+C7ryg3GdCQuTYIdljAkAX/W2WiIifXwUkwkRqa2b8cFd53F5/2Se/Hw7d7yWQfHxsmCHZYwJMjfJYySwyllDY72IbBCR9f4KzNQdTSPDeeKafjxyWS8WbM/n0r8uYu2+Q8EOyxgTRG5GmF/styhMnSciTDkvjd7J0dz39hqu+scSfj6xO1NHdrBqLGMaIDeLQe2pafNncKbuGdS+FbPuG8m47gk8+vEWbn8tg6JjJ89+ojGmXjlr8hCRxc7nERE5XG07IiKH/R+iqWtimkXy/E2DeOSyXizOLGDS04tYvrMw2GEZYwLorMlDVUc6ny1UtWW1rYWqtvR/iKYuqqrG+uDu82jSKIzrX1zGU59vp7yi8uwnG2NCnptBgg+ISFt/BmNCT+/kaD6673wm90/mqc8zufr5pewptOE/xtR3bnpbtQDmiMgiEblXRBL9FZQJLc0bR/Dktf155voB7Mg7ysVPL+KdFXttbixj6jE3DeaPqGov4B4gCVggIp/7LTITci7r15ZP7x9F/5QYfvHBBu54bRUFR23CZWPqo3NZhjYPyMGzJGyCb8Mxoa5tTFPemDqUX13Sg4WZ+Ux8aiFzt+QGOyxjjI+5afO4W0TmA3OB1sAdqtrXX4GZ0BUWJtx+fkf+e+9I4po3Zur0DH787jqKS2xkujH1hZs3jxTgflXtpaoPq6qt4WHOqFubFsy4dwQ/GNeZD9ceYPyTC/h8s72FGFMfuGnzeBBQp7H8XhHp58e4TD3ROCKcH0/oxox7RhAbFcntr2Vw/ztrOGgDC40JaW6qre7Ds5pggrO9ISI/cHF+ExFZISLrRGSTiDzilHcQkeUikiUi/xKRSKe8sbOf5fyeVu1aDzrl20TkIm9jMMHTOzmamfeO5IcXdOGj9dmMf3Ihn2605W6NCVVuqq1uB4aq6v+p6v8Bw4A7XJx/Ahinqv2A/sBEERkG/BF4UlU7AweBqc7xU4GDTvmTznGISE/gOqAXMBH4u4jYUnchIDIijB+N78qMe0eQ0KIx339jFXe9sYrcw6XBDs0Y45Kb5CFARbX9CqfMK+px1Nlt5GwKjAPec8qnA5c73yc7+zi/XyAi4pS/o6onVHUXkAUMcfEcJsh6tY1mxr0j+OlF3fhiax4XPr6A15fuprLSxoUYEyrcJI9XgOUi8rBT5bQceNnNzUQkXETW4unuOwfYARxS1XLnkP1AsvM9GdgH4PxejKeX19flNZxT/V7TRCRDRDLy8/PdhGkCoFF4GPeM7cxn94+ib0o0v56xie8+t4StOTZdmjGhwE2D+RPArXjGdxQAU1T1STc3U9UKVe0PtMPzttDdzfku7/WCqqaranp8fLy/bmNqKS0uijemDuWJa/qxp7CES59ZzJ8+3UppWcXZTzbGBI3X63mISDrwSyDNOW+aiOi5jPVQ1UMiMg8YDsSISITzdtEOOOAcdgBP9+D9IhIBRONJXFXlVaqfY0KQiHDlwHaM6ZbA7z/ewt/n72Dmuq946Du9uLBHAp7aSmNMXeKm2upNPFVXVwKXOtt3vD1ZROJFJMb53hQYD2wB5gFXOYdNAWY432c6+zi/f6GeyZJmAtc5vbE6AF2AFS6ew9RRsVGR/OXqfrx9xzCaRYZzx2sZTJ2eYRMtGlMHibeT14nI4qrp2c/pRiJ98TSAh+NJWu+q6m9EpCPwDhALrAFuVNUTItIEeB0YABQB16nqTudavwRuA8rxDFz85Ez3Tk9P14yMjHMN3QRBWUUl05fs5sk52ymrVL4/uhN3j+lEk0bWsc6YQBGRVaqaXuNvLpLHBcD1eKYn+Xq2O1X9wBdB+pMlj9CVe7iUR2dtYea6r2jXqim/vrQnE3omWlWWMQFwpuThptrqVpzxGXiqq76Dp+rKGL9JbNmEZ64fwFt3DKVpo3DufH0VN7603HplGRNkbt48tqlqNz/H4xf25lE/lFVU8sayPTz1eSZHSsu4YWgqD4zvRmxUZLBDM6Ze8tWbxxJndLcxQdEoPIxbR3Rg/k/GcNOw9ry9Yh9j/jyPlxbvosyWvzUmoNy8eWwBOgG78LR5CJ6B43V+WnZ786iftuce4bcfbWZRZgEd46L4+cXdrT3EGB/yVYN5+5rKVXVPLWILCEse9Zeq8sXWPH7/8RZ25B9jSFosD07qzoDUVsEOzZiQ55PkEcosedR/5RWVvLNyH099vp2Coye5pG8SP7+oO6mtmwU7NGNCls+Sh7OGx/nO7iJVXeeD+PzOkkfDcfREOS8s2MGLi3ZRXlnJTcPSuHdcZ2tUN+Yc+KTBXER+SC3W8zAmEJo3juCBCd2Y/9MxXDmgHa8u2cWoP83jqc+3c/RE+dkvYIzxips2j/XAcFU95uxHAUutwdzUZZm5R3h89nY+3ZRDbFQk94ztzPeGptpIdWO84KuuurVaz8OYYOiS2ILnbhrEh/eMoEdSC3770WbG/WU+767cR7l17zXmnJ3reh4PA8twuZ6HMcHSPyWGN28fxpu3DyW+RWN+9v56xj+5kA/XHKDCFqEyxjW3DeYDgarJERep6hq/ROVjVm1lqlNVZm/O5ck529mac4TOCc25/8IuTOqdRFiYvUwbU8VX4zymAz9U1UPOfivgcVW9zWeR+oklD1OTykrl0005PDlnO5l5R+mW2IIfje/ChJ5tLIkYg+/aPPpWJQ4AVT2IZ7p0Y0JSWJgwqU8Sn94/iqev609ZRSXff2M1l/x1MR9vyLY11Y05AzfJI8x52wBARGJxsRKhMXVVeJgwuX8ys380iieu6ceJ8grufnM1E59eyIy11iZiTE3cVFvdDPw/4N9O0dXAo6r6up9i8xmrtjJuVFQqszZk89e5mWTmHaVjfBT3ju3MZf3aEhHu5u9bxoQ2X44w7wmMc3a/UNXNPojP7yx5mHNR1SbyzNxMtuYcITW2GXeO7sh3B7azcSKmQbC5rSx5mFqorFQ+35LL3+bvYN2+Q8S3aMwd53fghqHtad7Yam5N/WXJw5KH8QFVZemOQv42P4svswqJbtqIKcPbc8uIDjZ3lqmXfNXbqrZBpIjIPBHZLCKbnLmyEJFYEZkjIpnOZyunXETkGRHJEpH1zhiTqmtNcY7PFJEpgXoG07CJCOd1juPN24fx4T0jGNohlme+yGLEY1/w0IyN7CsqCXaIxgRMwN48RCQJSFLV1SLSAlgFXA7cAhSp6mMi8guglar+XEQmAT8AJgFDgadVdajTyysDSAfUuc4gp+twjezNw/hLZu4Rnl+48+teWRf3SeLOUR3p2y4m2KEZU2u1qrYSkSN4/if9Pz/hWUmw5TkGNQN41tnGqGq2k2Dmq2o3EXne+f62c/w2YEzVpqp3OuXfOq4mljyMv+UUl/LKkl28tWwvR06UM6xjLHeO6sTorvE24NCErDMlj7O29qlqCz8ElIZngOFyIFFVs52fcoBE53sysK/aafudstOVn3qPacA0gNTUVN8Fb0wN2kQ34cGLe3Dv2M68vWIvLy/eza2vrqRzQnOmjuzAFQOSrYeWqVdctXmISCsRGSIio6o2tzcUkebA+8D9qnq4+m/qeQ3yST2aqr6gqumqmh4fH++LSxpzVi2aNGLaqE4s/NlYnrimH5HhYTz4wQbOe+wLnpiznfwjJ4IdojE+4XU/QxG5Hfgh0A5YCwwDlvLNuA9vrtEIT+J4U1U/cIpzRSSpWrVVnlN+AEipdno7p+wAnqqr6uXzvY3BmECIjAjjyoHtuGJAMst2FvHS4p389YtMnpu/g8n923LriA70bHtONb7G1Alu3jx+CAwG9qjqWDzVTofOfMo3RESAl4AtqvpEtZ9mAlU9pqYAM6qV3+z0uhoGFDvVW58BE5y3oFbABKfMmDpHRBjeqTX/nDKYuQ+M5trBKXy0PptJzyzi2ueX8unGbFtXxIQkN9OTrFTVwSKyFhiqqidEZJOq9vLy/JHAImADUPVfy//D0+7xLpAK7AGuUdUiJ9k8C0wESoBbVTXDudZtzrngmSLllTPd2xrMTV1SXFLGuxn7mL50N/sPHic5pik3DW/PdYNTiGlm40VM3eGrKdn/A9wK3I+nquog0EhVJ/kqUH+x5GHqoopKZe6WXF5dspslOwpp0iiMyf2SuWl4e3onRwc7PGN8P8JcREYD0cCnqnqylvH5nSUPU9dtzTnM9CW7+XDNVxwvq2BgagxTzktjYu82NI6wXlomOGx6EkseJkQUl5Tx71X7eGPZHnYXlhDXPJLrBqdyw9BU2sY0DXZ4poGp7SDBxao6stpgQan+ea6DBAPJkocJNZWVyqKsAl5fupu5W/MQYFz3RL43NJVRXeMJt4GHJgBqO0hwpPPp88GCxpiahYUJo7vGM7prPPuKSnh7xV7ezdjH51tySY5pyg1DU9mN8XcAABFcSURBVLk6vR0JLZoEO1TTQHnz5vHAmX4/pdttnWRvHqY+OFleyezNOby1fC9LdhQSESZc1KsN1w1JYUSnOJsGxfhcrd48gKo3jm54xnnMdPa/A6yofXjGGG9ERoRxad+2XNq3LTvyj/LW8r28v3o/szZkkxLblOsGp3L1oHYktLS3EeN/brrqLgQuUdUjzn4LYJaqup6iJNDszcPUV6VlFXy2KYe3V+xl2c4iwsOEcd0TuH5ICqO6xNuyuaZWavvmUSURqN4t9yTfTGJojAmCJo3Cmdw/mcn9k9lVcIx3Vu7l/VX7mbM5lzYtm/DdQclck55C+9ZRwQ7V1DNu3jx+CVwD/Mcpuhx4V1V/76fYfMbePExDcrK8krlbcnk3Yx8LtudTqTCsYyzXDk5hYq8kmkbauBHjHZ+N83BW8zvf2V2oqmt8EJ/fWfIwDVV28XHeX7WfdzP2s7eohBZNIvhOv7ZcNagdA1Ji8MwCZEzNfJk8WgFdgK9b5FR1Ya0j9DNLHqahq6xUlu8q4t2MfXyyMZvSsko6xUdx1aAUrhiQTJtoa2Q3/8tXc1vVOCW7qno9JXuwWPIw5htHSsv4eEM2763az8rdBwkTOL9LPN8d1I4JPRNt0SrzNV8ljw14uuouU9X+ItId+L2qXum7UP3DkocxNdtdcIz3V+/n/VX7+aq4lBaNI5jUJ4krByYzOC3Wxo40cL5KHrWakj2YLHkYc2aVlcqynYV8sOYAn2zI5tjJCtq1asoVA5K5YkAyHeObBztEEwQ2JbslD2O8VnKynNmbcnl/9X6+zCqgUqFfu2guH5DMpX3bEt+icbBDNAFS6+ThLMzUTlX3Ofs2JbsxDUDu4VJmrv2K/6w5wObsw4SHCSM7x3HFgGQm9EqkWaSboWIm1PiszUNV+/g0sgCx5GFM7W3PPcKHaw4wY+1XHDh0nKaNwpnQK5HL+rXl/C7xREbYaPb6xlfJYzrwrKqu9GVwgWDJwxjfqaxUMvYc5D9rDvDJxmwOlZQR06wRk/okMblfW2tor0d8lTy2Ap3xrDN+jG/W8+jr5fkvA5cCeara2ymLBf4FpAG78axfftCpJnsamIRn/fJbVHW1c84U4FfOZX+nqtPPdm9LHsb4x8nyShZl5jNz3VfM3pTL8bIKkqKbcGnfJL7Try19kqNtIGII81XyaF9Tuaru8fL8UcBR4LVqyeNPQJGqPiYivwBaqerPRWQS8AM8yWMo8LSqDnWSTQaQjmdBqlXAIFU9eKZ7W/Iwxv9KTpYzZ3MuM9d+xcLMfMoqlNTYZnynnyeRdEtsYYkkxNSZZWhFJA34qFry2AaMUdVsEUkC5qtqNxF53vn+dvXjqjZVvdMp/9Zxp2PJw5jAKi4p47NNOfx3/Vdf99jqktCcS/u25ZK+SXROsK6/ocBXs+r6Q6KqZjvfc/hmlt5kYF+14/Y7Zacr/x8iMg2YBpCamurDkI0xZxPdrBHXDE7hmsEpFBw9wScbsvnvumyemrudJz/fTvc2LbikTxKX9E2yMSQhKtjJ42uqqiLis9cgVX0BeAE8bx6+uq4xxp245o25aXgaNw1PI/dwKZ9syGbWhmwen7Odx+dsp0dSSy7p04aL+yTRyRJJyAh28sgVkaRq1VZ5TvkBIKXace2csgN4qq6ql88PQJzGGB9IbNmEW0Z04JYRHcgpLuVjJ5H8ZfZ2/jLb80Zyce8kJvVpQ5fEFme/oAmaYLd5/BkorNZgHquqPxORS4B7+abB/BlVHeI0mK8CBjqXXI2nwbzoTPe1Ng9j6rac4lI+2ZjNJxtyWLmnCFXonNCcSb3bMLF3Ej2SrLE9GOpEg7mIvI3nrSEOyAUeAj4E3gVS8XQBvkZVi5yuus8CE/F01b1VVTOc69wG/D/nso+q6itnu7clD2NCR+7hUj7blMOs9dms2O1JJO1bN2Ni7zZM7NWG/rYOScDUieQRTJY8jAlN+UdOMGdzLp9szGbpjkLKK5Wk6CZc1KsNE3u3YXBaLOE2INFvLHlY8jAm5BWXlPH5llw+2ZjDwsx8TpZXEhsVyYU9ErioVxtGdI6ztUh8zJKHJQ9j6pVjJ8pZsD2fzzbl8MWWPI6cKCcqMpwx3RKY0CuRsd0TaNmkUbDDDHl1eZyHMca4FuUsWjWpTxInyytZsqOAzzblMmdzLrM2ZNMoXBjWsTUTeiZyYc9EkqKbBjvkesfePIwx9UZlpbJm3yFmb85hzqZcdhYcAzzrkYx3EolNk+I9q7ay5GFMg5SVd5TZm3OYvSmXtfsOAZAS25QLeyQyvkcigzvE0ijcppI/HUseljyMafDyDpcyd2sen2/OZVFWASfLK2nZJIIx3RK4sGcio7vGE93U2kmqs+RhycMYU03JyXIWZRYwZ3Mu87bmUXjsJBFhwuC0WC7okcCFPRJJi4sKdphBZ8nDkocx5jQqKpW1+w7x+ZZc5m7JZXvuUQA6xUdxYY9ExnVPYFD7VkQ0wOotSx6WPIwxXtpbWMLcrbnM3ZLH8l2FlFUoLZtEMLpbAhd0T2B013haRUUGO8yAsORhycMYcw6OlJaxOLOAuVvzmL8tj4KjJwkTGJjairHdExjXPYHubepv7y1LHpY8jDG1VFmprD9QzBdbcvliWx4bDxwGICm6CWO6eRLJiM6taRZZf4bPWfKw5GGM8bHcw6XM35bHF1vzWJxZwLGTFUSGhzG0YyxjuiUwtls8HeKiQvqtxJKHJQ9jjB+dLK9k5e4i5m3NY962PHbkewYntm/djDFd4xnTPYFhHVrTNDK05t6y5GHJwxgTQPuKSpi/LY952/JZsqOA0rJKGkeEMbRja08yCZG3EkseljyMMUFSWlbB8l1FzN+Wx4Lt+ex03kpSY5sxums8o7vGM7xTa6Ia1722EkseljyMMXXE3sISFmTms2BbHkt2FFJysoJG4UJ6+1hGd/Mkk7rSg8uShyUPY0wddKK8glW7D7Jgez4LtuezNecIAAktGnN+l3hGdY3j/C7xxAZpXIklD0sexpgQkFNcysJMTyL5MquAQyVliEDvttGM6hrHqC7xDGzfKmCTOVrysORhjAkxFZXKhgPFLNyez8Lt+azZd4iKSiUqMpzhneK+fitJa93Mb1Vc9TJ5iMhE4GkgHPinqj52umMteRhjQt3h0jKWZBWyKDOfhZn57Cs6DkC7Vk05v0s853eJ47xOrYlp5rsqrnqXPEQkHNgOjAf2AyuB61V1c03HW/IwxtQ3ewqPsTCzgEXb81m6o5AjJ8oJE+jTLobzO8cxskscA1NbERlx7lVc9TF5DAceVtWLnP0HAVT1DzUdb8nDGFOflVdUsm7/IRZuL2BxVgFrnSquZpHh3DAklV9d2vOcrlsf1zBPBvZV298PDK1+gIhMA6YBpKamBi4yY4wJsIjwMAa1j2VQ+1h+NL4rh0vLWLqjkMWZBbSN8c/67aGaPM5KVV8AXgDPm0eQwzHGmIBp2aQRF/Vqw0W92vjtHqG6uskBIKXafjunzBhjTACEavJYCXQRkQ4iEglcB8wMckzGGNNghGS1laqWi8i9wGd4uuq+rKqbghyWMcY0GCGZPABU9WPg42DHYYwxDVGoVlsZY4wJIksexhhjXLPkYYwxxjVLHsYYY1wLyelJ3BKRfGCPi1PigAI/hVOXNcTnbojPDA3zuRviM0Ptnru9qsbX9EODSB5uiUjG6eZzqc8a4nM3xGeGhvncDfGZwX/PbdVWxhhjXLPkYYwxxjVLHjV7IdgBBElDfO6G+MzQMJ+7IT4z+Om5rc3DGGOMa/bmYYwxxjVLHsYYY1xr0MlDRCaKyDYRyRKRX9Twe2MR+Zfz+3IRSQt8lL7nxXM/ICKbRWS9iMwVkfbBiNOXzvbM1Y77roioiNSLLp3ePLeIXOP8eW8SkbcCHaOvefHvd6qIzBORNc6/45OCEacvicjLIpInIhtP87uIyDPOP5P1IjKw1jdV1Qa54ZnKfQfQEYgE1gE9TznmbuA55/t1wL+CHXeAnnss0Mz5fleoP7c3z+wc1wJYCCwD0oMdd4D+rLsAa4BWzn5CsOMOwDO/ANzlfO8J7A523D547lHAQGDjaX6fBHwCCDAMWF7bezbkN48hQJaq7lTVk8A7wORTjpkMTHe+vwdcICISwBj94azPrarzVLXE2V2GZ6XGUObNnzXAb4E/AqWBDM6PvHnuO4C/qepBAFXNC3CMvubNMyvQ0vkeDXwVwPj8QlUXAkVnOGQy8Jp6LANiRCSpNvdsyMkjGdhXbX+/U1bjMapaDhQDrQMSnf9489zVTcXzN5ZQdtZndl7jU1R1ViAD8zNv/qy7Al1F5EsRWSYiEwMWnX9488wPAzeKyH48awL9IDChBZXb/+7PKmQXgzL+JyI3AunA6GDH4k8iEgY8AdwS5FCCIQJP1dUYPG+YC0Wkj6oeCmpU/nU98KqqPi4iw4HXRaS3qlYGO7BQ0pDfPA4AKdX22zllNR4jIhF4XnELAxKd/3jz3IjIhcAvgctU9USAYvOXsz1zC6A3MF9EduOpE55ZDxrNvfmz3g/MVNUyVd0FbMeTTEKVN888FXgXQFWXAk3wTB5Yn3n1370bDTl5rAS6iEgHEYnE0yA+85RjZgJTnO9XAV+o0/oUws763CIyAHgeT+II9TpwOMszq2qxqsapapqqpuFp57lMVTOCE67PePPv+Id43joQkTg81Vg7Axmkj3nzzHuBCwBEpAee5JEf0CgDbyZws9PrahhQrKrZtblgg622UtVyEbkX+AxPD42XVXWTiPwGyFDVmcBLeF5ps/A0Rl0XvIh9w8vn/jPQHPi30z9gr6peFrSga8nLZ653vHzuz4AJIrIZqAB+qqoh+3bt5TP/GHhRRH6Ep/H8llD/S6GIvI3nLwFxTlvOQ0AjAFV9Dk/bziQgCygBbq31PUP8n5kxxpggaMjVVsYYY86RJQ9jjDGuWfIwxhjjmiUPY4wxrlnyMMYY45olD2OMMa5Z8jDGGOOaJQ9jakFEjro8/j4R2SIib57DvWJE5G635xnjDzZI0JhaEJGjqtrcxfFbgQtVdf853CsN+EhVe7s4R/D8d26T/hmfsjcP02CJSJSIzBKRdSKyUUSudcpvdlZbWycirztlH4rIKme1vWmnud6NIrJCRNaKyPMiEn7K78/hWaToE2dqjNNet6YYgMeATs71/+wc94AT+0YRud8pS3NW0nsN2Mi3J8RDRK5ypl9fJyKLRSS+9v80TYMT7BWwbLMtWBvwXeDFavvRQC88M8vGOWWxp3w2xfM/5NbO/lHnswfwX6CRs/934OYa7rm76tqnu+4ZYkij2kpxwCBgAxCFZy6yTcAA57hKYNhpnrt1te8PAfcE+8/CttDb7M3DNGQbgPEi8kcROV9Vi4FxwL9VtQBAVatWZ7tPRNbhmXE3hf+dtvwCPP8zXykia539jl7EUNN1TxfDqUYC/1HVY6p6FPgAON/5bY96VoyryS3OG9I6PEst15eVE00ANdhZdY1R1e3OCoKTgN+JyFzg4KnHicgY4EJguKqWiMh8PNN4f+swYLqqPujt/b287rk6dpp73oxnqdZxqnpURBbieWMxxhV78zANloi0BUpU9Q0809APBL4ArhaR1s4xsXiqsw46/4PvjmexqFPNBa4SkYSq80Sk/VlCON11a4oB4AiehauqLAIuF5FmIhIFXOGUnUkfYImTOL4LnIfnDcwYV+zNwzRkfYA/i0glUAbcpZ61Hx4FFohIBbAGuBP4vohsAbbhqWL6FlXdLCK/AmaLZ1nbMuAeYM8Z7v9pTdc9TQy3qGqheNYa3wh8oqo/FZFXgRXO9f6pqmucXlmn8yrwgYh8D5gN7FTVGt9SjDkT66prjDHGNau2MsYY45olD2OMMa5Z8jDGGOOaJQ9jjDGuWfIwxhjjmiUPY4wxrlnyMMYY49r/Bw4C5Wbu0mDsAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "z30Karo4Jdnw",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Not sure what are the units of the comoving distance? just ask:\n",
-        "jc.background.radial_comoving_distance?"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yihFIALbJ24Q",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Defining redshift distributions\n",
-        "\n",
-        "On our path to computing Fisher matrices, we need to be able to express redshift distrbutions. In `jax-cosmo` n(z) are parametrized functions which can\n",
-        "be found in the `jax_cosmo.redshift` module. \n",
-        "\n",
-        "For the purpose of this tutorial, let's see how to define a Smail type distribution:\n",
-        "$$ n(z) = z^a \\exp(- (z/z_0)^b) $$\n",
-        "which depends on 3 parameters:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "2D7ouxvVIR7M",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# You can inspect the documentation to see the \n",
-        "# meaning of these positional arguments\n",
-        "nz1 = jc.redshift.smail_nz(1., 2.,  1.)\n",
-        "nz2 = jc.redshift.smail_nz(1., 2.,  0.5)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Ef2oNlQ7Lmdi",
-        "colab_type": "code",
-        "outputId": "799bb7a6-1e67-45d8-dfd3-ff3b27ce6f81",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 281
-        }
-      },
-      "source": [
-        "# And let's plot it\n",
-        "z = np.linspace(0,5,256)\n",
-        "\n",
-        "# Redshift distributions are callable, and they return the normalized distribution\n",
-        "plot(z, nz1(z), label='z0=1.')\n",
-        "plot(z, nz2(z), label='z0=0.5')\n",
-        "legend();\n",
-        "xlabel('Redshift $z$');"
-      ],
-      "execution_count": 10,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEICAYAAABRSj9aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxV5bX4/8/KHCAESEIYwhAIg4xRUqCCA1gtWAW11qJ2sEr9abV667fe6tdf9VZvqy3eXmuVa61za7W2dcBb5wlFpQIKyAwymDBkJExJyLS+f+wdPIYMJ8k5Z5/ss96v13ntkz2ddfDlypPnefZ6RFUxxhjjX3FeB2CMMSa8LNEbY4zPWaI3xhifs0RvjDE+Z4neGGN8LsHrAFqSmZmpw4cP9zoMY4zpNlatWlWmqlktHYvKRD98+HBWrlzpdRjGGNNtiMiu1o5Z140xxvhcuy16EXkEOAcoUdUJLRy/Ebg04H4nAFmqWiEiO4FDQANQr6oFoQrcGGNMcIJp0T8GzGntoKouUtV8Vc0HbgaWqmpFwCmz3OOW5I0xxgPttuhV9V0RGR7k/S4GnupKQMYYA1BXV0dRURE1NTVehxJVUlJSyMnJITExMehrQjYYKyI9cFr+1wbsVuA1EVHgD6r6YBvXXwlcCTB06NBQhWWM6aaKiopIS0tj+PDhiIjX4UQFVaW8vJyioiJyc3ODvi6Ug7HnAu8367aZqaonAXOBa0Tk1NYuVtUHVbVAVQuyslqcIWSMiSE1NTVkZGRYkg8gImRkZHT4r5xQJvoFNOu2UdXd7rYEeA6YGsLPM8b4nCX543Xm3yQkiV5E0oHTgBcC9vUUkbSm98BZwLpQfF5E7V0Dqx6D6v1eR2KMMZ3SbqIXkaeAD4ExIlIkIleIyFUiclXAaecDr6nqkYB92cAyEVkDfAT8U1VfCWXwYffuIvjDqfDi9XDPJNiz2uuIjDEeWrVqFRMnTiQvL4/rrruOYNfzKC8vZ9asWfTq1Ytrr722/QtCrN1Er6oXq+pAVU1U1RxVfVhVH1DVBwLOeUxVFzS7bruqTnZf41X1l+H4AmGz71N4+04YNx8ufw2SesGzP4TaKq8jM8Z45Oqrr+aPf/wjW7duZevWrbzySnBt15SUFO644w7uvvvuMEfYMnsytjUv/wxS+8K5v4Oh0+C8xVC2BZYv9joyY0wEPPDAA+Tn55Ofn09ubi6zZs3i4MGDTJ8+HRHhe9/7Hs8//3xQ9+rZsyczZ84kJSUlzFG3LCpr3XiudAvseh/OvMNJ9gAjZ8GIWbDiYZhxPcQHP4fVGNM1v3hxPRv2HAzpPccN6s1t545v9fhVV13FVVddRV1dHbNnz2b27NksXbr02PGcnBx2794NwKJFi3jyySePu8epp57KvffeG9K4O8MSfUvWPg0SB5Mu+vL+6VfDXy6CjUtgwje9ic0YE1HXX389s2fPZu7cuV9K9IFuvPFGbrzxxghHFjxL9M01NsLaZ2DkbEgb8OVjeWdCn2HwyZOW6I2JoLZa3uH02GOPsWvXLu677z6Ki4spKio6dqyoqIjBgwcD1qLvfko2wIFCOP3m44/FxTmDs8v/B6orIbVP5OMzxkTEqlWruPvuu3nvvfeIi4tj4MCB9O7dm+XLlzNt2jSeeOIJfvzjHwPR36K3wdjmdrzrbEec1vLxE+ZBYx1sfS1yMRljIu6+++6joqKCWbNmkZ+fz8KFC1m8eDELFy4kLy+PkSNHMnfu3KDvN3z4cG644QYee+wxcnJy2LBhAwALFy4M+/ob1qJvbsdS6DcS0nNaPj54CvQa4PTTN+/DN8b4xqOPPtri/nXrOvfc586dO1vc/9BDD3Xqfh1hLfpADfWw833IbbUkj9N9M/rrsH2pc74xxkQ5S/SB9q6B2kNtJ3pwunWOHnTON8aYKGeJPtCej53tkHZqrw0/xdnuaHmqlTHGRBNL9IH2rIYemdB7cNvn9eoP/cd9MXBrjDFRzBJ9oL2rYVA+BFMGNPdU+Hw51NeGPy5jjOkCS/RN6qqhZCMMzA/u/CHToL4aij8Nb1zGGNNFluibFK8HbXBa9MFo6scvCu/8V2NM9OhsmWKAO++8k7y8PMaMGcOrr77a4jmXXXYZubm5x4qprV4dmtLoluib7HX/QYNt0afnQNogKPwofDEZY6JKZ8sUb9iwgaeffpr169fzyiuv8KMf/YiGhoYWz120aBGrV69m9erV5OcHmY/aYYm+SckmSO7d+oNSLckpgCJL9Mb4USjLFL/wwgssWLCA5ORkcnNzycvL46OPIpc77MnYJqWbIHN0cAOxTYZMdZ6QPVQMadnhi82YWPfyTc5iQKE0YCLMvavVw6EsU7x7926mT5/e4rXN3XLLLdx+++2cccYZ3HXXXSQnJ3f2Gx5jLfomZVsga0zHrhk8xdnag1PG+FZgmeLW3Hjjjce6WwJfHa1ceeedd7Jp0yZWrFhBRUUFv/71r7saPmAtekf1fjhc3PFEn+2WTt23FkafFfq4jDGONlre4RSqMsWDBw+msLCwxWsDDRw4EIDk5GR+8IMfhGzpQUv04KwoBZDZwUSfkg59h4f+T0pjjOdCWaZ43rx5XHLJJdxwww3s2bOHrVu3MnXq8U/g7927l4EDB6KqPP/880yYMCEk36XdRC8ijwDnACWqetynisjpwAvADnfXs6p6u3tsDvA7IB54SFW9+bXcnrLNzjZrdMevHTDREr0xPhRYphigoKCAxYsXc9lll1FdXc3cuXODLlM8fvx4LrroIsaNG0dCQgL3338/8fHxAJx99tk89NBDDBo0iEsvvZTS0lJUlfz8fB544IGQfJdgWvSPAfcBT7Rxznuqek7gDhGJB+4HzgSKgBUiskRVN3Qy1vAp3QwJKc7qUR01YBJsfBGOHoLktNDHZozxRKjLFN9yyy3ccsstx+1/6aWXjr1/6623OnXv9rQ7GKuq7wIVnbj3VGCbqm5X1VrgaWB+J+4TfuXbnBr0cfEdv3bARGdbvD60MRljTIiEatbNV0VkjYi8LCJNizsOBgoDzily97VIRK4UkZUisrK0tDREYQVp/07ol9u5a5sSvXXfGGOiVCgS/cfAMFWdDPweCO4JgmZU9UFVLVDVgqysrBCEFaTGRifR9x3euet7D4bUvs7MG2NMSHWkxECs6My/SZcTvaoeVNXD7vuXgEQRyQR2A0MCTs1x90WXw/ugvqbzLXoRG5A1JgxSUlIoLy+3ZB9AVSkvLyclJaVD13V5eqWIDACKVVVFZCrOL49yoBIYJSK5OAl+AXBJVz8v5CrcyUJ9O5nowRmQ/eiPztKC8TZj1ZhQyMnJoaioiIh35Ua5lJQUcnI6UKqF4KZXPgWcDmSKSBFwG5AIoKoPABcCV4tIPVANLFDnV3C9iFwLvIozvfIRVY2+Ecv9bqLvbIsenBZ9w1Eo3wr9TwhNXMbEuMTERHJzu/D/pTmm3USvqhe3c/w+nOmXLR17CXippWNRo2IHSDykD2n/3NYEDshaojfGRBmrdbN/h1OxMj6x8/fIHA3xyTYga4yJSpboK3Z0rdsGnF8SmaOdUsfGGBNlLNEfKOzcE7HNZY3+opSCMcZEkdhO9HXVcKS0a/3zTbLGQuXnUHuk6/cyxpgQiu1Ef8Cd1t8nFInerXxZtqXr9zLGmBCK8UTvVmjoyPKBrcka62xLrfvGGBNdYjzRu4sIhKLrpt8IiEtwliQ0xpgoEuOJvhAQ6D2o6/eKT4SMvC8WMTHGmCgR44m+CNIGdm0OfaCsMdaiN8ZEnRhP9IWhGYhtkjXWeQCrriZ09zTGmC6K7URfWRiagdgmWWNAG52FTIwxJkrEbqJvbISDu0MzENukaXFx674xxkSR2E30VeXQUOssHBIqGXkgcTaX3hgTVWI30R/a42x7DwzdPRNTnLr21qI3xkSR2E30B/c627QQTK0MlDXWHpoyxkSV2E304WjRg1PcrHybs9qUMcZEgdhN9Af3Ov3pPfuH9r4Zo6CxHip3hfa+xhjTSbGb6A/tcZJ8qNd4zRzlbG2KpTEmSsRuoj+4N/TdNuDMvAEo2xr6extjTCfEbqI/tDf0A7EAPfpBaj9r0Rtjoka7iV5EHhGREhFZ18rxS0VkrYh8KiIfiMjkgGM73f2rRWRlKAPvsoN7wtOiB6dVb4neGBMlgmnRPwbMaeP4DuA0VZ0I3AE82Oz4LFXNV9WCzoUYBnXVUFPpFDQLh8xR1nVjjIka7SZ6VX0XqGjj+Aequt/9cTkQwuIxYXKwaWplGLpuwGnRH94HRw+F5/7GGNMBoe6jvwJ4OeBnBV4TkVUicmVbF4rIlSKyUkRWlpaWhjisZg4XO9u0AeG5f9OArHXfGGOiQMgSvYjMwkn0PwvYPVNVTwLmAteIyKmtXa+qD6pqgaoWZGVlhSqslh3a52x7hSnRH5ti+Vl47m+MMR0QkkQvIpOAh4D5qlretF9Vd7vbEuA5YGooPq/LDpc4217Z4bl/31xArJ/eGBMVupzoRWQo8CzwXVXdErC/p4ikNb0HzgJanLkTcYeLnfVdU/uG5/6JKdBnKJRbojfGeK/dx0JF5CngdCBTRIqA24BEAFV9ALgVyAAWiwhAvTvDJht4zt2XAPxFVV8Jw3fouMPFTms+LoyPEdgUS2NMlGg30avqxe0cXwgsbGH/dmDy8VdEgcPF0CvENW6ayxwFn/wLVMH5ZWeMMZ6IzSdjm1r04ZSRB7WHnSdwjTHGQ7GZ6A9FoEVvUyyNMVEi9hJ9YwNUlYVvamWTpimWNvPGGOOx2Ev0R8pAG8Pfok8bBAmpNpfeGOO52Ev0h5selgpzH31cnDvzxlr0xhhvxWCiD/PDUoEyRlrXjTHGczGY6N06N+HuugGnn75yF9TXhv+zjDGmFTGY6Jta9BFI9BmjnPGA/TvC/1nGGNOK2Ev0VeWQ2AOSeob/s2yKpTEmCsReoj9SCj0yI/NZGSOdrfXTG2M8FIOJvgx6RijRp/aBnlk288YY46kYTPSlkUv04PTT21x6Y4yHYi/RV5U7rexIycyzrhtjjKdiK9Grun30GZH7zIw8p+RC9f72zzXGmDCIrUR/9BA01Ea2RZ9hywoaY7wVW4n+iLvoeET76N0pltZ9Y4zxSGwl+ip3OdtItuj7DgeJt7n0xhjPxFaiP1LmbCPZR5+Q5CR7m2JpjPFIjCX6pq6bCLbowa1iaX30xhhvxFair3Jb9JHsowenuFn5Z9DYGNnPNcYYgkz0IvKIiJSIyLpWjouI3Csi20RkrYicFHDs+yKy1X19P1SBd8qRMkjqBYmpkf3cjDyor4aDRZH9XGOMIfgW/WPAnDaOzwVGua8rgf8BEJF+wG3ANGAqcJuI9O1ssF12pCyy/fNNrLiZMcZDQSV6VX0XqGjjlPnAE+pYDvQRkYHA14HXVbVCVfcDr9P2L4zwOlIa+f55CFg/1hK9MSbyQtVHPxgoDPi5yN3X2v7jiMiVIrJSRFaWlpaGKKxmqiJY0CxQr2yny8ha9MYYD0TNYKyqPqiqBapakJUVplZ3JCtXBhKx9WONMZ4JVaLfDQwJ+DnH3dfa/shTdfvoPUj04HTfWNeNMcYDoUr0S4DvubNvpgMHVHUv8Cpwloj0dQdhz3L3RV7NAWis86aPHpwW/YFCqKv25vONMTErIZiTROQp4HQgU0SKcGbSJAKo6gPAS8DZwDagCviBe6xCRO4AVri3ul1V2xrUDZ9j5Q88atFn5AEKFdshe7w3MRhjYlJQiV5VL27nuALXtHLsEeCRjocWYl4UNAvUNPOmfJslemNMREXNYGzYHatz41Gi72frxxpjvBFDid6jOjdNkntB2iCbYmmMibjYSfRe1bkJlDHSEr0xJuJiJ9EfKYPk3pCQ7F0MmaOcrhtV72IwxsSc2Er0XtS5CZQxCmoqocqbiUfGmNgUQ4neozo3gY4VN7MBWWNM5MROoq+q8L5Fn2nrxxpjIi+GEn2594m+zzCIS7QBWWNMRMVOoq+ugB7elcIHIC4e+o2wRG+Miaignozt9mqroL4GUvt5GkbxwRrq4geTtHM9dzz1CYlxwsA+KUwc3IeZozLplRwb/zmMMZEVG5ml2p3l0sObRL+2qJLfvbGVtzaX8LP4nlweX8j6wnKONsZRfLCG+kYlOSGOeZMHcfXpIxmR1cuTOI0x/hQbib5pOmOEW/TVtQ388qUNPPmvz+mTmsi1s/KYn3QaSe+8yFsLR0C/ERytb+CTzytZsmYPz328m2c/2c0VM3O54czRpCTGRzReY4w/xUai96BFX7S/ioWPr2TTvkP8YMZwbjhzNGkpifD5fngHpzZ9vxEkJ8QzfUQG00dk8JOvjea3r2/mwXe38/amEv772/lMGJwesZiNMf4UG4OxEW7Rby0+xDf/5wP2VFbz+OVTue3c8U6SB8gc7WzLthx3XVZaMndeMInHfvAVDtbU8c3/+YCXP90bkZiNMf4VG4k+gi36nWVHuOShf9Go8LerTua00c0e0urRz3lwq3RTq/c4fUx/Xr7+VMYP6s2P/vIxDy/bEeaojTF+FhuJvmq/sw1zi/5QTR2XP76ChkblLwunMWZAWssnZo5psUUfqF/PJP7yw+mcNS6bO/53A/e/bVMyjTGdExuJvroCknpBQlLYPqKxUfk/z6xhV3kViy89iVHZrSR5gKwxTou+neJmKYnxLL50CuflD2LRq5t59H1r2RtjOi42BmOrKsLemr//7W28tqGYn58zjukj2nkCN2uMs4bt4WJIG9DmqfFxwt3fmkx1XQO/eHEDvZIT+FbBkDavMcaYQLHTog/jU7Friyr57ze2MD9/EJfPGN7+BVljnG3p5qDunxAfx70Xn8jMvEz+73Of8q/t5Z0P1hgTc4JK9CIyR0Q2i8g2EbmpheP/LSKr3dcWEakMONYQcGxJKIMPWhhb9HUNjfz739eS2SuZ2+dPQETavyizY4keIDkhnvsvPYkh/Xpw9ZMfU1hR1cmIjTGxpt1ELyLxwP3AXGAccLGIjAs8R1V/oqr5qpoP/B54NuBwddMxVZ0XwtiDV10Rthk3f1j6GZv2HeI/z5tAempicBelDYDkdCgLPtEDpKcm8vD3v0JDo3LF4yuoqq3vRMTGmFgTTIt+KrBNVberai3wNDC/jfMvBp4KRXAhU1Uelhb99tLD3PvmNr4xcSBnjW+7r/1LRCBrdIda9E1yM3ty/yUnsbXkMD9/fn2HrzfGxJ5gEv1goDDg5yJ333FEZBiQC7wVsDtFRFaKyHIROa+1DxGRK93zVpaWlgYRVpAa6p2BzzC06O96eRNJCXHcNm9c+yc31zTzphNmjsrkutmj+MfHRfxtZWH7FxhjYlqoB2MXAH9X1YaAfcNUtQC4BLhHREa2dKGqPqiqBapakJUVwpWgatzhghDXol+xs4LXNhRz1Wkj6J+W0vEbZI11Vr3q5LKC150xiq+OyODnL6xja/GhTt3DGBMbgkn0u4HA+Xw57r6WLKBZt42q7na323GqvJzY4Si7IgzlD1SVX720kezeyVwxc0TnbtKJAdlA8XHC7xbk0zMpgZ88s5q6hsbOxWGM8b1gEv0KYJSI5IpIEk4yP272jIiMBfoCHwbs6ysiye77TGAGsCEUgQftWPmD0E2vfGXdPj75vJIbzhxNalInK0w2TbHs4IBsoP69U/jl+RNZt/sgv3/Lnpw1xrSs3USvqvXAtcCrwEbgGVVdLyK3i0jgLJoFwNOqX3rc8wRgpYisAd4G7lLVyCb6ELfoGxuV376+hVH9e/HNk3I6f6P0IZDYo9Mt+iZzJgzgghMHc//b21hbVNn+BcaYmBPUk7Gq+hLwUrN9tzb7+T9auO4DYGIX4uu6EBc0e2NjMVtLDvO7BfkkxHdhiCMuDjJHQcnGLsd027zxfPBZOTc8s4b//fFMq2NvjPkS/z8ZG8IWvapy/zufMbRfD74xcWCX70f/8VDS9T9w0lMT+c2Fk9hWcpi7X+3aXwjGGP/xf6KvroC4BEhuo8hYkD78rJw1hZVceeqIrrXmm2SPc+rdHOl6SYNTR2fxnelDefj9HXzy+f6ux2aM8Q3/J/qm8gfBlCZox+J3PiMrLZkLp3Shbz5Qf3f+fUloHnz62ZyxZKelcPOzn9osHGPMMf5P9CEqf7Bhz0GWbSvj8hm5oesDz57gbItDk+jTUhK5ff54Nu07xEPvWUljY4zD/4m+an9I+uf/tHwnKYlxXDJ1aAiCcvXq7zzIFaJED3DW+AF8fXw297yxhV3lR0J2X2NM9+X/RB+CFv2Bqjqe+2Q35+UPJr1HkIXLgiHidN+EYEA20C/mTSAxPo5bnluHtrO4iTHG//yf6KsqILVrD0v9bVUhNXWNfPerw0IUVIDsCc4Uy8bQ9akPSE/h3+eMYdm2Mp5f3dpDzMaYWOHvRK/a5RZ9Y6Pyp+W7KBjWl/GD0kMYnCt7HNRVwf7Q9qlfOm0Y+UP68Mt/buRAdV1I722M6V78nehrj0BDbZf66N/dWsqu8iq+d/Lw0MUVqP94Zxvi7pv4OOGO+RMoP1LLf7/e9kLkxhh/83eiD8FTsU9/VEhGzyTmdKTefEf0HwtISAdkm0zMSefSaUN54sOdbNhzMOT3N8Z0D/5O9F18Krb88FHe3FTM+ScOJikhTP9UST2hX25YEj3AT88aQ3pqIrctsYFZY2KVvxN9Uy36Tg7GPr96D3UNyrcKhrR/cleEYeZNkz49krhp7lhW7NzPc5/YwKwxscjfib7aLQWQ2qfDl6oqf1tZyOScdMYM6Hr5hDZlj4fyz6A2PAt+f2vKEPKH9OFXL23iYI0NzBoTa3ye6N0WfUrHE/36PQfZtO8QF4a7NQ8wYCKgYWvVxx0bmD1qA7PGxCB/J/oudN38bWUhSQlxzJs0KMRBtWDgZGe755OwfUTTwOzjH9jArDGxxt+Jvno/xCdBYmqHLqtraGTJmj2cNS47tE/CtiZ9iDNgvHdNWD/GBmaNiU0+T/SVTrdNBytXvre1lP1VdZx/4uAwBdaMiNOq37s6rB8TODD77Mc2MGtMrPB3oq+p7FS3zZLVe0hPTeSUUVlhCKoVg/KdUgj1R8P6MU0Ds3e+bAOzxsQKfyf66v0dnnFTXdvAaxuKOXvigPDNnW/JwMnQWB+2+fRNbGDWmNjj80Rf2eEZN29uKqaqtoFzJ0dgEDbQwHxnG+Z+erCBWWNiTVCJXkTmiMhmEdkmIje1cPwyESkVkdXua2HAse+LyFb39f1QBt+uTnTdLFm9h/5pyUzLzQhTUK3oOxxS0sPeT9/kp2eNoU+PJG59wQZmjfG7dhO9iMQD9wNzgXHAxSIyroVT/6qq+e7rIffafsBtwDRgKnCbiHStZnBHVFd2qOvmQHUd72wu5ZxJg4iP6/rSgx1ybEA2/C16cAZmfzZnDCt32cCsMX4XTIt+KrBNVberai3wNDA/yPt/HXhdVStUdT/wOjCnc6F2UGMDHD3Yoa6b1zcUU9vQyLmTB4YxsDYMzHf66OtrI/JxXwzMWiljY/wsmEQ/GCgM+LnI3dfcN0VkrYj8XUSaHicN9lpE5EoRWSkiK0tLS4MIqx01B5xtB7puXlm3l0HpKeQP6fiTtCExcLJTVrl0U0Q+Li5O+M/zrJSxMX4XqsHYF4HhqjoJp9X+eEdvoKoPqmqBqhZkZYVgWmMH69wcPlrPu1vL+PqEAUgH592HzKATnW2E+ukBJgy2UsbG+F0wiX43EFjwJcfdd4yqlqtq0wTwh4ApwV4bNh2sc/PWphJq6xuZO8GjbhuAvrnOgOzuVRH9WBuYNcbfgkn0K4BRIpIrIknAAmBJ4AkiEpgd5wEb3fevAmeJSF93EPYsd1/41TS16IPrunll3V4yeyUzZVjkxoqPExcHOV+Bwo8i+rF9eiRx05yxNjBrjE+1m+hVtR64FidBbwSeUdX1InK7iMxzT7tORNaLyBrgOuAy99oK4A6cXxYrgNvdfeHX1KIPouumuraBtzeV8vXx2ZGfbdNczlTnCdmmMYYIuXBKjg3MGuNTQfXRq+pLqjpaVUeq6i/dfbeq6hL3/c2qOl5VJ6vqLFXdFHDtI6qa574eDc/XaEFTH30QXTdLt5RSXdfgbbdNkyFTAYWilRH9WBuYNca//PtkbE3wLfpX1++jT49Epo3o/NqyITN4CiAR774BZ2D2O9OG8cSHO1m/J7J/URhjwse/ib66EhJ7QEJym6fVNzTy9uYSZo/pT2J8FPxzpPR2Vpwqinyihy8GZn/+/DoaG21g1hg/iILMFiZB1rlZtWs/lVV1nHFCdgSCClLOV5yum8aGiH90eo9Ebp47lo8/r+TJjz6P+OcbY0LPv4k+yDo3b24qITFeOHV0ZgSCCtKQac5TvRF6cKq5C6fkMCMvg1+/vIl9B2o8icEYEzr+TfRB1rl5Y2Mx00dkkJYSgZWkgjVkqrP1oJ8eQET41fkTqWto5Oc2t96Ybs/HiX5/u103O8qOsL30CGeM7R+hoILUbwT0yPAs0QMMy+jJT84czesbinll3T7P4jDGdJ1/E30QXTdvbiwGiK7+eXAqWQ6ZBoXLPQ1j4cxcxg/qza1L1tvcemO6Mf8m+iC6bt7YWMyY7DSG9OsRoaA6YNgMqNgOB4o8CyEhPo67LphE+eGj3PXyxvYvMMZEJX8m+vpaqDvSZtfNgao6VuzczxknRFm3TZMRpznb7Us9DWNiTjoLTxnBUx8Vsnx7uaexGGM6x5+JPoiHpd7ZUkJDo/K1cVHWbdOk/3inn36Ht4ke4CdfG83Qfj342T/WUlVb73U4xpgO8meiP1bnpvU++jc3lpDZK4n8HI9qz7cnLg5yT3Va9B7PeklNiuc3F07i84oq7nzJmymfxpjO82mib7vOTV1DI+9sLmHWmP7EeV3ErC25p8HhfVC21etImD4ig8tn5PKn5bt4b2sIFoYxxkSMPxN9O103q3bt52BNffTNtmmuqZ8+CrpvAG78+hjy+vfixr+ttVk4xnQj/kz07XTdvLO5lIQ4YeaoKHoatiV9cyF9KGx/x+tIAEhJjOe3F02m9PBRfrFkvdfhGGOC5NNE33bXzdItpRQM70uv5IQIBtUJIjDiVE4uNlAAABKSSURBVNj5nid1b1oyKacP18zK49lPdvPPtXu9DscYEwR/JvqmrpuU9OMOFR+sYePeg5w2OkqnVTaXe7qzCEkE15Ftz49n53Hi0D7c9OxaCiuqvA7HGNMOfyb66kpI7g3xx7fYl25xBhJPGx2CBcgjYeRskDjY/IrXkRyTGB/HvQuchcx//NQn1DU0ehyRMaYtPk30rde5WbqllP5pyZwwMC3CQXVSzwwY+lXY9E+vI/mSIf16cNcFk1hdWMl/vWYrUhkTzfyZ6GsqIfX4bpv6hkaWbS3jtNFZiETxtMrmxpwNJeuhYofXkXzJNyYN5JJpQ3lg6We8u8WmXBoTrfyZ6KtbLmi2pqiSA9V1nDamm3TbNBl7trPd/JK3cbTg1nPGMSY7jX/762qK9lt/vTHRKKhELyJzRGSziGwTkZtaOH6DiGwQkbUi8qaIDAs41iAiq93XklAG36pWum6Wbi4lTmBmXpRPq2yu3winJMKm6Ev0KYnxLP7OSdTVN3LVn1dRUxcds4OMMV9oN9GLSDxwPzAXGAdcLCLjmp32CVCgqpOAvwO/CThWrar57mteiOJuW03LlSuXbiklf0gf+vRIikgYITX2bPj8A6iq8DqS44zM6sU9C/JZv+cgNz/7qS1UYkyUCaZFPxXYpqrbVbUWeBqYH3iCqr6tqk1/ty8HckIbZgeotth1U374KGt3H+D0Md1kWmVzY78B2ghbomf2TaAzTsjmJ18bzXOf7OaR93d6HY4xJkAwiX4wUBjwc5G7rzVXAC8H/JwiIitFZLmInNfaRSJypXveytLSLgzs1VVDw9Hjum7e21qGajeaVtncwHzonQMbXvA6klZdOyuPs8Zl86uXNlo9HGOiSEgHY0XkO0ABsChg9zBVLQAuAe4RkZEtXauqD6pqgaoWZGV1IRm3Uudm6ZZS+vVMYuLg42fjdAsiMPFC2Po6HC7xOpoWxcUJv/12PqP69+LqP3/Mhj0HvQ7JGENwiX43MCTg5xx335eIyNeAW4B5qnq0ab+q7na324F3gBO7EG/7Wqhz09iovLe1lJl5mdFdrbI9+ZeANsDaZ7yOpFW9khN49AdfoVdyAj947CN2V1Z7HZIxMS+YRL8CGCUiuSKSBCwAvjR7RkROBP6Ak+RLAvb3FZFk930mMAPYEKrgW3Ss/MEXLfrNxYcoO1wb/UXM2pM1BgYXwOonPa9R35aB6ak8dvlXqDrawGWPfMSBKqt0aYyX2k30qloPXAu8CmwEnlHV9SJyu4g0zaJZBPQC/tZsGuUJwEoRWQO8DdylquFN9E0FzQK6bpZtLQO64bTKluRfAiUbYO8aryNp09gBvfnD96aws/wIP/zTSqprbdqlMV4Jqo9eVV9S1dGqOlJVf+nuu1VVl7jvv6aq2c2nUarqB6o6UVUnu9uHw/dVXC103SzbVsaIrJ4M6pMa9o8PuwkXQHwyrP6L15G06+SRmfzXRfms2FnBD59YaXPsjfGI/56MbdZ1c7S+gX/tKOcUP7TmwfkFNvZs+PQZqKvxOpp2zZs8iEUXTub9z8q48k/2QJUxXvBfoq/eD4hTvRL4eFclNXWNzBzVTadVtmTKZc73XPd3ryMJyoVTcvj1BZN4d0spV/95FUfrLdkbE0k+TPTuU7Fxzldbtq2U+Dhh2oh+HgcWQrmnOSURlj8Q1YOygS76yhB+df5E3t5cysLHV3L4aL3XIRkTM/yX6GsqvzTjZtnWMvKH9KF3SqKHQYWYCEy/Goo/he1vex1N0C6ZNpTfXDiJDz4r5+IHl1N66Gj7Fxljusx/ib56/7EZNweq6li7+wAz/NI/H2jSRZA2CN692+tIOuSigiH88XtT2FpyiAsf+IBd5Ue8DskY3/Nhov+izs0HnzllD07p7vPnW5KQDDOuh13vw85lXkfTIbPHZvOXH07nYHUdFyz+gI92RF+hNmP8xH+JPqDrZtm2MnomxZM/pOXVprq9Kd+HtIHwxi+6TV99k5OG9uXvV59M79RELvnjch59f4dVvTQmTPyX6AO6bpZtK2P6iAwS4/33NQFITIXTb4aij2Dji15H02Ejs3rxwrUzOH1Mf37x4gb+7a+r7cEqY8LAXxkwoERxYUUVu8qrun/Zg/bkXwpZJ8Brt0Bt91vhqXdKIg9+dwo/PWs0S9bsYd59y/i06IDXYRnjK/5K9LWHnaJfKX1Yts1HZQ/aEp8A3/gvqPwc3l3U/vlRKC5OuHb2KJ64fCoHa+o4f/H73PPGFuoaGr0OzRhf8FeiD6hzs2xbGdm9k8nr38vbmCJh+AynZf/+72D3Kq+j6bRTRmXx2r+dxjmTBnLPG1u5YPEHrNttrXtjuspnid4pf9CY0ocPtpUxIy8TkW5clrgjvv4rSBsAz/5/cPSw19F0WnqPRO5ZcCKLLz2JPZXVnHvfMv7vc59ScaTW69CM6bb8lejdOje7jiSxv6rOn9MqW5PaB87/A1R8Bi9c0+1m4TR39sSBvPXT07ns5OH8dUUhs+5+h0ff32HlE4zpBH8lerfrZkWxk+RmjIyhRA+QewqccRtseB5ev7XbJ/v01ERuO3c8L19/CuMH9eYXL27gtN+8wxMf7rTiaMZ0gM8SvdOif6+ojjHZafTvneJxQB6YcT18ZSF8cG+3e2q2NaOz03hy4TSeXDiNIf1SufWF9Zy+6B3+sPQz9luXjjHtSvA6gJCqaUr0DXxzeoy15puIwNxFUHsE3v5PZ9+pP3X2d2Miwoy8TE4emcGHn5Xzuze3cufLm/jt61uYnz+I704fzoTBvWNnTMaYDvBXoq/eT6MkUFmf6P9plW2Ji4N594E2Osm+eB3Mvx+Su/8MJBHh5LxMTs7LZNO+gzzx4S6e+3g3z6wsIq9/L87LH8S8yYMZmtHD61CNiRo+S/SVVMenkRgfx9RcH5Ul7oz4BGdwdsBEp7++dBOccw8M+6rXkYXM2AG9+dX5E/nZnLEsWbOHF1fv4e7XtnD3a1sYP6g3s8f25/Qx/ckf0of47rwovDFd5K9EX1NJRWNPThzal57J/vpqnSICJ/8YsifAkh/Do3Ng8sVw+k3Qd7jX0YVMemoi350+jO9OH8buympeXLOHNzcWc//b2/j9W9vo0yORgmH9KBjel4JhfZkwOJ2UxHivwzYmYnyVDesOV1Ban+KfZQNDZeQsuOZf8N5/wfv3wtq/wgnnQsEVMGyG0/r3icF9UrnqtJFcddpIKqtqeW9rGe9uKWXlrv28sbEYgKT4OMYP7s3YAWmMyU5jzADnfd+eSR5Hb0x4SDAVA0VkDvA7IB54SFXvanY8GXgCmAKUA99W1Z3usZuBK4AG4DpVfbW9zysoKNCVK1d27JsAlfeczCflCaT/8AVOGtq3/Qti0YHd8NGDsOpRqDkAPTJgzFwYNhOGTnda+j4d0Cw7fJRVu/azatd+VhdWsnnfIQ5U1x073q9nEkP6ppLTrwdD+vZgSL9UBqankNUrhcy0JDJ6JpOU4K+JasY/RGSVqha0eKy9RC8i8cAW4EygCFgBXKyqGwLO+REwSVWvEpEFwPmq+m0RGQc8BUwFBgFvAKNVtc1J0J1N9OW/OoEPa0cw5+cvkuDXipWhUnsEtr0BG5bA1tfhqFtqICkNMkZCRh70GwG9+kPPLGebku5UzEzs8cWrG/81oKqUHDrK5n2H2LzvEDvKj1BYUUVhRRW7K6upazj+/40+PRLJ7JVMn9RE0lISSEtpvk2gR1ICyQlxzisxnhR3G7gvOSGOhDghLk6IFyE+zn2Js8+Yjmor0Qfzf+lUYJuqbndv9jQwH9gQcM584D/c938H7hNnntt84GlVPQrsEJFt7v0+7MwXaYuqklh7gJ69My3JByOpJ4yb77waG6F0IxT+C0o2Qfk2p/Txun8A7fzFF5cI8UkQF+/8JSDx7vuArYjznnYSWJt/SYT+WgGygWwRTg080AO0B9Q3NFLfqDQ06rFtQ2Mj9dVKY5XSoNDYqDSq0qgEVU+/3n21t66WuN+pKfKWvp4c98PxJwX7K8Onf8R1O1Xx6Yy75f2Q3zeYRD8YKAz4uQiY1to5qlovIgeADHf/8mbXDm7pQ0TkSuBKgKFDhwYT+5ccrWtgW/rJ9B45vcPXxry4OMge77wCNdRDVTkcKYUjJXD0ENRVO38N1FW7ryPQUAeNDc50Tm1w3zc4v0AC97WpjSTZbgIN/bUCJLqvYH35F0LTLwCloRHnfaPScGzr/GJQN0RFna06MTWoG5n7SwScewTzFbWFH7SV76nNLujez1J3f/WJaWG5b9T83a2qDwIPgtN109HrU5ISOOknfw95XDEtPgHSsp2XaVe8+zIm2gTTx7EbGBLwc467r8VzRCQBSMcZlA3mWmOMMWEUTKJfAYwSkVwRSQIWAEuanbME+L77/kLgLXU6LJcAC0QkWURygVHAR6EJ3RhjTDDa7bpx+9yvBV7F+cv0EVVdLyK3AytVdQnwMPAnd7C1AueXAe55z+AM3NYD17Q348YYY0xoBTWPPtI6O73SGGNiVVvTK20eojHG+JwlemOM8TlL9MYY43OW6I0xxueicjBWREqBXZ28PBMoC2E43YF9Z/+Lte8L9p07apiqZrV0ICoTfVeIyMrWRp79yr6z/8Xa9wX7zqFkXTfGGONzluiNMcbn/JjoH/Q6AA/Yd/a/WPu+YN85ZHzXR2+MMebL/NiiN8YYE8ASvTHG+JxvEr2IzBGRzSKyTURu8jqeSBCRR0SkRETWeR1LJIjIEBF5W0Q2iMh6Ebne65jCTURSROQjEVnjfudfeB1TpIhIvIh8IiL/63UskSAiO0XkUxFZLSIhreroiz76YBYw9yMRORU4DDyhqhO8jifcRGQgMFBVPxaRNGAVcJ6f/zu7ay/3VNXDIpIILAOuV9Xl7Vza7YnIDUAB0FtVz/E6nnATkZ1AgaqG/CExv7Tojy1grqq1QNMC5r6mqu/i1P+PCaq6V1U/dt8fAjbSyhrEfqGOw+6PTcvYdv/WWTtEJAf4BvCQ17H4gV8SfUsLmPs6AcQ6ERkOnAj8y9tIws/twlgNlACvq6rvvzNwD/DvQKPXgUSQAq+JyCoRuTKUN/ZLojcxRER6Af8A/k1VD3odT7ipaoOq5uOsuTxVRHzdTSci5wAlqrrK61gibKaqngTMBa5xu2ZDwi+J3hYhjxFuP/U/gCdV9Vmv44kkVa0E3gbmeB1LmM0A5rl91k8Ds0Xkz96GFH6qutvdlgDP4XRJh4RfEn0wC5ibbs4dmHwY2Kiqv/U6nkgQkSwR6eO+T8WZcLDJ26jCS1VvVtUcVR2O8//yW6r6HY/DCisR6elOMEBEegJnASGbTeeLRK+q9UDTAuYbgWdUdb23UYWfiDwFfAiMEZEiEbnC65jCbAbwXZwW3mr3dbbXQYXZQOBtEVmL06B5XVVjYrphjMkGlonIGuAj4J+q+kqobu6L6ZXGGGNa54sWvTHGmNZZojfGGJ+zRG+MMT5nid4YY3zOEr0xxvicJXpjjPE5S/TGGONzluiNr4hIg/sg1ToRebHpqdIOXP8fIvLTVo4Nb632v4h8EPD+OhHZKCJPikgfEflRx76FMaFlid74TbWq5rv1+SuAayLxoap6csCPPwLOVNVLgT7uz8Z4xhK98bMPcctVi8h33JWaVovIH9zFanCP3SIiW0RkGTDG3ddTRP7pruy0TkS+7Z4eLyJ/dFd7es2tP4OIHHa3DwAjgJdF5CfAXcBI93MXNQ9QRN4KKOdQIyIXhfHfw8QoK4FgfEVEDqtqLzeRP41TBG0X8BvgAlWtE5HFwHJVfUJEpgCPAdOABOBj4AFgBzBHVX/o3jcd6Atsw1kFaLWIPAMsUdU/N32ue+5O95wyt27+/7a3ApiIXA3MwlkZrSGE/yTGWIve+E6qu0jHPpxCUa8DZwBTgBXusTNwWt0ApwDPqWqVW9u+qerpp8CZIvJrETlFVQ+4+3eo6mr3/SpgeFcDFpHv4dQgv9SSvAmHBK8DMCbEqlU1X0R64FQzvQZn5Z7HVfXmYG+iqltE5CTgbOA/ReRN4AngaMBpDUBqV4IVkW8BlwLzVbWuK/cypjXWoje+pKpVwHXA/wGWAheKSH8AEeknIsPcU98FzhORVLce+LnuOYOAKlX9M7AIOKmToRwC0lo64K6k9COcLqWaTt7fmHZZi974lqp+4tZxnwz8/zjrccYBdTgt/V2q+rGI/BVYg7Mm6wr38onAIhFpdM+/upMxlIvI++60zJdV9caAw4/jzAx631lThd+r6sOd+Rxj2mKDscYY43PWdWOMMT5nid4YY3zOEr0xxvicJXpjjPE5S/TGGONzluiNMcbnLNEbY4zP/T/zuHRbtUFTrQAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "0eG0GXjCLmhz",
-        "colab_type": "code",
-        "outputId": "283348ed-0a18-45b4-a584-a58db0a72c39",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "# We can check that the nz is properly normalized\n",
-        "jc.scipy.integrate.romb(nz1, 0., 5.)"
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "DeviceArray(1.0000004, dtype=float32)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 11
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZUYVlhKkMLpl",
-        "colab_type": "text"
-      },
-      "source": [
-        "Nice :-D "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "PGCY4irsNI9B",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Defining probes and computing angular $C_\\ell$\n",
-        "\n",
-        "Let's now move on to define lensing and clustering probes using these two n(z).\n",
-        "In `jax-cosmo` a probe/tracer of a given type, i.e. lensing, contains a series of parameters, like redshift distributions, or galaxy bias. Probes are hosted in\n",
-        "the `jax_cosmo.probes` module.\n",
-        "\n",
-        "$C_\\ell$ computations will then take as argument a list of probes and will compute all auto- and cross- correlations between all redshift bins of all probes. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-YUfaBhzNINW",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# First we define a list of redshift bins\n",
-        "nzs = [nz1, nz2]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "R3qUxP9wO6fH",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# And now we define 2 probes \n",
-        "probes = [ jc.probes.WeakLensing(nzs, sigma_e=0.26), \n",
-        "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.)) ]"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "t40aS024QFHx",
-        "colab_type": "text"
-      },
-      "source": [
-        "Given these probes, we can now compute tomographic angular power spectra for these probes using the `angular_cl` tools hosted in the `jax_cosmo.angular_cl` module. For now, all computations are done under the Limber approximation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "QWedY8i6cFkw",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "outputId": "d8b34187-8daf-4218-84a1-e6093a5868f2"
-      },
-      "source": [
-        "# Let's define a range of \\ell\n",
-        "ell = np.logspace(1,3)\n",
-        "\n",
-        "# And compute the data vector\n",
-        "cls = jc.angular_cl.angular_cl(cosmo, ell, probes)"
-      ],
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-          ],
-          "name": "stderr"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "VSKlZxxARxYO",
-        "colab_type": "code",
-        "outputId": "3d39a4d7-165e-428d-d2a8-d482353d2064",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "# Let's check the shape of these Cls\n",
-        "cls.shape"
-      ],
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(10, 50)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 15
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "X-Vnim-cSQSh",
-        "colab_type": "text"
-      },
-      "source": [
-        "We see that we have obtained 10 spectra, each of them of size 50, which is the length of the $\\ell$ vector. They are ordered first by probe, then by redshift bin. So the first cl is the lensing auto-spectrum of the first bin"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-Xc458aidYL8",
-        "colab_type": "code",
-        "outputId": "960b3f8d-8bb4-4018-f45d-869de305ca19",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 303
-        }
-      },
-      "source": [
-        "# This is for instance the first bin auto-spectrum \n",
-        "loglog(ell, cls[0])\n",
-        "ylabel(r'$C_\\ell$')\n",
-        "xlabel(r'$\\ell$');\n",
-        "title(r'Angular $C_\\ell$');"
-      ],
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZMAAAEeCAYAAABPMvhnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXhV1b3G8e/vnCQEQgiQhCkMAQIRBJkCMqoIKlQRRRQRRRzACcfaWm+vvbbVaq/VWkRBVFCsIuBQBFGrVkUgjIKCzDNB5iHMQ5J1/0jsjSlDwkmyz/B+nodHzj777P2Lbs+btddae5lzDhERkUD4vC5ARERCn8JEREQCpjAREZGAKUxERCRgChMREQmYwkRERAKmMBERkYApTEREJGAKE5EgZGYbzKyn13WIFJfCROQMzOwrM9trZhW8ruVsmVm8mf3JzNaY2QEzW29mI80s2evaJDwoTEROw8xSgW6AA670tJgzMLOoU2yvCnwDnAP0ds7Fk/8zRQMNyq9CCWcKE5HTGwzMAV4Hbi78RsGtqIfN7HszyzaziWYWW/BeWzNbVNAKmFzw3hOFPuvMLK3Q69cLv1/kPL8xs7UFx1pmZlcXqeERM/seOHSKQPkrsAfo75xbDeCcy3LO3eGcW3C2/2JEClOYiJzeYOCtgj+XmVnNIu9fB/QCGgLnAUPMLAb4gPwAqg5MAK7m7K0lvyWRAPwe+LuZ1S70/kDgcqCqcy6n8AfNrB5wE/Bb51xeADWInJbCROQUzKwr+beBJjnnFpL/pX5Dkd1GOOd+dM7tAaYCrYGOQFTBeyecc+8D8862Dufc5IJz5DnnJgKrgQ5FatjsnDtyko/3BHY65zLP9vwixaEwETm1m4F/Oud2Fbx+myK3uoBthf5+GKgM1AG2uJ+v77D5bIsws8FmttjM9pnZPqAFkFTMY9cENp3h+Heb2eyzrU8E8n97EpEizKwi+bew/Gb2U2BUAKqaWSvn3Hen+fhWIMXMrFCg1CO/ZfOTw0ClQq9rAVknqaMB8ArQA8h0zuWa2WLACu12ukWJNhXU4jvNba7LALVcJCBqmYic3FVALtCc/FtXrYFm5I+KGnyGz2YWfHa4mUWZWV9+flsKYDFwg5n5zawXcOEpjhVHfljsBDCzW8hvmRTXtIJ/Pm1mVQqO0dTM/mZmSQWDAHZwkiATKQmFicjJ3QyMc85tcs5t++kPMBIYdKphuADOueNAP+A2YB9wI/lf6scK7XY/0Kfg/UHAP05xrGXAs+QH1HagJTCruD+Ec24/cDHQFFhdcJvsA+BQwe27FuQPHni1uMcUORnTsr0iZc/M5gKjnXPjvK6lMDO7mfx+nlEa7SWBUMtEpAyY2YVmVqvgNtfN5A8b/sTrugozMwNSye8zedDbaiTUqQNepGykA5PI7/NYR/6Ewa3elvRzBYMDfu91HRIedJtLREQCpttcIiISMIWJiIgELCL7TJKSklxqaqrXZYiIhJSFCxfucs6ddNmCiAyT1NRUFizQw1JFRErCzDae6r2Ius1lZn3MbEx2drbXpYiIhJWIChPn3FTn3LCEhASvSxERCSsRFSYiIlI2FCYiIhIwhYmIiARMYSIiIgGLyKHBZytr72FWbD1A3eoVqVutEpUr6F+fiAgoTEpkxqpd/NcHS/79umqlaFKqVqRutfxwSU2Ko1FSHA2T4qhVJRafz05zNBGR8KEwKYErWtWmWe14svYeIWvvEbbsO0zW3iOs3XmIr1ft5OiJ/18OIjbaR2piHI2S40irEU96zXjSa8WTmliJKL/uLopIeFGYlECV2Gja1K9Gm/rV/uM95xzb9x9j3a6DrN91iPU7D7F+1yGWbz3AJ0u3kVfwcOaYKB9pyZVJrxVPs9rxtEhJoEVKAlVio8v5pxERKT0Kk1JiZtRKiKVWQiydGyf97L2jJ3JZs+MgK7cdYNX2A6zYdoDMtbv5YNGWf++TmliJFikJtExJoGXdBFrVrUqc+mREJETo26ocxEb7/90CKWz3wWMs2ZLN0i3ZLNmSzaJN+5j2ff76SX6fcU6teNrWr0a7BtVoW78a9apXJH9xPBGR4BJRi2OZWR+gT1pa2tDVq1d7Xc5J7Tl0nO827+PbTXv5dtNeFm/ax6HjuQAkVa7A+Y2q06lRIh0bJdI4OU7hIiLlxswWOucyTvpeJIXJTzIyMlyoPDU4N8+xctsBFm7ay4INe5i7bg/b9h8F8sOlY6PqdGyUSLcmSTRIjPO4WhEJZwqTIkIpTIpyzrFx92HmrNvNnHW7yVy3m+37jwHQILES3ZokcUGTZDqnJWkejIiUKoVJEaEcJkU551i/6xDfrN7FjFU7yVy3m8PHc4nyGW0bVKN7eg16NqtBWo3KuiUmIgFRmBQRTmFS1PGcPBZu3MuM1Tv5euVOlm3dD0D96pXo0awGPZvVpEPD6kRrrouIlJDCpIhwDpOitmYf4YvlO/hi+XZmrd3N8Zw84mOj6J5eg94tanFReg0qxvi9LlNEQoDCpIhICpPCDh/P4ZvVu/h82XY+X76dvYdPUDHaT/dzkundojYXn1NDc1tE5JROFyb65ogglWKiuOzcWlx2bi1ycvOYt34P05du5ZOl25m+ZBsVonxc2DSZvq1T6NGsBrHRarGISPGoZSLk5jkWbNjDx0u38dGSrew8cIy4GD+XtahF39YpdGmcqOeJiYhucxWlMDm13DzH3HW7mbL4R6Yv3cqBozkkVY7h8pa1uaZdXVqmJGhUmEiEUpgUoTApnmM5uXy1cicfLv6Rz5Zv53hOHk1rVqZ/u7pc1SaFGvGxXpcoIuVIYVKEwqTkso+c4KPvt/Luws18u2kffp9xUdNk+rerS49mNYmJ0m0wkXCnMClCYRKYNTsO8t63Wbz/bRbb9x8jMS6G/u3qcn2H+jRM0iNdRMKVwqQIhUnpyM1zzFi9k3fmbeLz5TvIzXN0bpzIwA71ufTcmlSI0mgwkXCiMClCYVL6duw/yuSFWUyYt4msvUeoHhfDtRl1ufH8BtSrXsnr8kSkFChMilCYlJ28PMfMNbt4e+4mPlu+nTzn6HFODQZ3SqVrWhI+n0aCiYQqTVqUcuPzGRc0TeaCpslszT7C23M3MWHeJj5fPo+GSXHc1LEB/TPqaplikTAT8i0TM6sPjAD2AKucc0+f6TNqmZSvYzm5fLxkG29kbmDRpn1UivFzXUY9bumSqjVYRELI6Vomno7nNLOxZrbDzJYW2d7LzFaa2Roz+80ZDtMSeNc5dyvQpsyKlbNWIcrPVW1S+ODuLkwd3pVe59birbkbuegvXzFs/ALmrttNqP9SIxLpPG2ZmNkFwEFgvHOuRcE2P7AKuATIAuYDAwE/8FSRQ9wK5ALvAg540zk37kznVcvEe9v3H+XNzI28NXcjew+foEVKFW7v2ojLz6utx+OLBKmg7oA3s1RgWqEw6QQ87py7rOD1owDOuaJB8tPnHwbmOedmmNm7zrn+p9hvGDAMoH79+u02btxY2j+KnIUjx3P5YNEWxs5az5odB0mpWpHbujZkQPt6eoKxSJAJ2ttcp5ACbC70Oqtg26l8AtxnZqOBDafayTk3xjmX4ZzLSE5OLpVCJXAVY/zccH59/vnABYwdkkFKtYr8YdoyOj/9L57750p2HTzmdYkiUgwh/6ufc24pcNLWiIQOn8+4+JyaXHxOTb7dtJeXv17LC1+u4eUZ67g2oy53XNBY81VEglgwhskWoF6h13ULtgXMzPoAfdLS0krjcFJG2tavxss3ZbB250FembGOSfOzmDBvM31b1+Hui9JIq1HZ6xJFpIhg7DOJIr8Dvgf5ITIfuME590NpnVMd8KFlW/ZRXvlmHW/P3cTRnFx6t6jFPd3TOLdOgteliUSUoO0zMbMJQCaQbmZZZnabcy4HGA58CiwHJpVmkEjoqZUQy2NXNGfmI925+6LGfLNqF5ePmMkt4+axaNNer8sTEYKgZeIFtUxCW/aRE4yfvYGxs9az9/AJLkpP5oGeTWldr6rXpYmEtaAeGlyeCvWZDF29erXX5UiADh7LYXzmBl6ZsY69h0/QPT2Z+xUqImVGYVKEWibh5adQGTNjHfsKQuXBS5pyXl2FikhpUpgUoTAJTweP5fDG7A288k1+qFx2bk1+eWk6TWvGe12aSFhQmBShMAlvB46eYOzM/FA5dDyHq1qn8EDPJnqopEiAFCYF1GcSWfYeOs7oGWt5Y/YGcnId12bU474eadROqOh1aSIhSWFShFomkWXH/qOM/HINE+ZtwmfGkC6p3H1RGgkVtaaKSEkoTIpQmESmzXsO89fPVvHB4i1UiY1mePc0burUgNhorVUvUhxBO2lRpDzVq16J5wa0Ztq9XWlVrypPTl9Oj2e/5v1vs8jLi7xfqkRKk8JEIs65dRIYf2sH3rr9fKrFRfPQpO+4/IWZzFqzy+vSREJWRIWJmfUxszHZ2dlelyJBoEtaEh/e05URA9tw4OgJBr06l9ten8/anQe9Lk0k5KjPRAQ4eiKXcbM28OKXazh6IpcbOzbg/h5NqBYX43VpIkFDfSYiZxAb7eeuixrz1a8uYkD7eozP3MCFz3zJq9+s43hOntfliQQ9hYlIIUmVK/Dk1S35+P4LaFWvKk98tJxef5vB16t2el2aSFBTmIicRHqteMbf2oGxQzLIy3PcPHYeQ8cvYNPuw16XJhKUIqrPRDPg5Wwcy8nltZnrGfmvNeTkOe64oBF3X5RGxRjNT5HIokmLRagDXs7GtuyjPPXxcqYs/pE6CbH89xXN6d2iFmbmdWki5UId8CKloFZCLH+7vg2T7+xEQqUY7n7rW4aMm8/G3Ye8Lk3EcwoTkRJqn1qdqcO78LsrmrNw414u/esMRnyxmmM5uV6XJuIZhYnIWYjy+7i1a0M+f+hCejavyXOfraL3899oFr1ELIWJSABqJcTy4g1teePWDuQ6x6BX53L/O4vYffCY16WJlCuFiUgpuLBpMp8+cAH39WjC9CVb6flc/gMkI3GAi0SmiAoTPZtLylJstJ+HLmnK9Pu60TApjocmfcfgsfPYvEdzUyT8aWiwSBnIy3O8NXcjT3+8gjwHv7y0KUM6pxLlj6jf3yTMaGiwSDnz+YybOqXy2UMX0rlxIk98tJx+o2azctsBr0sTKRMKE5EyVKdqRV69OYMXBrYha+8R+rwwkxe/XENOrh4eKeFFYSJSxsyMPq3q8NmDF3BJ85o88+lKrn5JrRQJLwoTkXKSWLkCLw5qy4s3tGXLPrVSJLwoTETK2eXn1f5ZK6XfqNms3q5WioQ2hYmIBwq3UjbvOczlL8xk7Mz15OVF3uhKCQ8RFSaaZyLB5vLzavPpgxfQNS2JP0xbxk1j5/LjviNelyVSYppnIhIEnHO8M38zf5y2DL/P+GPfFvRtXUePt5egonkmIkHOzBjYoT4f39+NpjXjeWDiYoa/vYh9h497XZpIsShMRIJIg8Q4Jt3RiV9dls4/l22j1/PfkLl2t9dliZyRwkQkyPh9xj3d03j/ri5UivFzw6tz+N9PVnBCQ4gliClMRIJUy7oJTLuvKwMy6vHSV2vpP2o2G3ZpVUcJTgoTkSBWKSaKp685j1GD2rJh92EuH/EN7y7Uo+0l+ChMREJA75a1+fj+brRISeDhyd9x/zuLOXD0hNdlifybwkQkRNSpWpG3h3bk4Uub8tGSrVzxwkyWZGnOlAQHhYlICPH7jOEXN+GdYR05npNHv1GzGDdrvW57iecUJiIhqH1qdabf140Lmybz+6nLGPbmQs1JEU8pTERCVLW4GF4ZnMHvrmjOVyt38Iu/fcOCDXu8LksiVESFiZ7NJeHGzLi1a0Peu6sz0VE+BoyZw5gZa3XbS8pdRIWJc26qc25YQkKC16WIlKrz6lZl6r1dubR5Tf40fQVDxy8k+7BGe0n5iagwEQlnVWKjeWlQWx7v05yvV+3g8he+4bvN+7wuSyKEwkQkjJgZQ7o0ZNIdnXAOrh2dyfjMDbrtJWVOYSIShtrUr8ZH93Wla5MkfjflB4ZPWMTBYzlelyVhTGEiEqaqVorh1cEZPNLrHD5espW+I2eyZoeWB5ayoTARCWM+n3HXRY156/aOZB85wZUjZzHt+x+9LkvCkMJEJAJ0apzItHu70ax2FYa/vYjfT/1Bj7SXUqUwEYkQtRJieWdYR27pksq4WRsYOGYO2/cf9bosCRMKE5EIEu338T99zmXEwDYs27qfy0d8w5x1WslRAqcwEYlAV7aqw5R7ulClYjSDXp3L2Jl6WKQERmEiEqGa1Ixnyj1duPicGvxh2jIenLiYI8dzvS5LQpTCRCSCxcdG8/KN7fjlJU2Z8t2P9Bs1m027D3tdloQghYlIhPP5jHt7NGHskPZs2XuYPiNn8vWqnV6XJSFGYSIiAHRPr8HUe7tSOyGWIePm8eKXa9SPIsWmMBGRf2uQGMf7d3fm8pa1eebTldw7YRGHj+sxLHJmChMR+ZlKMVG8MLANj/Q6h4+WbOWaUZls3qN+FDk9hYmI/Aez/MewjBvSnqy9h7ly5Exmr93ldVkSxEI+TMysuZlNMrNRZtbf63pEwslF6TX4cHhXEitX4KbX5vH6LM1HkZPzNEzMbKyZ7TCzpUW29zKzlWa2xsx+c4bD9AZecM7dBQwus2JFIlTDpDg+uLsz3dNr8PjUZfz63e85lqP5KPJzXrdMXgd6Fd5gZn7gRfJDojkwsKD10dLMphX5UwN4E7jezJ4BEsu5fpGIEB8bzZib2nHfxWlMXpjFoFfmsuvgMa/LkiBiXjdZzSwVmOaca1HwuhPwuHPusoLXjwI45546w3H8wPvOub6neH8YMAygfv367TZu3FhaP4JIRJn2/Y88PPk7EuMq8MrgDJrXqeJ1SVJOzGyhcy7jZO953TI5mRRgc6HXWQXbTsrMUs1sDDAeeOZU+znnxjjnMpxzGcnJyaVWrEikueK8Oky+ozO5eY5rRs3mk6XbvC5JgkAwhkmJOOc2OOeGOecGOedmel2PSCRoWTeBD4d3Ib1WPHf+fSEjvlitjvkIV6IwMbOuZnaPmTUqtK1hKde0BahX6HXdgm0BM7M+ZjYmOzu7NA4nEtFqVMlfH6VfmxSe+2wV905YxNET6piPVCVtmSQDHYD/MbPnzCwD+HMp1zQfaGJmDc0sBrge+LA0Duycm+qcG5aQkFAahxOJeLHRfp69rtW/JzgOGDOHHQe04FYkOmOYmNljZnYPgHPuA+BW8kdbLQW6AcvP9uRmNgHIBNLNLMvMbnPO5QDDgU8Ljj3JOffD2Z5DRMrWTxMcR9/YjlXbDnDVyFks+3G/12VJOTvjaC4zWwK0d84dLbL9diD5TKOsglFGRoZbsGCB12WIhJ2lW7K5/Y0F7D96ghHXt6Fn85pelySlKNDRXCeKBkmB8cCNAVVWztRnIlK2WqQkMGV4F9JqVGbomwt4ZcY6dcxHiOKEyXEzq110o3PuOHCi9EsqO+ozESl7NavEMnFYJ3q3qMWT05fz6PtLOJGb53VZUsaKEybPAlPMrEHhjQWzz/Urh4j8h4oxfkYObMvw7mm8M38zQ8bNI/tISP3uKSUUdaYdnHOTzawSsNDM5gCLyQ+ha4HHy7Y8EQlVPp/x8GXppCbF8ej739N/1GzGDmlPveqVvC5NykCxhgY7594AGgITgWjgKHCDc+6tMqyt1KnPRKT89W9Xlzdu7cD2/Ue5+qXZLN68z+uSpAx4/mwuL2g0l0j5W7PjALe8Pp+dB47x/IDW9GrxH12xEuRC7dlcIhKG0mrE88HdXWhWuwp3vfUtY2as1UivMKIwEZFyk1S5AhOGduQXLWrzp+kreGzKUnI00issnLEDPpyYWR+gT1pamteliESs2Gg/LwxsQ91qFXl5xjq2ZR9lxMA2VIqJqK+jsBNRLRPNMxEJDj6f8egvmvGHvufyrxU7GDhmDjsPaLGtUBZRYSIiwWVwp1RevimDldsP0G/ULNbuPOh1SXKWFCYi4qlLmtdk4rBOHDmeyzWjZjN/wx6vS5KzoDAREc+1qleV9+/qQvVKMQx6dS4ffb/V65KkhBQmIhIU6idW4r27OnNeSgLDJ3zL2JnrvS5JSiCiwkQz4EWCW7W4GP5++/lc2rwmf5i2jD9NX05enuaihIKIChON5hIJfrHRfl4a1I7BnRowZsY6Hpi4mGM5Wg442Glgt4gEHb/P+P2V51I7oSJ//mQFuw4eY/RN7agSG+11aXIKEdUyEZHQ8dNywM9d14p56/dw3ehMtu/X+vLBSmEiIkGtX9u6jLulPZv3HKbfS7NZs0NzUYKRwkREgl63JslMvKMTx3LyuHb0bBZt2ut1SVJERIWJRnOJhK4WKQm8f1dnqlSM5oZX5vLlyh1elySFRFSYaDSXSGirn1iJd+/sTOMacdz+xgLeW5jldUlSIKLCRERCX3J8Bd4Z1olOjRL55eTvGP211kUJBgoTEQk5lStEMXZIe65sVYenP17BEx9pcqPXNM9EREJSTJSP5we0JqlyBV6buZ49h47zv/3PI9qv35G9oDARkZDl8xmPXdGMxMoxPPPpSvYdPs5Lg9pRMcbvdWkRRxEuIiHNzLinexpP9WvJ16t2cuNrc9l3+LjXZUUchYmIhIWBHerz0qC2LMnKZsDLc9iWrdny5UlhIiJho1eL2rx+S3uy9h7mmlGzWaeVG8tNRIWJJi2KhL/OaUm8M6wTR0/kcu3oTJZu0f/v5SGiwkSTFkUiQ8u6CUy+sxOx0X6uHzOHuet2e11S2IuoMBGRyNEouTLv3tWJmlUqMHjsPP61YrvXJYU1hYmIhK3aCRWZfGdnmtaMZ9j4hfxj0RavSwpbChMRCWvV42J4e+j5tGtQjQcmLmZ85gavSwpLChMRCXvxsdG8cWsHejarye+m/MCIL1breV6lTGEiIhEhNtrP6Bvb0q9NCs99toonPlquQClFepyKiESMKL+Pv1zbivjYKF6buZ5Dx3J48uqW+H3mdWkhT2EiIhHF5zMev/Jc4mOjGfnlGg4ey+G561oTE6UbNYFQmIhIxDEzHr4snfjYKJ76eAWHjuUw6sZ2xEbrAZFnS1EsIhHrjgsb8+TVLfhq1U5uHjuPA0dPeF1SyFKYiEhEG3R+A54f0JoFG/dy46tz2XtITxw+GxEVJno2l4icTN/WKbx8YzuWbzvA9WPmsOOAnjhcUhEVJno2l4icSs/mNXl9SHs27z3MgJfn8OO+I16XFFIiKkxERE6nc1oSb97WgV0Hj3Ht6Ew27DrkdUkhQ2EiIlJIuwbVmTC0I4eP53Ddy5ms3n7A65JCgsJERKSIFikJTLyjEw4YMGaO1kQpBoWJiMhJNK0Zz+Q7OlEx2s/AV+awcONer0sKagoTEZFTSE2KY9KdnUiMi+Gm1+aSuVaLbJ2KwkRE5DRSqlZk0h2dSKlakSHj5jFj1U6vSwpKChMRkTOoUSWWd4Z1pFFyZW5/YwGfL9OqjUUpTEREiiGxcgUmDD2fZrXjufPvC5m+ZKvXJQUVhYmISDFVrRTDm7efT+t6VRn+9rdaBrgQhYmISAlUKVi18fyGiTw4aTET52/yuqSgoDARESmhuApRjLulPRc0SeaR95bwZuYGr0vynMJEROQsxEb7GTO4HT2b1eCxKT/w2sz1XpfkKYWJiMhZqhDl56VB7ejdohZ/nLaM0V+v9bokzyhMREQCEBPl44WBbejTqg5Pf7yCF75Y7XVJntCyvSIiAYry+3h+QGuifcazn63iRG4eD17SFDPzurRyE3JhYmaNgN8CCc65/gXb4oCXgOPAV865tzwsUUQikN9nPHNtK6L9Pkb8aw3Hcx2P9EqPmEAp19tcZjbWzHaY2dIi23uZ2UozW2NmvzndMZxz65xztxXZ3A941zk3FLiylMsWESkWv894ql9LBp1fn9Ffr+XJj5bjnPO6rHJR3i2T14GRwPifNpiZH3gRuATIAuab2YeAH3iqyOdvdc7tOMlx6wJLCv6eW8o1i4gUm89nPHFVC6L9Pl6duZ5c5/jdFc3DvoVSrmHinJthZqlFNncA1jjn1gGY2TtAX+fcU8AVxTx0FvmBshgNKhARj5kZ/9OnOT4zxs5aT16e4/Erzw3rQAmGL94UYHOh11kF207KzBLNbDTQxsweLdj8PnCNmY0Cpp7ic8PMbIGZLdi5U0/9FJGyZWY8dkUzhnZryBuZG3lsylLy8sL3llfIdcA753YDdxbZdgi45QyfGwOMAcjIyAjf/6IiEjTMjP/6RTP8Ph+jv15Lbh48eVULfL7wa6EEQ5hsAeoVel23YJuISMgzMx7plY7fBy9+uZa8PMdT/VqGXaAEQ5jMB5qYWUPyQ+R64IayOJGZ9QH6pKWllcXhRUROysx4+NJ0/D4fI75YTZ5z/Pma88IqUMp7aPAEIBNIN7MsM7vNOZcDDAc+BZYDk5xzP5TF+Z1zU51zwxISEsri8CIip2RmPHRJU+7v0YTJC7P49XvfkxtGfSjlPZpr4Cm2Tweml2ctIiJeyJ8ZD89/vhrn4H/7n4c/DFoowXCbS0QkojzQsyk+M577bBUOxzP9W4V8oERUmKjPRESCxX09mmDAs5+tAgfPXBvagRIM80zKjfpMRCSY3NujCQ9f2pT3F23hV5O/C+k+lIhqmYiIBJvhFzfBzHjm05U44C8h2kKJqDDRbS4RCUb3dM//Tnrm05UYoXnLS7e5RESCwD3d0/7/lte7oXfLK6JaJiIiwWz4xU1wLr9T3rCQGjasMBERCSL39mhCnoO/fr4KnxEyM+UVJiIiQeb+nk1wOJ7/fDVm8HS/4A+UiAoTdcCLSKh4oGdT8hyM+GI1hgX9wyHVAS8iEqQe7NmEey9OY+KCzfz2H8G9HkpEtUxERELJTw+HzM1zvPTVWqJ8xh/6BueKjQoTEZEgZmb86rJ0cvMcL89Yh9+XvyRwsAWKwkREJMiZGb/pfQ65eY5XZ67HV7AkcDAFisJERCQEmBm/vbwZOXmOsbPWE+U3Hu19TtAESkSFiUZziUgoM8u/xZXnHGMKbnn9+rL0oAgUjeYSEQkhZsbvrzyXQefXZ9RXa/nr56u9LgmIsJaJiEg4MDP+2LcFOYFjRNEAAAT3SURBVLmOEV+sJtpn3Nujiac1KUxEREKQz5c/kfFEXh7PfraK6Cgfd17Y2LN6FCYiIiHK5zOe6d+KnFzH0x+vIMpn3N6tkSe1KExEREKY32c8d10rTuTm8cRHy4mJ8jG4U2q51xFRHfBm1sfMxmRnZ3tdiohIqYny+xgxsA2XNK/J76b8wNtzN5V7DREVJhrNJSLhKtrvY+QNbeiensx/fbCEyQs2l+v5IypMRETCWYUoP6NubEe3Jkk88t73TFm8pdzOrTAREQkjsdF+xtyUQUZqdR6a9B2fLN1aLudVmIiIhJmKMX7GDmlPq7oJ3DthEV8s317m51SYiIiEocoVonj91g40q12Fu/7+LTNW7SzT8ylMRETCVJXYaMbf2oHGNSoz7M0FZK7dXWbnUpiIiISxqpVi+PttHahXrRK3vTGfhRv3lMl5FCYiImEusXIF3hp6PrUSYlm57WCZnCOiZsDrEfQiEqlqxMcy/b5uxEb7y+T4EdUy0aRFEYlkZRUkEGFhIiIiZUNhIiIiAVOYiIhIwBQmIiISMIWJiIgETGEiIiIBU5iIiEjAzDnndQ3lzsx2AvuAUy25mHCa95KAXWVRVxk73c8UzOcK5Fgl/Wxx9y/OfmfaJ9yuMV1fpbd/MF9fDZxzySd9xzkXkX+AMWf53gKvay/tnzeYzxXIsUr62eLuX5z9zrRPuF1jur5Kb/9Qvb4i+TbX1LN8L1SV589UmucK5Fgl/Wxx9y/OfmfaJ9yuMV1fpbd/SF5fEXmbKxBmtsA5l+F1HRK+dI1JWSqr6yuSWyZna4zXBUjY0zUmZalMri+1TEREJGBqmYiISMAUJiIiEjCFiYiIBExhEiAza2Rmr5nZu17XIuHHzK4ys1fMbKKZXep1PRJezKyZmY02s3fN7K5AjqUwOQkzG2tmO8xsaZHtvcxspZmtMbPfADjn1jnnbvOmUglFJby+/uGcGwrcCQzwol4JLSW8vpY75+4ErgO6BHJehcnJvQ70KrzBzPzAi0BvoDkw0Myal39pEgZep+TX138XvC9yJq9TguvLzK4EPgKmB3JShclJOOdmAHuKbO4ArCloiRwH3gH6lntxEvJKcn1Zvj8DHzvnvi3vWiX0lPT7yzn3oXOuNzAokPMqTIovBdhc6HUWkGJmiWY2GmhjZo96U5qEgZNeX8C9QE+gv5nd6UVhEhZO9f11kZmNMLOXCbBlEhXIhwWcc7vJv58tUuqccyOAEV7XIeHJOfcV8FVpHEstk+LbAtQr9LpuwTaR0qDrS8pSmV9fCpPimw80MbOGZhYDXA986HFNEj50fUlZKvPrS2FyEmY2AcgE0s0sy8xuc87lAMOBT4HlwCTn3A9e1imhSdeXlCWvri896FFERAKmlomIiARMYSIiIgFTmIiISMAUJiIiEjCFiYiIBExhIiIiAVOYiIhIwBQmIiISMIWJSBAxszgzG2lmHb2uRaQkFCYiweVOIBbo6nUhIiWhMBEJLr2AlcBirwsRKQmFiUiQMLNYwA+0Bb72uByRElGYiASPJuSHyQrn3AmvixEpCa20KBI8koGmFKzNLRJK1DIRCR51gPcAn5lV87oYkZJQmIgEATOLIr+vpBYwGsj1tiKRktHiWCIiEjC1TEREJGAKExERCZjCREREAqYwERGRgClMREQkYAoTEREJmMJEREQCpjAREZGA/R9BmHGm3sHDZQAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ri-QjcD8UckV",
-        "colab_type": "text"
-      },
-      "source": [
-        "In addition to the data vector, we can also compute the covariance matrix using the tools from that module. Here is an example:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "zIdQSRgkUYC7",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "mu, cov = jc.angular_cl.gaussian_cl_covariance_and_mean(cosmo, ell, probes);"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yGd3NelNVZpj",
-        "colab_type": "text"
-      },
-      "source": [
-        "The data vector from this function is in a flattened shape so that it can be multiplied by the covariance matrix easily."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WX5lmHsRVXIh",
-        "colab_type": "code",
-        "outputId": "64a404cf-9269-4e8b-ff67-3de6eb3ba183",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 265
-        }
-      },
-      "source": [
-        "semilogy(mu);"
-      ],
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD4CAYAAAAKA1qZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO29d3xcd5nv/36mqZdRl60uy7Llbsm9pDgJTiHZhSwkbKHkR4ALu+wu7N2EbXDvsiyXuyxbQgkkhIVLsgECJCGQnjhOnMRyt+MSx01yb3KTrTbf3x8zI43GM9LMnDI60vf9eullzdF4vt8zGp3nPO3ziFIKjUaj0UxMXOnegEaj0WjShzYCGo1GM4HRRkCj0WgmMNoIaDQazQRGGwGNRqOZwHjSvYFkKCkpUXV1denehkaj0TiKDRs2nFJKlcb6mSOMgIi8H3j/lClTaG9vT/d2NBqNxlGIyMF4P3NEOEgp9ZRS6t6CgoJ0b0Wj0WjGFY4wAhqNRqOxBm0ENBqNZgLjCCMgIu8XkQfPnTuX7q1oNBrNuMIRRkDnBDQajcYaHGEENBqNRmMN2ghoNBrNBEYbAY1Go0mQ7YfP8cTGTi719Kd7K6bhuGYxjUajSRdf/90uXnv3FAVZ73DfzdO4a0E1IpLubRnCEZ6ATgxrNJqxQPiCP70yj/uf2MYXf7aV3v5AmndlDEcYAY1GoxkLKKWYV1PIo59czF/cMJVfbOzkiz/bQiDg3AmNjggHaTQazVhAKXCJICJ8/oYmfB4XX//dLuqKs/nLm5rTvb2U0J6ARqPRJEhAKSIzAJ++poE7W6v4j5f3su6902nblxG0EdBoNJoECSiFKyIRLCJ85fYZ1BXn8MWfbaG713lVQ2k1AiJyrYi8JiLfFZFr07kXjUajGQ2lILoYKCfDw9c/OJvDXZf5zivvpWdjBkjZCIjIwyJyQkS2Rx1fLSK7RWSviNw3ysso4CKQCXSmuheNRqOxg3BOIJqF9UX83txJfO/VfRw8fSkNO0sdI57AI8DqyAMi4gYeAG4GWoC7RaRFRGaJyNNRX2XAa0qpm4G/Br5iYC8ajUZjOQGlrvIEwtx/y3S8buGrv9lp76YMkrIRUEqtAc5EHV4I7FVK7VNK9QKPAXcopbYppW6L+jqhlAoX2J4FMmKtIyL3iki7iLSfPHky1e1qNBqNYRSxPQGA8vxMPnVNI8+9c5ytnV32bswAZucEJgMdEY87Q8diIiIfEJHvAT8G/jPWc5RSDyql2pRSbaWlMUdkajQajS2M5AkAfHxZHf5sL998fo99mzJIWhPDSqknlFKfUkp9WCn1Srzn6XkCGo1mLBBQjCgTkZfp5VPXNPLK7pO0H4gOlIxNzDYCh4HqiMdVoWMajUbjfJTCNYpU0J8sqaUk18d/vrzXnj0ZxGwjsB5oEpF6EfEBdwFPGn1RrR2k0WjCnLnUy+pvreH3v/06//zbXew7edG2tQNxqoMiyfZ5+OiSOl7ZfZLdxy7YtLPUMVIi+iiwDmgWkU4RuUcp1Q98DngW2Ak8rpTaYXSTOhyk0WjCHDrTza5jFzh3uY/vv7aPm/51DV/77U76BqwXcovuGI7HHy2uJcvr5sE1+yzfk1GMVAfdrZSqVEp5lVJVSqmHQsefUUpNVUo1KqW+asYmtSeg0WjCBFRQrO3vb2th3f3X84H5k/neq/v4xCPrLe/YVaPkBML4c3x8eEE1v958mKPnLlu6J6M4QjZCewIajSaMChkBlwhleZn8nzvn8M8fmMXre0/xpz/dRL+FHkEggZxAmHuW1zOgFD9965Bl+zEDRxgB7QloNJowYdXmyNj8XQtr+ModM3lx1wn+73PWlWfGko2IR3VRNtdMLeXx9g5LDZNRHGEEtCeg0WjChLX7o+/I/3hxLXcvrOZ7a97jjb2nLFlboUZNDEdy14Iajp/v4dU9Y7fR1RFGQHsCGo0mTNgTiBWb/7vbWqgvzuH+X27jSt+AJWsnYwRWTS+jJDeDR9/uGP3JacIRRkCj0WjCDOUErv5Zts/DV+6YwcHT3fzgNfMrcwJKkVB5UAiv28WdrVW8vPsEx89fMX0/ZuAII6DDQRqNJsxgTiBOhnZFUyk3z6zgP1/ey+EukytzkvQEAP6grYqBgOI3W4+auxeTcIQR0OEgjWbs0T8Q4I29p/jmc7v5wuNb+LtfbefnGzo5191n6bqBETyBMH9z63SUgm+anCROpjooTGNpLtMq8nhm29g0AnrGsEajSYm/+/V2Hn27A5cEFTQv9vTz4zcPkpfp4Qs3TuWjS+sSqqlPlrARGOm1q/zZ/MmSWh5au5/PXNvIlLJck9ZOKho0yG2zK/m/z+3h6LnLVBZkmbIXs3CEJ6DRaMYeR89dYUpZLju+spp1969i6z/cxK8/u4x5NX6+/NQ7fOHxLZaURqoYJaKx+PQ1jWR63XzrBfO8gejxkolyy6xKAJ7Zdsy0vZiFI4yAzgloNGMPpSDH5ybL5waCd+Zzqgv50ccX8Jc3TuWJTYf5u19vH0zkmkUi4SCA4twMPrGsnqe3HmXXsfOmrJ1ox3A0DaW5TK/MH5MhIUcYAZ0T0GjGHoE4nVMiwp+tauKz1zXy6Nsd/Ne6gyavG/w3kTvyT65oINvn5nuvmlMppFLICYS5dVYFGw6eHXNVQo4wAhqNZmwy0vXwizc1c11zKf/0zE72HDdPTXMoJzD6cwuyvdy9sIYntxyh82y3CWsn3jEczY0tFQC8uPOE4X2YiTYCGo0mJYJD1+P/XET4P3fOISfDw5ee2GZaWChSOygRPrG8HgEeXnvA+NpJdgxHMrU8lyp/Fi/uPG54H2aijYBGo0kJhRo1Pl6al8H/fF8z7QfP8uSWI6asm0w4CGByYRa3z5nEY+sPce6ysfLV0SaLjYSIcMP0ctbuPcXlXvO7mVPFEUZAJ4Y1mrFHIJBYueQftFUza3IB//TMTi71GJd6TjQxHMnHl9XT3TvArzcbG3SoRpkxPBo3TC+npz/AWou0jVLBEUZAJ4Y1mrFHoqERt0v48u0tHD/fw/dNkHIYSTsoHrOqCpgxKZ9H3+4wFJYaLQQ2Ggvri8jL8IypkJAjjIBGoxl7KEXCnVOttUXc2FLOQ2v3G+4oHkk7aCTuWljDzqPn2dqZekQh1T6BMD6Pi5VTS3lx14lBNdR0o42ARqNJiSS11PiLG6Zy4Uo/D6015g0EkkwMh7lj7iSyvG4eW5/6kJdUO4YjWTW9jJMXeth2eGyEt7UR0Gg0KZFspUzLpHxumVXBw68foKu7N+V1A6Em5GSNQH6ml9tmV/Lk5iMpy0wHcwLGzMB1zWW4BF7cNTZKRbUR0Gg0KZHMlK0wn181lUu9/YYGsCfTJxDN7XMncal3gFd2pzbkRaWgIhqNP8fHnOpCXnt3bAyaSasREBGXiHxVRP5DRD6azr1oNJrkCKRQKdNckcctsyr58bqDXEyxUmhQOyiFDO2ShmL82d6U5RtSOedYrGgqZUtHl+WKq4mQshEQkYdF5ISIbI86vlpEdovIXhG5b5SXuQOoAvqAzlT3otFo7EeR2l3xJ1c0cKGnn8fXpzZtK5US0TAet4vVMyt4cefxlEJCKsV1o1nZVEJAwRvvpb9U1Ign8AiwOvKAiLiBB4CbgRbgbhFpEZFZIvJ01FcZ0Ay8oZT6S+AzBvai0WhsJtVKy7nVhbTW+vnhG/sZSKFCJtlmsWhumVWZckjIaHVQmDnVheRleFjzroONgFJqDXAm6vBCYK9Sap9Sqhd4DLhDKbVNKXVb1NcJgnf/Z0P/N6ZZFpF7RaRdRNpPnhwbMTSNRhO8K041SXrP8no6zlzmhRTq5Y3kBMBYSCiQRFnsSHjdLpY0FrNmz0nTVVaTxeycwGQg0sfrDB2LxxPA+0TkP4A1sZ6glHpQKdWmlGorLS01b6cajcYQSqmUr4c3tZQzuTCLH6egMJqsdlA0HreLm1oqeHn3CXr7k5x3YEJiOMzKqaUc7rrM/lOXTHm9VElrYlgp1a2Uukcp9adKqQfiPU/LRmg0Yw8j3bOe0AD21987lfQcYKPhIAjW6l+40s/6A9HBjNHWTl1KOpqVTcGb2tfSHBIy2wgcBqojHleFjmk0mnFGIgJyI/HB+VUoBb/cmFxNiJHEcJjlTSX4PK6kw1EBpRAz4kFATXE2tcXZaS8VNdsIrAeaRKReRHzAXcCTRl9Uawc5i0s9/Zy+2JPubWgsJlEBuXjUFGezqL6IJzYeTiounop2UDTZPg/LGot5ceeJpNc2yxMAWD6lhHXvnabPgjGciWKkRPRRYB3QLCKdInKPUqof+BzwLLATeFwptcPoJnU4yFn8w5M7aP3HF7j/iW2cv5L+OmiNNRhJDId5/5xJ7Dt1id1JDJ1JVTsomhtayjl0ppu9Jy4mta7Rc45kaWMJl3oH2J5GCQkj1UF3K6UqlVJepVSVUuqh0PFnlFJTlVKNSqmvmrFJ7Qk4i8NngzHex9s7uOXfXuNdE6dKacYORmWVAd43owKR5Aawp6odFM2qaeUAPJ9gSEgNeiCGlh3GooYiANbtO23eiyaJI2QjtCfgLDK9LmZXFfD4p5bQ0x/gww++ye5j2hCMN5IVkItFaV4GC+qK+N32xMs1zUgMA1QUZDJzcn7C4x7NMj6RlORmMLU8lzf3JZegNhNHGAHtCTiLsNJia62fxz+1BK9b+MQj6zml8wTjCiOjFiO5ZWYFe45f5L2TiYVljPYJRHLD9HI2HjqbUA4rnDkwMycAwb6F9gNn0pYXcIQR0J6As4iMFdeX5PD9P2nj1MUePv/YpjGjoa4xTioCcrFYPbMSgN9tTywkpEzyBACun1aGUiQ06StgQU4AYHFDMd29A4bmHBjBEUZAewLOQkXVUs+uKuTLt8/g9b2n+a91B9K1LY3JBI298depKMhkXk0hz+5IzAiEbyTMuCOfMakAf7aXNXtGNwJW5AQAFjUUA/BmmvICjjACGmcRS1/lrgXVXNdcytd/t5uj55JrDtLEJxBQ/G77UVNm9ya9tgna+mFumF7O1s5zHD9/JYF1g/+6TbACbpewbEoJr707unyDmR5IJEU5PqZV5GkjMBI6HOQsAoGr75ZEhP91x0wGlOLrv92Vno2NQ3Ydu8Cnf7KRmV9+NunOW8OYkBgOs2p6GQAvJTBoxeywzMqmUk5c6GHP8ZFzEmY0qcVjcUMx7QfOJi9jYQKOMAI6HOQs4nWSVhdl86mVDfxq8xE2HExfNcR4ojeUTFQKPvL9NzmRwJ20WZjRJxCmuTyPyYVZCQ1gjw43GmXF1BKAUTt3B42PaaZviMUNxVzuG2BrZ5fprz0ajjACGmcxUlflZ65tpCI/k3/8zc60qyeOB8Lv4Z+tauLkhR4+8aP1KY9OTJaAAQG5aESEG6aXsXbvqVH3HzBRxA2gsiCLprLcUWWdw59Ws3MCAIsbihCBde/ZHxLSRkBjOmoEfZVsn4c/W9XEpkNdY0JL3emE4+Pzawr597vmsf3web7ylOEm/YQwIiAXi1XTy7nSF+D1USp1zNL0j2RFUylv7Ts9ogFSKc42ToTCbB/TKvLT0jTmCCOgcwLOQilwjfDJurO1ismFWXzrhT3aGzDMUAPTDS3lfPqaRh59u4OXbRhiblRALppFDUXk+Ny8MErzVsCk0tRIVkwtoac/QPuBs3GfY2Z/QiyWNBSz4aD9eQFHGAGdE3AWo92p+TwuPnvdFO0NmEAgqmzxL25sYmp5Ll/65baUZ/gmvLZBAbloMjxuVk4t5aVdx0e8OVAWeAKL6ovwuV2sGSEvMNQsZo0VWFjvp6c/wPYj9t7sOsIIaJKnfyDAN5/fww9e28feE/ZKNgTv1Eb+Q7mztYpJBZl895X3bNrV+CS6bDHD4+afPzibo+eu8J1X9lq+vtmNU6uml3P8fA87jpyP+xwzNf3DZPs8zKspHHHmr5XVQQCttUEdofYkZxwYRRuBccru4xf49xff5R9/s5MbvrmGP/zBm+yxScgtkYlTPo+Ljy2rY92+0+yw+c5nPDFUsTLE/Bo/d8ydxA9e288RC8tGzRCQi2ZFU7BSZ6QOXrMTw2GWNBaz48h5zl2OrXwbsKpbLERpXgZ1xdmsHyEkZQXaCIxTAqGw4ld/fyb33TyN7YfPc9t/rOXXm62f8aNI7G7pwwtqyPa5eWjtfsv3NF4Zui4Nf8P/6n3NKOAbz+62bm3MDQcBlOdnMrU8l7UjhAkDFhgfCJZpKgVv749zJz7odZm/dpi2uiI2HDxra67MEUZAJ4aTR4U+seV5mXz6mkZe/MI1zK0u5POPbeaxtw9Zunai1RsFWV4+1FbNU1uO2FrfPp5QcZKVVf5sPrGsnl9uOmyZB2hFlQ4EK3XePnAmbqVOsPDA/HXnVheS4XHF7dw1S710JBbU+TlzqZd9Ns4ddoQR0Inh5In2XEtyM/jJPYu4ZmopX/rlNl7aldxYvWSI1TEcj48vq6M/oPipxYZpvDJSsvLelQ1k+9x8+2VrcgNmCchFs7yphN7+QNz5v1YZn0yvm/k1/hGMwNWhN7Npq7M/L+AII6BJnliNLT6Pi+/80XymV+bzF/+9xTKZgWQ6SWuLc1g+pYSftXdqhdEUGKlssSjHxx8truXJLUc4YMGdpVkCctGEK3XiDWC3IjEcZkljMe8cPU9Xd+9VP7O6OgigoSSHohyfrXkBbQTGKYNhgqj7lmyfhwc+Mp+BgOILj2+2JPaYbFv/h9qqOdx1mddHqMzQxEaNEqf+/1bU43G7+LYFlULKRAG5SLJ9HubXFo5gBMyvSgozUl4gfJNioQ1ARGit9WtPQGOckVrc60py+Jtbp/PmvjM83t5h+tqBETqGY3HTjHIKs708tt78vYx3BitW4rzfZXmZfLitml9tOsLJC+YO9TFjslg8VjSVsvPo+Zh7Nls7KJI51QVkel0xO3fjJeHNZkGdnwOnuzlxwZ48mTYC45TRhmJ/uK2ahfVFfO23u+KWxKW+9sgdw9FkeNz8/rzJPL/jOGcvXe2Ga+KTyLSrjy2ro3cgwKMm512sCgfBUKloLAmJQMC6kEyGx01rrT/muEer+wTChPMCG2wKCaXVCIjIChH5roj8QETeSOdexhuDdy1xfu5yCX9/WwvnLvfxHZMbtlLRmb+ztYregQC/TXC61Fjj+XeO883n99iu6z+asQdoLM3lmqml/OTNg6ZKEiTr8SXDjEkFFGZ7Y/YLWJUYDrOkoZidR89fdUNiR04AYOakAjI8LtoPjnEjICIPi8gJEdkedXy1iOwWkb0ict9Ir6GUek0p9WngaeBHqe5FczWJKB7OnFzA78+dzMOv7zc1SaxSaOZpqcynoSSH32w7Yto+7OTbr+zl3198l5v/7TX2nkhsVq4ZjJYTCPOxZXWcuNDDb5MY6J7I2lbdFbtdwqL6It7af3VYxgrtoEgWhyZ9vRWVF7BaOyiMz+NiTnWhbXkBI57AI8DqyAMi4gYeAG4GWoC7RaRFRGaJyNNRX2UR//UjwE8N7EUTxZAnMPIn9i9vmgrAt57fY9raqUgMiwi3zq5k3XunHTmQvjDLC0B3bz8f/M4btnVBBxL8PV/TVEpdcTY/efOgaWtblRgOs7ihmI4zl+k8233Vulbejc+uKiTL676qVDQRr8ssFtT52X7kPN291nuWKRsBpdQaINpULQT2KqX2KaV6gceAO5RS25RSt0V9nQAQkRrgnFIqZkeLiNwrIu0i0n7y5MhDHzRDqATjl1X+bD6ysIYnNh2m40z3yE9OdO0E1o3FrbMrCajEB46PJRQwu6qAX/6PZeT43Hzsh+tNez9HXDfBu1OXS/iDtmrWHzhrWrmo1QW9g3fk+66+I7cyLu/zuGit9V9VIZSo12UGbXVFDAQUmw9ZP2TG7JzAZCCyxKMzdGwk7gF+GO+HSqkHlVJtSqm20tJSE7Y4MQiMXDQyjE9d04BL4HtrzMkNpBqzbS7Po7E0h99sNS9kYRfhSpnqomz+656F9PQN8NmfbrRcFjhaRXQkPji/CpfALzZ2mrJ2KmG/ZGguz6Mw23vVHblV2kGRtNX52XXsPOevDBVN2NExHGZ+jR8RbOkXSHt1kFLqH5RSIyaFtWxE8oRlIxJJ3FUWZPHB+VU83t5pinxDIEBKtYMiwq2zKnlrv/NCQgoGr8RTyvL4xh/MYWvnOf7lOeu0eyJWTujCVFGQyYqmUn6xwZzGPCsE5CJxhfICb+6PNgLWrguwoK6IgIJNEXfidnQMhynI8tJcnke7DWNYzTYCh4HqiMdVoWMau0lS8PAz1zbSPxDg4dcPmLJ8qndLN82oIKDgld3OCv1F166/b0YFdy+s5gdr9/POCLLIRknGE4BgFdaRc1d4w4QxhlYIyEUTzgtEFi5Y7YFAUEfI7ZJhyVm7+gTCzKspZHNHl+Wd9GYbgfVAk4jUi4gPuAt40uiLau2g5EkiGgQE5RveN6OCx9YfMjyj1kjMdsakfMrzMxIaOD6WiNU4dd/q6RRmefnbX22z7A85ep7AaNzYUk5epodfmaAmG1DKEiG3SIbyAkNGy+oSUYCcDA8tlfnD9Ivs6hMIM6/Gz4Ur/ew7ZW21mZES0UeBdUCziHSKyD1KqX7gc8CzwE7gcaWU4YGnOhyUPIMXhyQ+sR9dWkdXd59huWkjf6QiwvXTylmz5yQ9/fYMTDeDWKMWC7K9fOmW6Ww81MXPNljTDZ1siCLT6+bG6eU8/85x+gaM5Sus7BgOEysvMBCwPhwEwbzA5o6uwffJbk9gfo0fgI0HrU0OG6kOulspVamU8iqlqpRSD4WOP6OUmqqUalRKfdWMTWpPIHlSiV8uqi9iWkUej7xx0JCmkNE67huml3Gpd+CqqpCxTLwL4gfmT2ZeTSHfeuFdwx5WzHVD/yZzYbplViXnLveNOtA9obUtvh66XMLCuqJhHbx2JIYhmBe40hcYnHKmsNcTaCjJIT/Tw6YOa5PDaU8MJ4L2BJInkWaxaESEjy6tY+fR84aqEpRBga9lU0rI9LocFRKKJ6ssIvzVTc0cPXeFn75lvlx2oiWikSxvKiE3w8NvtxkrxbW6Xj/M4oZiDp3pHswLKKWSkiVJlbba4J14OC9gZ3UQBA3gvBr/2PUE7ER7AskzdCef3Af29+ZOJsfn5ucGwhdGBb4yvW6WTynhhZ0nbJ2wZIRY4aAwS6eUsLSxmG+/stf05p9kcwIQfH9XTS/j2XeOGQoJ2REOgqvzAnbkBADK8jOpKcoezAsMjZe0fOlB5tUUsufEBS5cMVffKxJHGAHtCSRPKp4AQJbPzS2zKnlm2zEu96YWvjBDU2bV9HIOd11mt01zkY0SGOWC+IWbmjl1sZf/96a53kCqZYu3zKqkq7sv7gCVRLBSQC6SaRXD8wJWSklH01bnHxz3mIrBNcr8Gj9KwZYO6659jjAC2hNIAQMf2A/Mr+JiTz/PvZNauCDVjuFIVk0Lqoq8uPOEsReyi1HyIK21fhY3FPHw6/sNJ2SHLZvi73llUykZHpeh99dKAblIXC6hrdZPeyhEaXXHcCRttUWcutjLgdPdCXfhm8mc6kIANh2yLi/gCCOgSR4jjS2L6ouYXJjFLzamViUUCBjXlCnLz6SlMp/X3nVGv4Bi9Avip1Y2cvTcFZ7aYp5IXqqiZlk+N8umlPDiruMph9ysFJCLpq2uiH2nLnH6Yo8tfQJhFtQF8wLrD5xJWKfJTAqyvDSV5bJxohsBHQ5KnugZw8ngcgkfmD+Zte+e5HgKHcRm/ZGumFrChoNnbZdnToVE5u1e21zK1PJcHlyzz7RcR6phP4Drp5XRceayMdVTmy/G7QfP2uoJNJbmUpjtpf3AmbR4AhAMCW3q6LIsP+YII6DDQckzlBZO7RN7x9xJBBQ8tyP5kJBZbf0rm0rpG1CG4tZ2EQyBjXzSIsInVzSw69gFUzp2wZiy5fXhkNuu5ENCyoCnmQozJxfg87hoP3AmpXkVqRIZihrqzrbXCsyrKaSru4/9FsyJBocYAU3ypFI6GMmUsqCY2+9SMAJm5AQgGEfP9MYfOD6WSNTwvX/OJAqzvaaVixpRtpxUmMX0ynxeSiEvYHe5ZIbHzdyqQtaHLsZ23o231gZDUWE9K5ttAPNDpaobLVIU1UZgnGIkTBBm9cwK3tx3JumRj2aV8GV63SxuKGaNA/ICiXrqmV43d86v4tkdx0yZIWs0Tn3D9DLaD56hqzu537HRm4xUaK3zs/3wObp7+22t0InMC4C91UEAU0pzycvwWJYcdoQR0DmB5Bly11P/wK6eUclAQPF8kk1bAROVxVY0lbLv5KWrBouMNYLlkomd9N2LaugPKH7WblzS2WgX6/XTyggoeHVPcoY2tS4UYyyo89MfUOw6esHWC/HMyQV43TJYnWR3TsDlCg5cKsnNsOb1LXlVk9E5geQxkhgOM3NyPpMLs3g22SEvJlZvrAwNHB/zIaEkpqk1luaypKGYR98+ZFhYLpm5EbGYU1VIcY6PF5IMCQ2Kqdl4RWytCQ5g77dJOyhMptfNjEkF7DoWlI+wOxwE8M8fnM1f3DjVktd2hBEwSiCgeGjtfi46oMrELMwIB4kIq2dW8Nq7p5Kq0DGzemNKWS4V+ZljvlQ02capuxZW03n28jCVytQWTnyeQCxcLuGa5lLWvnsyKYOUjkbuguygxj7YH5KZX+NPW2LYaiaEEVh/4Az/++l3uOFfXk3a7XUqic4YHo1V08voHQiwNgmxMTObiESEFU0lrH33FAMW66obIdk8yI0t5WR53fzaYM/AUE4gdVY0lXC2u29QKC0Z7L4etoXi87aXadYWDn5vtwGymglhBBY1FPPE/1hKQZaXj//wbf5r3YF0b8lyzFI8XFBXRF6Gh5eTKCM0qzoozNIpxZy/0s/Oo9YNZzFKsjo62T4PN80o55ltRw2NoFQGPQEICvYBSSXgAyasmwpDRsB+TyDM+DIBDjECZiSG59f4+eVnl7Jqejl//+sdlig6jiWSnTgVD6/bxYqpJby8OzExt7DGipkuc1hAbCz3CyTSLBbNHXMn0dXdxxoD3qkZv+eyvEymV+azNom8Sxq01ICgjAPYH5KZVJhFRX4moD2BtMn8RscAACAASURBVGBWYjjb5+GBj8znuuZS/vZX23jDoJ76WCZVFdFYXNdcxvHzPQmFC6wQ2aosyKKuOHtsGwEg2fd6RVMp/myvoSlfqcwTiL2XEtoPnklY5dSMnFMqVPmDF2Ofx/4LcTgkNM5sgDOMgJn4PC7+8yPzaSjN5U8f3WTKYPWxjBkf2GubyxAhoZBQqlo2o7GksZi39p8Zs3mBVIaue90ubp5VyUu7TqQ8cMasev0VTSX0DSje2p9YotqMMFQqiAj/+ZF5fH6VNZUyIxEOCWkjMA7IyfDw3T+az8Wefr70y+2WatZf6RuwVAs8Hma666V5GcyuKuSl3aMbgfA7aXbibnFDMReu9Fs6tN0IqYqpvW9GBd29AylP+TLL81pQV0SGx8VrexLbRzptcVtdEc0Vebave/ucSdy9sIYpZbm2r20lE9IIQFAW4Ys3NfPCzuP8ZttRy9b50hPbmPXl5wZrjO1iKDFsztX4+uYyNnd0cTrUOh+PIU/AXCsw1vMCiaiIxmJJQzF5GR6e25HaFDUjarGRZHrdLKwvYu3eBPMT47RcciTK8jP52gdmkeFxp3srpjJhjQDAJ5bXM2NSPl97Zpcl818Bth0OJrPvevBNywSgYhEIFZyY9Td6/bQylIJXdo98kTCjSS0W5fmZNJTksG6sGoEU5yr7PC6um1bGCzuPpxTqGvK8TFBtbSphz/GLHDs3eohUpZQF0YxF0moERKRGRH4lIg+LyH12r+92CX9z63QOd13mobX7LVmjuiib/EwPLhE+8ch6zl22JzRkVEU0mhmT8inJ9Y3aL2Dl9KXFjcWs33+GfhOHspiFkSlb75tRwelLvWw4mLw2jJk5mHCpaCLe1pCAnPF1NeklZSMQunCfEJHtUcdXi8huEdmbwIV9FvBzpdQngHmp7sUISxtLuLGlnG+/vJeTF0YOdaRCQCnqS3L43h+30nGmm7/9lbU5iDBmC3y5XMLSxhLW7j014v6H6sfNWTeSxQ3FXOjpT6mpyWqUgQa5a5pL8bldKcl2m+l5Ta/IpyDLy7oEZK6NSFhrxhZGPIFHgNWRB0TEDTwA3Ay0AHeLSIuIzBKRp6O+yoA3gXtE5CXgdwb2Yoj7b57G5b4Bvv/aPtNfOzwPdUFdEX9+QxNPbTnCU1uty0GEscLMLG8q4eSFnhHn/lrZRLS4IVgjHu9ONRBQ/HxDZ1rkQYx4ArkZHpY0FieUeL9qXROEAsO4XMLC+iLe3J+AEQj9q22A80nZCCil1gDR9WQLgb1KqX1KqV7gMeAOpdQ2pdRtUV8ngI8D/6CUuh64NdY6InKviLSLSPvJk9ZIPjSU5nL7nEn85M2DnElSNnk0VISOzmeuncKcqgL+99PvWF8xFHbXTbwlXx4KF4zUVGRl1UhZXiaNpfHzAjuPneeLP9vCtd942faQkdEGueuag2qpB08nlzcyMk8gFosbijl4upsjXZdHfJ5VBQAa+zE7JzAZ6Ih43Bk6Fo/fAX8mIt8FDsR6glLqQaVUm1KqrbS01LSNRvPZ66ZwuW+Ah03ODURqyrhdwv+6YyanLvbw7y++a+o6sdYFcxN3kwqzaCjNGTkvYPGwkSUj5AWu9AWPnbrYyzee223J+vFQSaiIxuLa5uCUr9ES79GYLWoW9rbeGs0bSFPHsMZ80poYVkptV0rdqZT6tFLqi/GeZ8c8gabyPG6eWcGP3jjAeRPv0gOB4RfEOdWFfLitmh++foC9J+KHVYxilbu+fEoJb+07E1fvxsqcAMDC+mIu9Q6w69jV713YMNQVZ/Pgmn288Z59HeFGwkEAdSU51Jfk8EqSISGzNKLChPMCb743ctOYDgeNH8w2AoeB6ojHVaFjjuDT1zRyoaefn5sw7CNMrLGDf/W+ZjI8Lv71Beu8AbNURKNZPqWEy30DbIwz5cjqMEFb7fApT5H0h26Lv3z7DOqLc/jrX2y1rPQ3mmQF5GJxbXMpb7x3Oqk9m+0JuFzCogTyAlZWgWnsxWwjsB5oEpF6EfEBdwFPGn1Ru4bKzK4qpLXWz4/WHTBNnkDFGLBSnJvBx5bV8cy2o5Y1kQ3WcZvdudtYjNslcfMCVnUMh5lUmMXkwqzBKU+R9IU8gbxML//4ezPpOHOZ771qfrI/FgrjIzWvbS6jpz+QXC9ECnIVo5FIXsCKcKMmPRgpEX0UWAc0i0iniNyjlOoHPgc8C+wEHldK7TC6STvHS35saR0HT3cn7ZbHI6AUrhjv8idXNJDj8/BvFnkDVjVt5Wd6mVNVwGtx8gJ2JAzb6vy0HzxzValq/0DwsdctLJ1Swq2zK/n2K3vpOGP9aMpAAMNXxEX1RWR6XbyShGx3wAQPJJpEurN1OGj8YKQ66G6lVKVSyquUqlJKPRQ6/oxSaqpSqlEp9VUzNmnneMnVMyuoyM/kh68fMOX14g0bKcz28Ynl9fx2+zH2jFBymSpmlg5Gs2xKCdsPn4tZ4WRHmKCtrojj53voPDv8TrU/1CbtCVndv7llOi4RvvGsPUlio+91ptfNssYSXt59MuFeEjM8kGimVeQF8wIjGQFdHTRucIRshJ2egNft4iOLali79xSHThu/gwz3CcTiY0vryPS6TK9IAmvv1BbVFzMQULTH6HC1SkU0kgV1sfMCvRGeAARDRx9dWsdTW4/wrgWGNpJUVERjcW1zKYfOdHMgwc9eIEW5ipEYzAvsi58cTtc8AY35OMII2D1o/s7WKkTg5xs6Rn/yKET2CURTlOPjg/OreGLTYU6NIsyW/LrBf634I51fW4jXLbwV4yJhdt16LKaW5ZGX6WF9VF4gXB3kdQ99rO9d2UC2182/WVySqzDnvV7eFCyDTlRV1OwBPmEWNxRz6Ew3h+PkBZTJCWlN+nCEEbDTE4DgHeSKplJ+vqHTcII4ECMxHMknltfT2x/gJ28eNLRONFa669k+D7OrCmOGC+zICbhcQmutn/YoTyCcE/C4h9YuyvHx0aV1/GbbUUvCbmFiFQCkQl1xNpMKMpMwAsb6E+KxKNQvsD7OfAEtIDd+cIQRsNsTAPhQWxVHzl0xXGseGMETAGgszWXVtDJ+vO4gPf3mlTNaXaWzuKGIbYfPcSlKosGuMMGCuiLePXGRsxEd3n2Bqz0BCCbhs7xuSyuFYpUCp4KIsGxKCev2nU7oBiQ4z9n8d3taRT55GZ6YpbgQISDniCuIZiT0rzAON7aUU5jt5XGDPQMj5QTC/PGSWk5f6uX5d1LTlI+3LliTGIb4eQG76sfD/QKRypuDnkCU5fPn+LiztYqnthzhxAVrJskZbRaLZHlTCV3dfQkN0AkEzC8RhWB3+7xaf1xlUysLDzT24ggjYHc4CCDD4+bWWZW88M7xhOeuxiIRd31FUymTC7N47G3jOYjIdQHLbslba/14XMJbUSGhwY5hiz9Zc6qDeYn1B4fuVMN9Ah731Yt/fFk9fYEAP1lnbtgtTPC0zXmzlzQGSzRHk+0G6zwBCBra3ccvxJQ/1yWi4wdHGIF0hIMAbps9ict9A7y8K3XhukRixW6X8KG2atMqkiKx6o80J8PDrKqCq/ICAZvuEDO9bmZNLmBDRHI43DHsdV+9dn1JDqumlfOTtw5Z1EVs3h15WV4mzeV5CYUiAxblBCDYj6EUMbvDdWJ4/OAII5AuFtYXUZqXwdNbj6T8GvGaxaL50IIqXAL/3X4o5bUisSM2v7ihmK2d54Z5SnbeIbbVFbG189zgRT1cHeSJ84bfs7yeM5d6edoCKW8zZCMiWTqlmLf3nxnVYKU60SwR5lYX4nHJVQn44Lo6MTxe0EZgBNwu4ZaZFby068RVCdBECSYMR/9TqSzI4pqppTyx8TABEyQrzJ4xHItF9UX0B9SwuHH44mCHpkxbrZ/egcDgCM++gfieAAST2Q0lOTz2tjmGNpJ4TYGpsnxKCT39ATaOMm1MJfj5SoVsn4cZk/JjSnTocND4wRFGIB05gTC3zp5ET3+AF5No5Y8kmdLB35s3maPnrsStyEiGIWExwy8Vl7a6Ityu4f0CAZsSwxDMS8BQ01h/IIDbJXEviiLChxdU037wrOkKrmYmhgEWNQQ1ml4fJSQUzAmYt240bXVFbO7ouko1VgvIjR8cYQTSlROA4N1mWV4Gv9ueWghhtBLRSG6YXk6W182TW1IPP4WxSkU0ktwMDzMnD88L2NExHKY4N4OG0pzBvED/gLqqMiiaD7ZW4XWLqUl4MD8clJvhYdbkgpgNeZEk6mmmSlutn57+ADuODL8B0wJy4wdHGIF04nIJq6aXsWbPqbga+iMxWrNYJDkZHm5oKeeZbUcHK11SxSoV0WgW1xexpbNrMHZtR8dwJPNr/Gzq6EIpRd+AuqpHIJqS3AxubCnnFxs7U/p9xsOKsMyihuB7e7k3fl4g6GmauuwwWkMSHdEhIasECjX2o41AAqyaVs7Fnv7Rpy3FINkmojvmTOJsd9+IIxwTwYZZ9kAwJNM3oNjaGbxTtHvs4PwaP2cu9XLwdDf9gcCwbuF4/EFrNWe7+1izx7xxpVa83Yvri+kbUGyKM7sBwuE3697rsrxM6oqzrwpRDt1kaCvgdLQRSIBlU0rI8Lh4cWcqg8CTi5uunFpKQZaXp0wICYH1d2rhuHx7qF7fbmGx+bWFQLCMsW9Axa0MimR5Uwn+bK8pYbcwZslGRNJa58cl8FYc6YbQypZ7Xa21RWw4eHaYsqkWkBs/OMIIpDMxDJDlc7N8Sgkv7DyesMRvmGRyAgA+j4tV08t4cdcJQyGhcIWR1Ym76Li83QnDprI8cjM8bDrURf9AIG5lUCRet4ubZ1XyvMFGwEjMUhGNJD/TS8uk/BE90EDAekO/oM7P6Uu97D91afCY7hMYPzjCCKQzMRxm1fRyOs9eZs/xi0n9v1RKB29qqeDc5b644l2JMFjCl/IrJE5brZ8Nh84SCCjbOobDuF3CnOoCNh46S39AJRQOArh9TrAR0CypDrNURKNZVF/MpkNdcXWlrJgnEE1bOC8QWQqsBeTGDY4wAmOBVdPLAHhhZ3IXjUS0g6JZOTUYfnrOwAXKzju1ttoiurr72Hfqou05AYB51X52HbvAhSt9eBO0PgvriqjIzzQt7GZV09ai+iJ6+gNs6YjtBVsxWSyaxtJc/NneYU1jgx6fvoI4Hv0rTJDy/ExmTS7gxSSNwEjzBOKR7fOwcmopz+04lnT4aXBdG+/UIitIAmmIFc+vLWQgoNh4qCthT8DlEm6dXcmaPae4mGIjYCQKa0o1F9YHJZ3fjhMSsmqeQCQiYenuIU/ALnkQjfVoI5AEq6aXsamjizMR8sWjkUyJaCQ3tZRz5NwVdiSgJBkLO0v4GkpyKMrxhcIF9nUMh5lXHTRCZy71JpQYDnNTSzm9AwFTqoSsmPAFwTGk0yry4iaHrchFxKK1toh9py4NSncP3ppoG+B4tBFIgpVTS1Eq8alPkHxiOMyq6eW4hJRDQnbOgBUR5tcEh7zY2TEcxp/jo74kBwCvJ/GPdGutH3+215y8gLJStjtYnROrUMBKFdFI5tUEq7A2d3YF19Udw+OGtBoBEWkRkcdF5Dsicmc695IIc6oKyc/0JHXnGNR7T/4PpSjHx9zqQl7dnaJcBfY28rTV+TlwupuTF4JjMu2+NoQvUt4kLK7H7eL6aeW8ZLASC8LhIEMvEZdFDcV09w4MaiRFYtYwm9GYXVWAS2DTobAR0Inh8ULKRkBEHhaREyKyPer4ahHZLSJ7ReS+UV7mZuA/lFKfAf4k1b3YhdslLG8q4bV3TyUcqzdSP35tcxlbD59Laf6w2TIGo9EWpeNjtxGYXxNcP9GcQJgbW8qDlVgG9ZqsfL/DeYF4M53tuBvP9nmYVpE/2LimBeTGD0Y8gUeA1ZEHRMQNPEDw4t4C3B26258lIk9HfZUBPwbuEpFvAMUG9mIbK5pKOXb+CntPJFYqmmo4CODa5mD4KZWYtVWJynjMnFyAz+0avJjaHSYY9ARGkY2IZuXUEnwel+GQkJWeV0luBo2lOTElna2cJxDNvJpCNnd0EQgoHQ4aR6RsBJRSa4DoT+VCYK9Sap9Sqhd4DLhDKbVNKXVb1NeJ0NdngfuAmIF2EblXRNpFpP3kSfPa/FNlRVMJAK8meGEOqGAlSirMnFRASa6PV3anYARs9gQyvW5mVRWw/XAwkW33xaG5PI9sn3tUAblosn0elk8p4fl3km8EjESZLCUdTWtEL8awdbHvbnxudSEXrvQPLwW2Z2mNhZidE5gMRMozdoaOxURE6kTkQeC/gG/Eeo5S6kGlVJtSqq20tNTUzaZClT+bhtIcXktQ20eR+p2ayyWsnFrKmndPJjR0PJJUq5KMEG4qAvvDBB63iz9aXMvypuQ/Ize2BBsBdx1LXV7a6nr9oV6MS8OOWzlPIJp5oZDbxkNdQ9pU2go4nrQmhpVSB5RS9yql/lAptTbe89ItGxHNyqZS3tp/OqExhak0i0VybXMZXd19bO7oSur/KWx2BQheqMLYpSIayZdumc49y+uT/n/hRsCXU0zCD2KlJxAysBsORgm5WawiGklDSQ75mUGJDjuGFmnswWwjcBiojnhcFTo2rlg5tYQrfYGYE5eiSaVZbNhaTSW4hOSrhOy3AYNicuAsTZmyvExaKvN5NYWwG9hTKdNQkhPq2h3+mQvmBOx5r10uYW6NP5gc1gJy4wazjcB6oElE6kXEB9wFPGn0RceCdlAki+qL8bqF1/aOftEwGpYpzA6Wir6SZHLY7hJRCJa1hnHaxeGa5lI2HDybUvewHY154a7dDQev1vW38/c8r7qQPccvcCH0PjnJ2GtiY6RE9FFgHdAsIp0ico9Sqh/4HPAssBN4XCm1w+gmx1o4KCfDw5yqQt4cZeoTGKsOCnPN1DK2HT432K2ZCMrGO8RIwobAaReHlU2l9AcUbyTRCBgmHB63OjQS7tqN7Fg3Gm5Mlnk1hQQUbAmFJx32a9bEwEh10N1KqUqllFcpVaWUeih0/Bml1FSlVKNS6qtmbHKseQIAixuK2X74HBeu9MV9jlLKFG2XZVOKUQrW7Ut8qE3AxlhxJOHqqYtXzJFotovWWj85PnfCVV+R2FUpEw63DfcGrJ8nEMnc6qH5DZCez5jGXBwhGzHWPAGAJY3FDATUiE1GZtVSz6kuJMfnTkquwg5hsVj80+/P4q9XT2NJoyPaPgbxeVwsaSzh1T0nky4VtUunaXZVAV63DA7wAes0i+JRmO2joTQnQtVUWwGn4wgjMBY9gdZaPz63a8SQ0KC2vsG/E6/bxeKGYt54L3FPwEhpqhFyMjx85tpG3A68RbymuZTOs5eHDU9JBLtGLWZ63cycXMDGSF1/i/sTYjGv2s/lUGWcDgc5H0cYgbHoCWR63cytKWTdCBfmQTE1Ey6IS6eUsP/UJQ53XU7o+cqqKSfjmGtCPQbJhoTsmucM0FrjZ0vnucEhM3bME4gm3J0NukR0POAIIzAWPQGAJQ3F7DhyjnOXY+cFhgasGF9r+ZRgrD2ZkJD+80yOmuJs6ktyUsoLgD13xW11fnr7A4Od2cEqsPRIdID+jI0HHGEExiqLG4oJKOKOgTRTX2VqeS4luRkJG4GAUqZ4IBON5VNKeHv/maRURYfCfta/362hhrxw05hd8wQiaS7PI8vrBnQ4aDzgCCMwFsNBELwj8nlccat2zMoJQPBub9mUYl7fezqhxKXd2kHjhaWNQdnmrZ2Jd2grGxunSvMyqC3OHqwQsktFNBKP28XsqqBXrsNBzscRRmCshoMyvW5aa/xx8wJm3yEuayzh1MWehIbd260iOl5Y3BCsahop1xON3bLKrTXBpjGllK0qopGEdYQ0zscRRmAss6SxmJ3HztPVfXUj1+C8XZOuDkunhC9Qo4eEtCeQGv4cH9Mr85OrxLJ53m5rnZ9TF3s5eLo7LZ4ABPtB3C4Z1iWucSbaCBhkcUOwkSvWDFhlYjgIggqmkwuz4s6bHbY2Ol6bKksbi2k/eDYhgUBIgydQG1bzPBv0NtPwe142pYSNf3cjkwqz7F9cYyqOMAJjNScAwQ7KDI+LN2PkBayYt7uooYi3958ZNS9gp8TweGNpYzG9/YHBUYqjoUI5ZLve76ayPHJ8bjZ3dIVmDNuy7FUUZHnTs7DGVBxhBMZqTgCCnaZzqwuvEvYCcxPDYRbVF3H6Ui/vnRw5L6DDQamzsL4It0sSCrtBRLOYlZuKwO0S5lQXBiWd06QRpRk/OMIIjHUW1BWx48h5LkUpUA71CZjoCdQH8wKjidfZrS45nsjL9DJzckHCeQG7ZCMimVdTyM6j5+nuHcCl/4o1BtAfHxNYUF/EQEBdNfjFijmstcXZlOdnjJoXCMpGaCuQKksbi9nc0UV37+hCeOkYsjWv2k9/QLHn+AX9e9YYQhsBE5hfU4hLuEpMzoo7RBFhUX0xb+0buV9AewLGWNpYTH9AsT7BwUFgb+fu3FDXbt+A/c1imvGFI4zAWE4MQzB8MK0iP+bUJzA/cbewvogTF3o4cLo77nPSMWN4PNFWW4TXLbyRQF5gqADA4k1FUJKbQU1RNuC82Q2asYUjjMBYTgyHWVDnZ+Ohs/RHyA1YkRMAWNwQlA54e3/8mLVi5Oohzchk+dzMq/bzZgJ5gcH3Ok0aPlodRGMERxgBJ9BWV0R37wA7j14YPGZFTgCgsTSXklwfb42UHNbhIMMsaihie4yE/1Wkad7uvNCAF/1r1hhBGwGTaKsLNvC8fSBy4Ic14SARYWF90YjJYd0sZpwFdcGEf3iKVjzsbhYLE5Zu0GE/jRG0ETCJyoIsqvxZtB8YPvUJrPkjXVhXxOGuy3SciZ0X0PXjxplf6w8m/EerxBr0BOx9v6dX5uPzuLSx1xhCGwETWVBXxPoDZwerRcycJxDNopDQ2dtxLlDpmjE8nsjN8DBjUsEw7y4WVnl8o+HzuHj/7EnMnDx2c2WasY9tRkBEGkTkIRH5ecSxHBH5kYh8X0T+0K69WEVbnZ9TF3s4GKraUSariEbSXJ5HXqaH9hidypCeYSPjkQV1RWw61EVvf/z5AukKBwH8y4fm8Oc3TLV/Yc24ISEjICIPi8gJEdkedXy1iOwWkb0ict9Ir6GU2qeUuifq8AeAnyulPgncntTOxyAL6oJVO+F+ASvDQS6XML/GPzhcJBqVJonh8cbCej89/QG2HY5fnmy3iqhGYyaJegKPAKsjD4iIG3gAuBloAe4WkRYRmSUiT0d9lcV53SqgI/R9YpKNY5gppbkUZHkH+wWsDhO01vrZc/xizPGWCnTZiAm01YXLcUdIwqejZVijMYmEjIBSag0Q/VewENgbusPvBR4D7lBKbVNK3Rb1dSLOS3cSNARx9yIi94pIu4i0nzyZ2uxXu3C5hLZaP+tDd+cBi9Ul2yIkha9CC8iZQkluBg2lOVd1g8dCv98aJ2IkJzCZobt4CF7QJ8d7sogUi8h3gXkicn/o8BPAB0XkO8BTsf6fUupBpVSbUqqttLTUwHbtoa2uiH0nL3HqYo/lnsCc6kLcLmFDDGmDgFK6dNAkFtYV0X7gDIFA7AY8q5oCNRo78Ni1kFLqNPDpqGOXgI+P9n9F5P3A+6dMmWLR7swjPPBj06EuKvIzAevquHMyPEyvzIspY621g8xjYX0Rj63vYPfxC0yvzL/q5yoNshEajVkY8QQOA9URj6tCxyY0s6sK8LhkaOoTWCr121ZbxOaOLvoGhlevaBVR84hO+EeTzuogjcYoRi5P64EmEakXER9wF/CkOdsajhO0g8Jket20TMpnU4QRsDJM0Frr53LfADuPnh92XHsC5lHlz6KyIDNuclhXB2mcTKIloo8C64BmEekUkXuUUv3A54BngZ3A40qpHVZscqyriEYzv8bPlo5z9A1Y1ycQJhx+ig4Jafk48xCRUCNg7LGe2hPQOJlEq4PuVkpVKqW8SqkqpdRDoePPKKWmKqUalVJftWqTTvIEIKjuGHl3bmWseFJhFpMKMq9qGlM6MWwqrbV+jp/v4ci5K1f9bJRxzxrNmMYRshFO9ARg6O7c6otxa10RGyLkKkCHg8wm7HFtjJmEt97j02iswhFGwGmeQJU/i5LcjEEjYPW1obWmkGPnrwy7S9UqouYyrSKPLK87diVW6F/9fmuciCOMgNM8ARFhfk0hh7suBx9bnDAMd7VGKphqFVFz8bhdzKkuYFOMxrx0qYhqNGbgCCPgNE8AgjLEYayuH59WkUe2b/hdqvYEzGd+jZ8dR85zpW+4wkl4sph+vzVOxBFGwImE8wIQlJOwEo/bxdzqwmFGIKB0B6vZtNb66Q8otnYO90iHPAGNxnk4wgg4LRwEMGtysGkM7Okkbav1s/Po0ChErSJqPvNqYpfjatkIjZNxhBFwYjgoy+celBiw4+Iwr9ZPQDHsLlVfk8ylKMdHQ0nOVYJ9g56Afr81DsQRRsCpzK8JDgK3o3RwblVwrU0dwQuU0iqiljCvxs/Gg2djNo3p91vjRLQRsJBw1U6m1/q32Z/jo74kh82HuoCQdpC+NTWd+bWFnL7Uy6GI2c5DnoB+vzXOwzYVUSM4SUU0kltmVZKb4aG5PM+W9eZWF7J27ymUUgQCWtXSCiJlOmqLc4CI6qC07UqjSR1HeAJOzAkAuF3CddPKbLtDnFdTyMkLQWkDrSJqDU1leeRmeIblBQbHiDrir0mjGY7+2I4j5laH8gKHzgZDFNoGmI7bJcyrKWTDwa7BY1pFVONktBEYR0yryCfD42LToS60DbCOeTV+dh87z8VwOW74B/oN1zgQbQTGET6Pi1mTC9jc0RWcMawvSpbQGirH3dIRSsLrZjGNg3GEEXBis1i6mFtdyLbD5+gZCGhVS4uYW12ISGTTmG4W0zgXRxgBpyaG08G8Gj+9/QH2HLugPQGLKMjy0liaG/S4iEgM6/db40AcYQQ0iTM31KB2uW9AoD4uhQAABv5JREFUJyotZG51IVs6ulBKaRVRjaPRRmCcMakgk7K8DEDnBKxkbnWwaazz7OWh6iD9fmsciDYC4wwRGSwV1VjHYDluR9fQUJn0bUejSRltBMYhYbVLnRi2juaKPDI8LjYf6hqaMazfbo0Dsc0IiEiDiDwkIj8f6ZjGOPNCeQFtA6zD6w6W427p7NLNYhpHk5AREJGHReSEiGyPOr5aRHaLyF4RuW+k11BK7VNK3TPaMY1xZk0uwCX6xtRq5lYXsv3wOXoHAoCuDtI4k0Q9gUeA1ZEHRMQNPADcDLQAd4tIi4jMEpGno77KTN21ZkRyMjzMrS7En+1L91bGNXOqC+npD7Dr2AVA9wlonElCKqJKqTUiUhd1eCGwVym1D0BEHgPuUEp9DbjNrA2KyL3AvQA1NTVmvey454cfW4jbrS9KVhKp1QQ6/KZxJkZyApOBjojHnaFjMRGRYhH5LjBPRO6PdywapdSDSqk2pVRbaWmpge1OLAqyveRmOEIp3LFU+bMoyfWxKTTDQdsAjROx7SqhlDoNfHq0Y7Fw6jwBzfhGRJhTVciLu06EHqd5QxpNChjxBA4D1RGPq0LHNJoJQ2RPhs4JaJyIESOwHmgSkXoR8QF3AU+as63haO0gzVglLNMBOhykcSaJlog+CqwDmkWkU0TuUUr1A58DngV2Ao8rpXZYsUmtIqoZq8yu0p6AxtkkWh10d5zjzwDPmLqj2Os8BTzV1tb2SavX0miSoSDLS0NpDvtOXtKegMaROEI2QnsCmrFMOC+gHQGNE3GEEdA5Ac1YZl7ICGitJo0TcUQhuS4R1Yxlbps9iY6zl5lanpfurWg0SSNqUAJx7NPW1qba29vTvQ2NRqNxFCKyQSnVFutnjggHaTQajcYaHGEEdGJYo9ForMERRkAnhjUajcYaHGEENBqNRmMN2ghoNBrNBMYRRkDnBDQajcYaHGEEdE5Ao9ForMERRkCj0Wg01uCoZjEROQkcNPASJcApk7bjFPQ5Twz0OU8MUj3nWqVUzNGMjjICRhGR9nhdc+MVfc4TA33OEwMrzlmHgzQajWYCo42ARqPRTGAmmhF4MN0bSAP6nCcG+pwnBqaf84TKCWg0Go1mOBPNE9BoNBpNBNoIaDQazQRmQhgBEVktIrtFZK+I3Jfu/ZiFiDwsIidEZHvEsSIReV5E3g396w8dFxH599B7sFVE5qdv56kjItUi8rKIvCMiO0Tk86Hj4/a8RSRTRN4WkS2hc/5K6Hi9iLwVOrf/FhFf6HhG6PHe0M/r0rl/I4iIW0Q2icjTocfj+pxF5ICIbBORzSLSHjpm6Wd73BsBEXEDDwA3Ay3A3SLSkt5dmcYjwOqoY/cBLyqlmoAXQ48heP5Noa97ge/YtEez6Qe+oJRqARYDnw39PsfzefcA1yul5gBzgdUishj4OvCvSqkpwFngntDz7wHOho7/a+h5TuXzwM6IxxPhnK9TSs2N6Aew9rOtlBrXX8AS4NmIx/cD96d7XyaeXx2wPeLxbqAy9H0lsDv0/feAu2M9z8lfwK+BGyfKeQPZwEZgEcHOUU/o+ODnHHgWWBL63hN6nqR77ymca1Xoonc98DQgE+CcDwAlUccs/WyPe08AmAx0RDzuDB0br5QrpY6Gvj8GlIe+H3fvQ8jlnwe8xTg/71BYZDNwAngeeA/oUkr1h54SeV6D5xz6+Tmg2N4dm8K3gP8JBEKPixn/56yA50Rkg4jcGzpm6Wfbk+pONWMfpZQSkXFZAywiucAvgD9XSp0XkcGfjcfzVkoNAHNFpBD4JTAtzVuyFBG5DTihlNogItemez82slwpdVhEyoDnRWRX5A+t+GxPBE/gMFAd8bgqdGy8clxEKgFC/54IHR8374OIeAkagP+nlHoidHjcnzeAUqoLeJlgKKRQRMI3cpHnNXjOoZ8XAKdt3qpRlgG3i8gB4DGCIaF/Y3yfM0qpw6F/TxA09gux+LM9EYzAeqApVFXgA+4CnkzznqzkSeCjoe8/SjBmHj7+J6GKgsXAuQgX0zFI8Jb/IWCnUuqbET8at+ctIqUhDwARySKYA9lJ0BjcGXpa9DmH34s7gZdUKGjsFJRS9yulqpRSdQT/Zl9SSv0h4/icRSRHRPLC3wM3Adux+rOd7kSITcmWW4A9BOOof5Pu/Zh4Xo8CR4E+gvHAewjGQV8E3gVeAIpCzxWCVVLvAduAtnTvP8VzXk4wbroV2Bz6umU8nzcwG9gUOuftwN+HjjcAbwN7gZ8BGaHjmaHHe0M/b0j3ORg8/2uBp8f7OYfObUvoa0f4WmX1Z1vLRmg0Gs0EZiKEgzQajUYTB20ENBqNZgKjjYBGo9FMYLQR0Gg0mgmMNgIajUYzgdFGQKPRaCYw2ghoNBrNBOb/BxhRCruZizHFAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "KLdw1eSvVXE3",
-        "colab_type": "code",
-        "outputId": "cc8fc33a-ccb2-47a8-8e3b-cf4fdc4d9eb1",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 595
-        }
-      },
-      "source": [
-        "figure(figsize=(10,10))\n",
-        "imshow(np.log10(cov+1e-11),cmap='gist_stern');"
-      ],
-      "execution_count": 19,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAJCCAYAAADKjmNEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3df5Ddd33f+9dnd7WWZQH2yhhjC8dxJMo4NBDXVzaE4RIorVW4MZ2huYBU3AypJ7mNnSbpBNLJvUDm/mhyZ0Jq5zYdJnDjxGoJQ5tCaFSGC3ScSYkUQRJ+mAZtKD9ssIW9/iVkeb06n/vHnnU/dR0sy2f3u+fjx2PmOzrnu0fW++vv2d3nfr/fc7bUWgMAwKqZoQcAANhMxBEAQEMcAQA0xBEAQEMcAQA0xBEAQGNd4qiUck0p5S9KKYullHesx78BALAeyqTf56iUMpvky0lem+SOJH+S5M211tsn+g8BAKyD9ThytCfJYq31K7XW5SQfSHLtOvw7AAATN7cO/82Lk3yjuX9Hkqu+218opXibbgDYpGaTnBp6iPVxT631uY9fOdgF2aWU60spR0opR4aaAQB4cqeSLJQuX8P1tSdauR5Hju5M8oLm/s7xuv9GrfW9Sd6bOHIEAJvdUh0NPcKGWY8M/JMku0sp31tKmU/ypiQfWYd/BwBg4iZ+5KjWulJK+akkH8vqacr311q/OOl/BwBgPUz8pfxnNITTagDAxvtMrfXKx6/s8uoqAIAzJY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABpPGkellPeXUo6VUr7QrFsopXy8lHJ0/Od54/WllHJTKWWxlPK5UsoV6zk8AMCknc6Ro99Kcs3j1r0jySdqrbuTfGJ8P0n2Jtk9Xq5P8huTGRMAYGM8aRzVWm9LsvS41dcmuWV8+5Ykb2jW/3Zd9cdJzi2lPH9SwwIAG2+hPLOuwjnTrX1erfVb49t3JXne+PbFSb7RPO6O8br/Tinl+lLKkVLKkTOcAYAptGtmbugR1sW+Ldu6jIh9W7bl1rMXhh5jQz3tvVhrrUnqGfy999Zar6y1Xvl0ZwBgeiyOVroMpAOPnshVs/PdBdKBR0/kXY88mEPnXDD0KBvmTPfg3Wuny8Z/HhuvvzPJC5rH7RyvA4DH9BpIB1dOZtfMXHfbdvjUcvaeuOcZcwTpTOPoI0muG9++LsmHm/VvHb9q7eokDzSn3wDgMYujle6OsiSrIZH0d/pwqY6y/+Gl3LT13KFHWXdl9azYd3lAKf86yauSnJ/k7iTvTPLvknwwySVJvpbkR2utS6WUkuTXs/rqthNJfqzW+qTXFJVSnvJpOQD6sFBmslRHQ48xcWvh1+O23TC/PTcvHx96jEn4zBNd3vOkcbQRxBEAveox/hbKTK6anc/BlZNDj/J0PWEc9Xc8EwA2kaU66u704VId5dCp5e5OHa7pa28BwCbU25GjZHWbegy/RBwBAGdoLfp6C6S+tgYA2FA9HhUTRwDA09JbIIkjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOILGQvEpAett79zWoUdYF4fOuSC7ZuaGHmPijm6/MJ9+/hVDj7GhfCeAxlIdCSRYZ4dOLWfP7PzQY0zcvoeXcuP89u62be+Je3L+Q9/M7Re8eOhRNozvAvA4S3U09AjQtaU6yuJopbujLIujldz66IlcNTvfVSAtjlay98Q9eeg7x3LfeZcNPc6GEEcAbLilOurySO3hU8s5dGo5O8pMV/G3Fkj3PHoih865YOhx1l1fz0oApsbaUdoeA+noaCW7Z+a6CqSlOsru43dloczknWc9e+hx1lVfz0gApkqvp7EXRys5OlrJQpnpLv52H78r+7ds6/bC+kQcATCwHk+vJauB1OO1VclqIN0wv73LbUvEEQCbQK+BtFRHOdzpq/P+zol7cuP89i73W39bBMBU6vUUW7J6HVKPR1luPHl/9m3Z1l0g9bU1ALBJ9XqK7ebl47lqdr6rbRNHALBBFscXaffm4MrJJOkmkPrbQwCwifV6fdXiaKWbbZv+LQCAKdPr9VW9vHfVdE8PAGwqPbz7+fRODgBsWtN8dEwcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0njSOSikvKKV8qpRyeynli6WUnx6vXyilfLyUcnT853nj9aWUclMpZbGU8rlSyhXrvREAAJNyOkeOVpL8XK318iRXJ/lHpZTLk7wjySdqrbuTfGJ8P0n2Jtk9Xq5P8hsTnxoAYJ08aRzVWr9Va/3s+PZDSb6U5OIk1ya5ZfywW5K8YXz72iS/XVf9cZJzSynPn/jkAADr4Cldc1RKuTTJDyY5lOR5tdZvjT90V5LnjW9fnOQbzV+7Y7zu8f+t60spR0opR57izAAA6+a046iUsj3Jv0nyj2utD7Yfq7XWJPWp/MO11vfWWq+stV75VP4eAMB6Oq04KqVsyWoYHai1/tvx6rvXTpeN/zw2Xn9nkhc0f33neB0AwKZ3Oq9WK0nel+RLtdZfbT70kSTXjW9fl+TDzfq3jl+1dnWSB5rTbwAAm1pZPSP2XR5QyiuS/GGSzycZjVf/06xed/TBJJck+VqSH621Lo1j6teTXJPkRJIfq7V+1+uKSilP6ZQcAMAEfOaJLu950jjaCOIIABjAE8aRd8gGAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCAGiIIwCAhjgCYEMtlD6/9eyZnR96hHWxZ3Y+N8xvH3qMDdXnMxSATWupjroMpMOnlrNrZm7oMSbu8KnlHFw5+YwKpP6enQBsekt1NPQI62JxtJKFMtNd/C2OVnLg0RPZt2Xb0KNsiL72HgAMrNfwW6qjHFw52e3pw5Y4AoAJ6zmQFkcrXZ4+bIkjAOC0LdVRt9eNrel3ywCAdbF2ZKzXQOpzqwCAddXrqcNEHAEAZ6jX02v9bREAsGF6PIIkjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGk8aR6WUraWUw6WUPy+lfLGU8u7x+u8tpRwqpSyWUn63lDI/Xn/W+P7i+OOXru8mAABMzukcOXokyatrrS9J8tIk15RSrk7yy0neU2vdleS+JG8bP/5tSe4br3/P+HEAAFPhSeOorjo+vrtlvNQkr07yofH6W5K8YXz72vH9jD/+mlJKmdjEAADr6LSuOSqlzJZS/izJsSQfT/KXSe6vta6MH3JHkovHty9O8o0kGX/8gSQ7Jjk0ANNrofR5ueveua1dbtu+Ldty6JwLhh5jQ53WXqy1nqq1vjTJziR7krzo6f7DpZTrSylHSilHnu5/C4Dp0mNE3FtH2TUz1922LdVRkuTWsxcGnmTjPKU9WGu9P8mnkrwsybmllLnxh3YmuXN8+84kL0iS8cefk+TeJ/hvvbfWemWt9coznB2AKbT2zbY3h08tJ1kNv54C6eDKydxw8v7snpnLDfPbhx5nQ5zOq9WeW0o5d3z77CSvTfKlrEbSG8cPuy7Jh8e3PzK+n/HHP1lrrZMcGoDptlRHXQXEmjaQenL41HL2nrgn+7dsy57Z+aHHWXflybqllPIDWb3AejarMfXBWusvlVIuS/KBJAtJ/jTJ/lrrI6WUrUl+J8kPJllK8qZa61ee5N8QTwDPQAtlpssjSbtmVk+sLI5WnuSR0+cPtp2f/Q8v9bLfPvNEZ7CeNI42gjgCeObqNZDWTq/1GEi3nr2Q/Q8vDT3GJDxhHPV13A+AqdNjGCWr27U4WnnsKFJP9j+8lHee9eyhx1g34ggA1tHiaKW7a5CS5N2PPJh9W7YNPca66G9vAcAm0+sF6AcePdHlBdr97SkA2IR6DaTDp5a7e3+nfrYEADa5Xq+v6u2ic3EEADxtPYWfOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAJgQ+2ZnR96hHVxw/z2LJT+vq3unduam7aeO/QYG6q/vciG2DUzN/QI62Lv3NYuv7j1rNf9tVBmuty2PbPz+YWL93S5bd+4/O/l6PYLhx5j4v7nnS/LR1/5i9k7t3XoUTZOrXXwJUm1TN+ya2Zu8BnWY9kzO18Xyszgc1hOf+l1fy2UmS63baHM1I++4OWDz7Eey89d/sZ633mXDT7HpJejz7287t178+BzrMNy5Am7ZOgwEkfTvfQaSLtm5rr8pmSZzqXX5+JtF105+AzrsRy49FX1q+e/aPA5Jr0cOueCes01vzb4HBNenjCOyjhOBlVKGX4IzthCmclSHQ09xsStHfbvcduYPr1+nt1+wYvzim/f3t223X7Bi5Mklx/7wsCTTNYN89vz+Zf/k/zH//iuoUeZlM/UWq98/Mr+Tvqy4ZbqqMvrB9a+WPe4bUyfXj/PXvHt2/OX517a3XWMr/j27fm+Rx58LJJ6cfPy8Vz8R7+SH77yJ4YeZV3195nGIHr7qW/NUh11+02J6dPj59lSHeV/eODrObjt/K5exbZUR/n+h76Zh75zLHfueOHQ40zUgUdP5O9+4QP5pb/2I91F7Rpf8eE0CCRYP4ujlex7eCn7t2zrKpDWtutTJ+7JI8+5ZOhxJurGk/fnzXcezq9fdGVX+2yNa44A2BT2zM7nqtn5HDq1nMOnloceZ2IWykxu2npuds/M5arvHBt6nIm691kX5eT89vz4A1/PwZWTQ49zJlxzBMDmdfjUcg6dWs7umbmuTtcs1VFuPHl/jo5W8s6znj30OBO146FvZuvy8dx69kJX74MkjgDYNHoOpP0PL2X3zFxXEZGsBtJSHeWG+e3dnGITRwBsKoujlRwdrWT3zFx31/rtf3gp+7Zs6yr8kmT38btWA7CTbevrWQdAFxZHKzl0ajlXdXIkorUWSD2G39HRSm7s4HfMTff0AHRrqY5ycOVkN6dqWu9+5MEuA+nm5eM5uHIyN8xvH3qUp6WvvQJAdw6fWu4ykG5ePp6rZue7C6SDKydz4NETUx1Ife0RALp0+NRyF9eyPN7BlZNZKDPdBdLiaCUHHj2RfVu2DT3KGelrbwDQrcXRSncRkaxuV9LfrypaqqMcePTEVL46r689AUDXen23+p5/l+PBlZNTd9Svv70AQNd6/B1zSd+/y3HajvpNz6QA8AzQc/xNSyBNx5QAwNSblvATRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAADXEEANAQRwAAjdOOo1LKbCnlT0spHx3f/95SyqFSymIp5XdLKfPj9WeN7y+OP37p+owOADB5T+XI0U8n+VJz/5eTvKfWuivJfUneNl7/tiT3jde/Z/w4AICpcFpxVErZmeR1SX5zfL8keXWSD40fckuSN4xvXzu+n/HHXzN+PADApne6R45+LcnPJxmN7+9Icn+tdWV8/44kF49vX5zkG0ky/vgD48fTkX1btg09wro4dM4F2TUzN/QYPAV7ZueHHmFd7J3b2uW23TC/PW946Y8NPca6eOMbP5A7d7xw6DEm7oqrbszP/MzXhx5jQz1pHJVSXp/kWK31M5P8h0sp15dSjpRSjkzyv8vGOLhyMnvntg49xsTte3gpN85v7/KbUq8On1ruMmgPnVpO0l/8HXj0RN73lx/Lz13+xqFHmbh//qn/Lft/4O/n08+/YuhRJup3v/jBHPz0e/KTP/n5oUfZOLXW77ok+b+yemToq0nuSnIiyYEk9ySZGz/mZUk+Nr79sSQvG9+eGz+uPMm/US3TtyyUmbpndn7wOSa97JmdrzfMb+9y23peFsrM4DOsxzbtmpmru2bmBp9l0st9511WD1z6qsHnmPTy6edfUV93xY/X2y66cvBZJrkc3X5hfdHVP1Pf/ObfH3yWCS9HnqhLnvTIUa31F2qtO2utlyZ5U5JP1lr3JflUkrX0vy7Jh8e3PzK+n/HHP1nHBURfluooS3XU3U/th08t59Cp5ewoM91tW+8WSl/vTrL2OZaku+fiefd9JT90/K7cfsGLu9pvL/vWZ/P2u/4sH3/2zhy58KVDjzMxu4/flV/881vy4W/+Sf7m3/xnQ4+z7p7OM/LtSX62lLKY1WuK3jde/74kO8brfzbJO57eiGxmi6PVy856+uKWrAbS0dFKds/MdfdNqVdtSPRkqY66/Ty79J7/nCT51rN3dvV59spvHsm19381f7T9wq6uQdr/8FL+xz/6lczOzuctL3nr0OOsq7IZDuqUUoYfgqdlocx0+Y1p18xcFspMFkcrXW4f02XXzNxjodST2y94cR76zrHse3ipq+27c8cL86HzLsv+uz+XHQ99c+hxJmahzOTlr/sXedvnbs3bvvGfpv1r42dqrVc+fmVfP4YwmKU66u6n2mT1yNjiaKWrn2qZXr0+Fy8/9oXs3Hpu3nXWs7v6OnLxvV/O/rs/l//3eS/JTVvPHXqciVmqo3z0oz+R3/zrb8nnF3Z1+Zzs51nI4HoNpKU6yuFTy929aojptDha6fLz7OJ7v5y/N789N209t6vt2/HQNzN/x6ezvPNl3X0N+ff//n/JW1/6D/LFZ13U1T5LnFaDp6TX0xpMn15PZR8654IcHa1k/8NLQ48yUXtm5/MPv+eVeft/+WR3++2Kq27MbX/xkWy//6tDj3ImnFaDp6vX0xpMn16P1F71nWM5OlrJrWcvDD3KRB0+tZy3/5dP5n0vePnQo0zcZw/dlP/9wh/MsYVdQ48yMY4cwRno9ad22Cz2zm3Nvi3bujuClCR//rwfyEvu/tzQY0zcf9h5df76w0u5+N4vDz3KU/GER47EEZwhgQTra9fMXPZt2ZZ3P/Lg0KNM3H3nXZbvu/+r3X0NObawK4+WmWkKJKfVYJJ6+6IGm83iaCU3Lx/PDfPbhx5l4r7v/q/m4LbzuztN/6L7vpI7Tt6f4+deOvQoT4s4AmDTWqqjHHj0RHe/y3GpjrLv4aXs27Ktq0BaqqPsPXFP/u+Hl3J0+4VDj3PGnFYDYNNbKDOPvSFrT3bNzGX3zFyOjt9TrRcLZSb7tmzLVbPzm/26MdccATC91l6d19sp7V7fiX+hzDx2xO/AoycGnuav5JojAKbXWjj09hYGa+/Ev3Z0rBdrp0STTN0bYPazFwDoXk9HVlprvzi5pzhac+DRE9kxZeE3PZMCQPp9A8ylOur218McXDk5VRee97cHAOher0eQkn7j7/Cp5akJpP7+7wPAlOs1kKblyNjmnxAAnoF6PTo2DeG3uacDALqz2cNPHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRZ2Tflm1Dj7Aujm6/MLtm5oYeg6dgz+z80COsi31btmXv3Nahx5i4vXNb81uX/vDQY6yLq/b8VI5uv3DoMSbuty794bz2tb8y9BgbalPE0ezQA/CULJSZ7NuyrctvSvc866Ic3Ha+QJoiV83Od7m/bpzfnned9ezuPs/2bdmWf/XC1+Xocy8fepSJe/kP/Xz+pxe/ubtA+lcvfF3e8pal/K2/cf3Qo2ycWuvgS5K6UGZqEssULYfOuaDL/Xb7BS/udtt6XW6Y397l/rr17IUun4t757bWvXtvrofOuWDwWSa9/ORPfr6+6OqfqbeevTD4LJNc/tbfuL7+/u9/T/29S14x+CwTXo48YZcMHUZrcWSZzqW3LwBry33nXdblF+6el31btnUXEclq+PX6XLzmml+rN8xvH3yOSS9vfvPv1+e88hfr3rmtg88yyeX3LnlFve22C+u9z7po8FkmuIgjy/osN209d/AZ1mM5uv3CenT7hYPPYTn9Zc/sfJeBtGd2vv7BtvMHn2M9lle96l1135Ztg88x6eW1r/2V+rf/9q9293y891kX1T/8w511z+z84LNMaBFHlvVbej2t8c6zni2QpmzZNTPX5XNxocx0e6T2h6/8iS5/yHrLS95aX//6fzn4HJNe9szO14MHF+qumbnBZ5nAIo4s67vsndva5TelvXNbu/2pvddlocx0+VxMVoN96BnWY/mlv/YjXZ4+/L1LXlFf97p/Mfgck152zczV97//f+0h2MWRZf2XXn9q3zUz1+VPtj0vPQdSj6ehds3M1f+w8+rermepC2Wm3rnjhfU1r/k/B59l0sutZy/Ud75zVO8777LBZ3kaiziybMzS6zelhTLT5cWjvS89PheT9HTNx3+zTXfueGF3gbRrZq4+8pxL6hVX3Tj4LJNe7jvvsnrddZ+sRy586eCznOHyhHG0Kd7niL4s1VGS1fdD6slSHeXAoye6fGO+nq09H3tz+NRyd+/vdPjUcn78ga8nSVfvFbQ4WsnzH7wjt/3FR/KOF/3doceZqPPu+0pu+NjP5u3f/6O57aIrhx5nYsr4yM2wQ5Qy/BBwmta+IS2OVgaehGe6tR9AegvAvXNbc8P89izVUfY/vDT0OBN1bGFXPrvt/Fxzxx8PPcpEfeLiPfmXz708P3v35/Kyb3126HGeis/UWv+7qhNHcAZ2zcxlqY66+6YEm8We2fns37ItR0cruXn5+NDjTNSdO16YLXWUF933la6+htx20ZU5vO25ufaBr2X3t28fepzT9YRx1Nd5D9gga0eNejt1CJvF4VPLuWn5eHbPzHV3Kvvie7+cR8tMDm47v6uvIa/85pFc+8DXcvicC/LIcy4ZepynpZ+9Ahusp5/4YDNaHK3kXY88mD0d/v68i+/9cr5/y7bcML+9q0Da/e3b88b7vpI/eM4lufXshaHHOWP97BEYwFIddfWFDTabpTrKux95MHvntnb3ubb9/q9m/5Zt2bdlW1fbdtYDX893vn17zt/xwuzbsm3occ5IP3sDBuIIEqy/m5ePd3d6LUl2H78rV83Od7dt+x9eyu/c/bn81Pkvmsqjfi7IBmBq7J3bmoMrJ4ceY+LWjrAcePTEwJNM1q6Zufx/C7ty6T3/eehR/iperQbA9Ns1M9flW2nsmZ3PjjLTZfw98pxLctb4Paw2Ga9WA2D6LY5WurpGZ83hU8s5dGo5e2bnhx5l4s564Os5dM4FQ49x2vp7dgHQvV5fDLFUR12++3mSXPWdY3nnWc8eeozT0t8zC4BnhJ5fDNHr0bG1Vx5udv39nweADvR6dOzgyslNf2Ssv//rANCJXo+ObfYjY5t3MgCgW5s5/MQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHIti7yUAAARcSURBVAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBjbugBxu5J8p3xn0yH82N/TRv7bPrYZ9PF/po+3/NEK0utdaMHeUKllCO11iuHnoPTY39NH/ts+thn08X+6ofTagAADXEEANDYTHH03qEH4Cmxv6aPfTZ97LPpYn91YtNccwQAsBlspiNHAACDGzyOSinXlFL+opSyWEp5x9DzsKqU8v5SyrFSyheadQullI+XUo6O/zxvvL6UUm4a78PPlVKuGG7yZ6ZSygtKKZ8qpdxeSvliKeWnx+vts02qlLK1lHK4lPLn43327vH67y2lHBrvm98tpcyP1581vr84/vilQ87/TFZKmS2l/Gkp5aPj+/ZZZwaNo1LKbJL/J8neJJcneXMp5fIhZ+Ixv5Xkmsete0eST9Radyf5xPh+srr/do+X65P8xgbNyH+1kuTnaq2XJ7k6yT8afy7ZZ5vXI0leXWt9SZKXJrmmlHJ1kl9O8p5a664k9yV52/jxb0ty33j9e8aPYxg/neRLzX37rDNDHznak2Sx1vqVWutykg8kuXbgmUhSa70tydLjVl+b5Jbx7VuSvKFZ/9t11R8nObeU8vyNmZQkqbV+q9b62fHth7L6hfvi2Geb1vj//fHx3S3jpSZ5dZIPjdc/fp+t7csPJXlNKaVs0LiMlVJ2Jnldkt8c3y+xz7ozdBxdnOQbzf07xuvYnJ5Xa/3W+PZdSZ43vm0/biLjQ/c/mORQ7LNNbXx65s+SHEvy8SR/meT+WuvK+CHtfnlsn40//kCSHRs7MUl+LcnPJxmN7++IfdadoeOIKVVXX+bopY6bTClle5J/k+Qf11ofbD9mn20+tdZTtdaXJtmZ1SPpLxp4JL6LUsrrkxyrtX5m6FlYX0PH0Z1JXtDc3zlex+Z099qpl/Gfx8br7cdNoJSyJathdKDW+m/Hq+2zKVBrvT/Jp5K8LKunONd+72W7Xx7bZ+OPPyfJvRs86jPdDyX5kVLKV7N6Gcirk/zz2GfdGTqO/iTJ7vGV/vNJ3pTkIwPPxF/tI0muG9++LsmHm/VvHb8C6uokDzSnctgA4+sY3pfkS7XWX20+ZJ9tUqWU55ZSzh3fPjvJa7N6rdinkrxx/LDH77O1ffnGJJ+s3qhuQ9Vaf6HWurPWemlWv199sta6L/ZZdwZ/E8hSyt/J6jnc2STvr7X+H4MORJKklPKvk7wqq79l+u4k70zy75J8MMklSb6W5EdrrUvjb8y/ntVXt51I8mO11iNDzP1MVUp5RZI/TPL5/NdrIf5pVq87ss82oVLKD2T1Yt3ZrP6g+sFa6y+VUi7L6lGJhSR/mmR/rfWRUsrWJL+T1evJlpK8qdb6lWGmp5TyqiT/pNb6evusP4PHEQDAZjL0aTUAgE1FHAEANMQRAEBDHAEANMQRAEBDHAEANMQRAEBDHAEANP5/0VLMrPfpKhAAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 720x720 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hN5jA8ogp7Bb",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Where the wild things are: Automatic Differentiation\n",
-        "\n",
-        "Now that we know how to compute various quantities, we can move on to the amazing part, computing gradients automatically by autodiff. As an example, we\n",
-        "will demonstrate how to analytically **compute Fisher matrices, without finite differences.** But gradients are usefull for a wide range of other applications.\n",
-        "\n",
-        "\n",
-        "We begin by defining a Gaussian likelihood function for the data vector we have \n",
-        "obtained at the previous step. And we make this likelihood function depend on an array of parameters, `Omega_c`, `sigma_8`.\n",
-        " \n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "QUBA8ajicFk4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Let's define a parameter vector for Omega_cdm, sigma8, which we initialize \n",
-        "# at the fiducial cosmology used to produce the data vector.\n",
-        "data = mu;\n",
-        "params = np.array([cosmo.Omega_c, cosmo.sigma8])\n",
-        "\n",
-        "# Note the `jit` decorator for just in time compilation, this makes your code\n",
-        "# run fast on GPU :-)\n",
-        "@jax.jit\n",
-        "def likelihood(p):\n",
-        "  # Create a new cosmology at these parameters\n",
-        "  cosmo = jc.Planck15(Omega_c=p[0], sigma8=p[1])\n",
-        "\n",
-        "  # Compute mean and covariance of angular Cls\n",
-        "  m, C = jc.angular_cl.gaussian_cl_covariance_and_mean(cosmo, ell, probes)\n",
-        "\n",
-        "  # Return likelihood value assuming constant covariance, so we stop the gradient\n",
-        "  # at the level of the precision matrix, and we will not include the logdet term\n",
-        "  # in the likelihood\n",
-        "  P = jax.lax.stop_gradient(np.linalg.inv(C))\n",
-        "  r = data - m\n",
-        "  return -0.5 * (r.T @ P @ r)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "4Us1pbt1dt-h",
-        "colab_type": "code",
-        "outputId": "42bfcaff-0ed7-457f-95ce-108d1d8462eb",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
-        }
-      },
-      "source": [
-        "# Computing the likelihood at our fiducial params, we should get 0 since we don't\n",
-        "# have the normalization term\n",
-        "print(likelihood(params))\n",
-        "%timeit likelihood(params).block_until_ready()"
-      ],
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "-2.5765703e-09\n",
-            "10 loops, best of 3: 40.5 ms per loop\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EmJfTrVSySAW",
-        "colab_type": "text"
-      },
-      "source": [
-        "This is an illustration of evaluating the full likelihood. Note that because we \n",
-        "used the `@jax.jit` decorator on the likelihood, this code is being compiled to \n",
-        "and XLA expression that runs automatically on the GPU if it's available. \n",
-        "\n",
-        "\n",
-        "But now that we have a likelihood function of the parameters, we can manipulate\n",
-        "it with JAX, and in particular take the second derivative of this likelihood \n",
-        "with respect to the input cosmological parameters. This Hessian, is just minus \n",
-        "the Fisher matrix when everything is nice and Gaussian around the fiducial comology.\n",
-        "\n",
-        "\n",
-        "So this mean, by JAX automaticatic differentiation, we can analytically derive\n",
-        "the Fisher matrix in just one line:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "V9vX2W1UyRhm",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "outputId": "e5985d95-374b-4150-8b28-e16218ab9d45"
-      },
-      "source": [
-        "# Compile a function that computes the Hessian of the likelihood\n",
-        "hessian_loglik = jax.jit(jax.hessian(likelihood))\n",
-        "\n",
-        "# Evalauate the Hessian at fiductial cosmology to retrieve Fisher matrix\n",
-        "F = - hessian_loglik(params)"
-      ],
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-          ],
-          "name": "stderr"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_Vvm8-IpB4rf",
-        "colab_type": "text"
-      },
-      "source": [
-        "What we are doing on the line above is taking the Hessian of the likelihood function, and evaluating at the fiducial cosmology. We surround the whole thing \n",
-        "with a `jit` instruction so that the function gets compiled and evaluated in one\n",
-        "block in the GPU.\n",
-        "\n",
-        "Compiling the function is not instantaneous, but once compiled, it becomes  fast but the evaluation is:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NgrRoxsSB3UZ",
-        "colab_type": "code",
-        "outputId": "ec070fd3-1f46-449c-e5c5-bca82ccae07d",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "%timeit hessian_loglik(params).block_until_ready()"
-      ],
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "1 loop, best of 3: 270 ms per loop\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZqXezv82EnxE",
-        "colab_type": "text"
-      },
-      "source": [
-        "And best of all: **No derivatives were harmed by finite differences in the computation of this Fisher!**\n",
-        "\n",
-        "We can now try to plot it:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "pmTdQeeXk8qB",
-        "colab_type": "code",
-        "outputId": "3ac0f9a9-3dc5-4dd4-b58b-fa6a6d8e1291",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 299
-        }
-      },
-      "source": [
-        "# We can now plot contours obtained with this \n",
-        "plot_contours(F, params, fill=False);\n",
-        "xlabel('Omega_m')\n",
-        "ylabel('sigma8')"
-      ],
-      "execution_count": 25,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "Text(14.5, 0.5, 'sigma8')"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 25
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deZyN9f//8ceLMcY+tj7WWTJaZBsmDLKnTNlKmJBsE9FG6wclaf9Jq0/fLEkiVEp9CFkqjBj7EmPKGINKicJIeP3+OBefaTLM0RzXOTOv++12bnPOda5zzfOM5TnX9b7O+xJVxRhjjMmpAm4HMMYYE1isOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWnxSEiN4rIDhFJEZFHz/F8mIgsFZH1IrJJROKc5WWd5UdE5PUsr+nmrLtVRJ73ZX5jjDF/J776HIeIFASSgeuBdGANEK+q2zKt8xawXlX/IyI1gHmqGiEixYBooCZQU1WHOOuXBdYD9VX1gIi8A0xV1cXny1KuXDmNiIjI/TdpjDF52Nq1a39W1fJZlwf58Hs2AFJU9XsAEXkf6Ahsy7SOAiWd+6WAfQCqehRYLiJRWbZ5ObBTVQ84j78AbgXOWxwREREkJSX9g7dijDH5j4jsPtdyXxZHZWBPpsfpQMMs64wCForIPUAxoM0FtpkCXCkiEc72OgHBuZDVGGNMDrk9OB4PTFHVKkAc8K6IZJtJVX8FBgEzga+BVODUudYVkQQRSRKRpAMHDpxrFWOMMRfBl8WxF6ia6XEVZ1lm/YBZAKqaCIQA5c63UVX9VFUbqmossAPPOMq51ntLVWNUNaZ8+b8dojPGGHORfFkca4DqIhIpIsFAd2BulnXSgNYAInI1nuI47+6BiFzmfC0N3A1MzOXcxhhjzsNnYxyqelJEhgALgILAZFXdKiKjgSRVnQsMAyaIyAN4BsrvVOc0LxFJxTNwHiwinYC2zhlZr4hIHefbjFbVc+5xGGOM8Q2fnY7rT2JiYtTOqjLGGO+IyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXfFocInKjiOwQkRQRefQcz4eJyFIRWS8im0Qkzlle1ll+RERez/KaeBHZ7Kz/uYiU8+V7MMYY81c+Kw4RKQi8AbQDagDxIlIjy2ojgFmqGg10B8Y7y48DI4EHs2wzCHgFaKmqtYFNwBBfvQdjjDF/F+TDbTcAUlT1ewAReR/oCGzLtI4CJZ37pYB9AKp6FFguIlFZtinOrZiI/OK8NsVn78BctMOHD7N7927S0tLYvXs36enpHDlyhIyMDI4fP87x48f/dv/EiRMUKVKEYsWKnfdWpkwZKlasSKVKlahUqRJly5ZFRNx+y8bkG74sjsrAnkyP04GGWdYZBSwUkXuAYkCb821QVf8UkUHAZuAosBMYfK51RSQBSAAICwu7iPjmQlSV5ORkEhMTWbt2Lbt27TpbFKdOnSI8PJzw8HDCwsKoWrUqFStWpEiRIoSEhJz9mvl+oUKFOH78OEePHs32tnfvXjZv3sy+ffvYv38/+/bt48iRI1SqVInw8HAiIiLOft+oqChq1qxJmTJl3P5RGZOn+LI4ciIemKKqY0UkFnhXRGqq6ulzrSwihYBBQDTwPfAa8BgwJuu6qvoW8BZATEyM+ih/vvLbb7+xevVqVq1aRWJiIqtWraJEiRLExsZy7bXX0qZNG8LCwggPD6d06dKXbC/g+PHj7N27l9TUVHbv3s3u3bv56quvmDhxIlu3bqV48eLUrFmTmjVrUqtWLWrWrEmNGjUoWrToJclnTF7jy+LYC1TN9LiKsyyzfsCNAKqaKCIhQDngp2y2WddZ9zsAEZkF/G3Q3eSeH3/8kVmzZjFjxgw2btxIdHQ0sbGx9OvXj4kTJ1KxYkW3IxISEkK1atWoVq3a355TVfbs2cOWLVvYvHkzixcv5uWXXyY5OZnKlSufLZNGjRoRGxtL6dKlXXgHxgQWXxbHGqC6iETiKYzuwO1Z1kkDWgNTRORqIAQ4cJ5t7gVqiEh5VT0AXA98m+vJ87nDhw/z0UcfMWPGDFavXk379u0ZMWIEbdq0ITg42O14XhERwsLCCAsLIy4u7uzykydPkpKSwpYtW9iwYQNjx45l9erVhIeH06RJE5o0aULTpk2JjIy08RNjshBV3x3FcU6vfRkoCExW1adFZDSQpKpznbOsJgDF8QyUP6yqC53XpuIZ/A4GDgFtVXWbiAwE7gP+BHYDd6rqL+fLERMTo0lJST55j3nJypUrGTt2LF988QWtWrUiPj6em2++Od8c0vnzzz/ZuHEjK1asOHs7ffr02SJp0qQJ0dHRFCpUyO2oxlwSIrJWVWP+ttyXxeEvrDjOb+3atYwcOZKtW7fy2GOP0b17d0JDQ92O5TpVJTU19S9FkpaWRsuWLYmLi6Ndu3ZUqVLF7ZjG+IwVhxXH32zevJnHH3+c1atXM3z4cPr160fhwoXdjuXXfvrpJxYsWMD8+fNZuHAhFStWpF27drRr144mTZoE3KE8Y87HisOK46xffvmFe++9l8WLF/PII48wcOBAihQp4nasgHPq1CnWrFnD/PnzmT9/PsnJybRs2fJskVStWvXCGzHGj2VXHDZXVT6zfPlyoqOjqVChAikpKTzwwANWGhepYMGCNGrUiCeffJLVq1eTnJzMLbfcwrJly4iOjqZevXo899xz7Nq1y+2oxuQq2+PIJ06dOsVzzz3Ha6+9xqRJk7jpppvcjpSnnTp1iq+++oqZM2fy0UcfERERQbdu3ejatavtiZiAYYeq8nFx/PDDD/Tq1Ys//viD6dOn24DuJXby5EmWLFnCrFmzmDNnDldeeSXdunXjtttuo1KlSm7HMyZbdqgqn0pJSaFBgwY0bNiQJUuWWGm4ICgoiLZt2zJx4kT279/PiBEjWLduHddccw3Nmzdn/Pjx/Pzzz27HNCbHrDjysF27dtG6dWtGjBjBmDFjCApye4YZExwcTFxcHO+88w779+9n6NChLF++nKioKLp3784XX3zB6dPnnHHHGL9hxZFH/fjjj7Ru3ZqHH36YhIQEt+OYcwgJCaFjx45Mnz6dXbt2cd111/Hggw8SFRXF008/zd69WWfoMcY/WHHkQceOHaN9+/bccccdDB58zsmDjZ8pXbo0gwcPZv369cyaNYu0tDRq1qxJ+/btmTt3LidPnnQ7ojFn2eB4HtSzZ09EhKlTp9o8SwHsyJEjzJ49mwkTJpCamkqfPn3o27fvOSdzNMYXbHA8n/jiiy9YuXIlb731lpVGgCtevDh9+vRh5cqVLFq0iIyMDBo1asRNN93EkiVLyA+/9Bn/ZMWRh5w4cYJ77rmHl19+2T7Ul8dcc801vPTSS6SlpdG5c2eGDBlCdHQ0U6dO5cSJE27HM/mMFUce8sorrxAZGUn79u3djmJ8pEiRIvTv358tW7bw3HPPMW3aNCIjI3n22Wc5ePCg2/FMPmHFkUfs3buX559/nldeecUOUeUDBQoU4MYbb2ThwoXMnz+fnTt3EhUVxeDBg0lOTnY7nsnjrDjyiGeeeYb+/ftTvXp1t6OYS6x27dpMnjyZbdu2UaZMGZo2bUrHjh358ssvbRzE+IQVRx5w8uRJZs+ebZ/XyOcqVKjAU089RWpqKnFxcQwYMIDmzZvbQLrJdVYcecCSJUuIiIjg8ssvdzuK8QNFixblrrvuYtu2bSQkJDBw4EBatGjB0qVL3Y5m8ggrjjxg1qxZdOvWze0Yxs8EBQXRs2dPtm3bRv/+/UlISKBFixYsW7bM7WgmwFlxBLgTJ04wZ84cbrvtNrejGD8VFBREr169+Pbbb+nTpw/9+/enZcuWfPnll25HMwHKiiPAffnll1xxxRWEhYW5HcX4uaCgIHr37s327dvp3bs3ffv2pVWrVnz11VduRzMBxoojwH377bfUr1/f7RgmgAQFBXHnnXeyfft2evXqRZ8+fWjTpg3r1q1zO5oJEFYcAS41NZWIiAi3Y5gAVKhQIfr06cP27du59dZbiYuLo1evXqSlpbkdzfg5K44AZ8Vh/qlChQoxaNAgdu7cSUREBNHR0TzyyCMcOnTI7WjGT1lxBDgrDpNbSpQowVNPPcWmTZv4+eefufLKKxk/frxN6W7+xoojwFlxmNxWuXJlJk2axMKFC/nggw+oW7cuixYtcjuW8SM+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nWr+EiGzIdPtZRF725XvwZydPnuTQoUOULVvW7SgmD6pTpw6LFy9mzJgxDBo0iA4dOtg8WAbwYXGISEHgDaAdUAOIF5EaWVYbAcxS1WigOzDeWX4cGAk8mHllVf1dVeueuQG7gY989R78XVBQEMHBwWRkZLgdxeRRIkKnTp3YunUrzZo1o3HjxgwfPtz+zuVzvtzjaACkqOr3qnoCeB/omGUdBUo690sB+wBU9aiqLsdTIOckIlcAlwFf53bwQFKqVCkOHz7sdgyTxxUuXJgHH3yQTZs2kZKSQq1atezwVT7my+KoDOzJ9DjdWZbZKKCniKQD84B7vNh+d2CmZjN7m4gkiEiSiCQdOHDAi80GltDQUCsOc8lUqlSJmTNn8uqrr5KQkECPHj348ccf3Y5lLjG3B8fjgSmqWgWIA94VkZxm6g7MyO5JVX1LVWNUNaZ8+fK5ENU/2R6HcUNcXBxbtmyhcuXK1KpViwkTJnD69Gm3Y5lLxJfFsReomulxFWdZZv2AWQCqmgiEAOUutGERqQMEqera3IkauEqVKmXn2xtXFCtWjBdeeIFFixYxadIkmjVrxtatW92OZS4BXxbHGqC6iESKSDCePYS5WdZJA1oDiMjVeIojJ8eV4jnP3kZ+ctlll7F//363Y5h8rE6dOqxYsYIePXrQokULGzzPB3xWHKp6EhgCLAC+xXP21FYRGS0iHZzVhgEDRGQjniK488yYhYikAi8Bd4pIepYzsrpixQFATEwMq1evdjuGyecKFizIoEGDzg6e165dm5UrV7ody/iI5Icrg8XExGhSUpLbMXxi1apVDBo0iPXr17sdxZizPv74YwYOHEj//v15/PHHCQ4OdjuSuQgislZVY7Iud3tw3PxD0dHRJCcnc+TIEbejGHNWp06d2LBhAxs3biQ2NpZt27a5HcnkIiuOAFe4cGHq1KnDmjVr3I5izF9UqFCBuXPnMnDgQJo3b86rr75qZ17lEVYceUBsbCyJiYluxzDmb0SEAQMGkJiYyIwZM7jhhhtIT093O5b5h6w48oDGjRuzfPlyt2MYk62oqCi+/vprWrRoQb169Zgxw85tCWQ2OJ4H/Pbbb4SFhZGSkkK5chf8GIwxrlq7di09e/akbt26vPnmm5QqVcrtSCYbNjieh5UsWZKbbrrJfoszAaF+/fqsW7eOMmXKEBMTw6ZNm9yOZLxkxZFH9O7dm3feecftGMbkSJEiRXjjjTd48sknad26NVOnTnU7kvGCFUce0bp1a3744Qeb8sEElNtvv51ly5bx9NNPM3DgQI4fz3ZCbONHrDjyiIIFC9KrVy/b6zAB55prrmHNmjX8/PPPXHfddaSmprodyVyAFUce0rt3b6ZNm2bXiDYBp2TJksyePZv4+HgaNmzI559/7nYkcx5WHHnIVVddRUREBJ988onbUYzxmogwdOhQPvjgA/r168eoUaM4deqU27HMOVhx5DHDhw9n1KhR9gldE7Cuu+461q5dy9KlS7n55pv57bff3I5ksrDiyGPi4uIoVqwYs2fPdjuKMRetQoUKLF68mMjISJo2bcqePXsu/CJzyVhx5DEiwujRo2033wS8oKAg3njjDXr37k1sbCzr1q1zO5JxWHHkQddffz3lypVj+vTpbkcx5h8REYYNG8Yrr7zCDTfcwH//+1+3IxmsOPKkM3sdTz75JH/++afbcYz5x2699VY+/fRT+vfvz/jx492Ok+9ZceRRLVu2JCwsjHfffdftKMbkikaNGrFixQpeffVVhg0bZieAuOi8xSEil4vIZBEZIyLFRWSCiGwRkdkiEnFpIpqLNWbMGJ544gl+//13t6MYkysuv/xyVq5cSVJSErfddhvHjh1zO1K+dKE9jinAGuAIsArYDrQDPgcm+zSZ+ccaN27M9ddfz8iRI92OYkyuKVOmDAsXLqRIkSK0bt2aQ4cOuR0p37lQcZRQ1f+o6nNASVUdq6p7VHUSUPoS5DP/0AsvvMD7779vZ6SYPKVw4cK8++67NGzYkDZt2nDw4EG3I+UrFyqO0yJyhYhcCxQVkRgAEYkCCvo8nfnHypUrx3PPPUdCQoJNRWLyFBFh3LhxtGrVipYtW3LgwAG3I+UbFyqOh4FPgalAJ+AxEUkBVgJ2/CNA9O7dm9DQUMaOHet2FGNylYjw/PPP0759e1q0aMEPP/zgdqR8Ieh8T6rqYuDKTIuWi0g54FdVtU+XBQgRYeLEiVx77bW0b9+eGjVquB3JmFwjIowZM4bChQvTokULFi9eTOXKld2OlaedtzgyE5GaQA0gxHmMqtrVVwJEREQETz31FH369GHFihUEBeX4j96YgDBy5EiCg4Np3rw5S5YsISwszO1IeVaOPschIk8Arzm3lsALQAcf5jI+kJCQQIkSJRgzZozbUYzxiUceeYTBgwfTvHlzdu3a5XacPCunHwDsArQGflDVPkAd4IJXmBeRG0Vkh4ikiMij53g+TESWish6EdkkInHO8rLO8iMi8nqW1wSLyFsikiwi20Xk1hy+h3yvQIECTJs2jYkTJ9r1Dkye9cADD/Dggw/SokULmxzRR3J6vCJDVU+LyEkRKQn8BFQ93wtEpCDwBnA9kA6sEZG5qrot02ojgFmq+h8RqQHMAyKA43gG32s6t8yGAz+p6hUiUgAok8P3YPDMOjpjxgy6dOnC6tWrCQ8PdzuSMblu8ODB/PHHH9xwww0sX76cMmXsv4nclNM9jiQRCQUmAGuBdUDiBV7TAEhR1e9V9QTwPtAxyzoKlHTulwL2AajqUVVdjqdAsuoLPOusd1pVf87hezCO6667jocffpguXbrwxx9/uB3HGJ8YOnQocXFxdOjQgYyMDLfj5Ck5Kg5VvVtVD6nqm3j2IHo7h6zOpzKQeT8x3VmW2Sigp4ik49nbuOd8G3TKC+ApEVnnTH3yr5y8B/NXQ4cOJSwsjPvvv9/tKMb4zAsvvEBERATx8fH2OaZclONJDkWktoh0AOoBUSJySy58/3hgiqpWAeKAd53DT9kJAqoAK1W1Hp69nv+XTd4EEUkSkST7YNDfiQhvv/02ixcvtokQTZ5VoEABJk+ezLFjxxg8eDCq6nakPCGnZ1VNxjM31a1Ae+d28wVetpe/joNUcZZl1g+YBaCqiXhO9S13nm3+AhwDPnIez8ZTZH+jqm+paoyqxpQvX/4CUfOnkiVL8uGHHzJ06FA2b97sdhxjfCI4OJgPP/yQpKQkRo8e7XacPCGng+ONVNXbT42tAaqLSCSewugO3J5lnTQ8Z2tNEZGr8RRHtrsHqqoi8inQAljivHZbduubC6tVqxbjxo2jc+fOrFy5kssuu8ztSMbkuhIlSjBv3jyaNGlCxYoVSUhIcDtSQMtpcSSKSI0sZ0Sdl6qeFJEhwAI881pNVtWtIjIaSFLVucAwYIKIPIBnoPxOdfYlRSQVz8B5sIh0Ato63/8RPIe0XsZTMhcaazEX0LNnT3bs2MFNN93E0qVLKV68uNuRjMl1//rXv/j8889p1qwZVapUIS4uzu1IAUtycsxPRJoDc4EfgD8AwbMDUNu38XJHTEyMJiUluR3Dr6kqAwYMID09nU8//ZRChQq5HckYn0hMTKRTp06sWrWKyMhIt+P4NRFZq6oxWZfndHB8EtALuJH/jW+0z714xm0iwptvvkmhQoXo16+fDSKaPCs2Npbhw4fTpUsXjh8/1xn/5kJyWhwHVHWuqu5S1d1nbj5NZi65oKAgZs6cyc6dO3nsscfcjmOMz9xzzz1Ur16de++91+0oASmnxbFeRKaLSLyI3HLm5tNkxhVFixbls88+4+OPP+aVV15xO44xPnFmxuivv/6at99+2+04ASeng+NF8IxttM20TPnfabEmDylbtiwLFiygadOmVKhQgW7durkdyZhcV7x4cT788EOaN29OdHQ0devWdTtSwMhRceTgU+ImjwkPD2fevHm0adOGkiVL0q5dO7cjGZPratSowWuvvUaXLl1ISkoiNDT0wi8yOT6r6tVzLD6M57TaT3I9VS6zs6ou3qpVq+jQoQMTJ06kQwebSd/kTffddx9paWl89NFHiIjbcfzGPz2rKgSoC+x0brXxfBK8n/N5CpNHNWrUiHnz5jFgwAA+/PBDt+MY4xMvvvgiqampTJ1q16bLiZyOcdQGmpy5XKyI/Af4GmgK2FwVeVxMTAwLFiygXbt2nDhxgvj4eLcjGZOrgoODefvtt2nbti1t2rSxS89eQE73OEoDmT9OXAwo4xSJzcudD9StW5dFixYxbNgw3nnnHbfjGJPr6taty913381dd91ln2O6gJwWxwvABhF5W0SmAOuBF0WkGPCFr8IZ/1KzZk2WLFnC8OHDmThxottxjMl1//73v9mzZw/Tp093O4pfy9HgOICIVMRzcSaANaq6z2epcpkNjueunTt30rp1ax599FHuvvtut+MYk6tWr15Nx44d2bZtG6VLl3Y7jqsuanBcRK5yvtYDKuK5MNMeoIKzzORD1atX58svv+TFF1/kueees916k6c0aNCAW265hUcffdTtKH7rvHscIvKWqiaIyNJMi8++QFVb+TJcbrE9Dt/Yu3cvN998M9deey1vvPGGTYxo8ozDhw9To0YNZs+eTePGjd2O45qL2uNQ1TOT1v8H6KiqLYGleD7D8WCupzQBpXLlynz11Vekp6fTvn17fvvtN7cjGZMrSpUqxTPPPMMjjzxie9TnkNPB8RGq+puINAVaARPxlInJ50qUKMHcuXOJjIykadOm7Nmz58IvMiYA9OzZkwMHDrBo0SK3o/idnBbHKefrTcAEVf0vEOybSCbQBAUFMX78eHr16kVsbCzr1693O5Ix/1jBggUZNWoUjz/+uO11ZJHT4tgrIv8HdAPmiUhhL15r8gER4aGHHuLll1+mbdu2zJs3z+1IxvxjXbt25ciRI/b3OYuc/uffFc8lYG9Q1UNAGeAhn6UyAatLly7MnTuXfv368Z//2NFME9gKFCjAk08+aXsdWeSoOFT1mKp+pKo7ncf7VXWhb6OZQBUbG8vy5ct5+eWXGTJkCCdOnHA7kjEXrXPnzpw+fZqPP/7Y7Sh+ww43GZ+oVq0a33zzDXv27KF58+Y2aG4C1pm9jieeeML2OhxWHMZnQkNDmTNnDp06daJBgwZ88YXNTmMCU/v27Tlx4gSJiYluR/ELVhzGpwoUKMAjjzzC9OnTueOOO3j66ac5ffq027GM8YqI0Lt3b5vg02HFYS6Jli1bsmbNGubNm0fHjh359ddf3Y5kjFd69erF7NmzycjIcDuK66w4zCVTuXJlli1bRlRUFDExMfZ5DxNQqlSpQv369Zk7d67bUVxnxWEuqUKFCjFu3DieffZZ2rZty6RJk2zA0QQMO1zlYcVhXNG1a1e++uorxo0bR7du3Th48KDbkYy5oM6dO5OYmMj+/fvdjuIqnxaHiNwoIjtEJEVE/jZHsYiEichSEVkvIptEJM5ZXtZZfkREXs/ymmXONjc4t8t8+R6M71x99dUkJSVRpUoVateuzYIFC9yOZMx5FStWjE6dOjFr1iy3o7jKZ8UhIgWBN4B2QA0gXkRqZFltBDBLVaOB7sB4Z/lxYCTZz8DbQ1XrOrefcj+9uVRCQkJ46aWXmDp1KgMGDGDIkCEcO3bM7VjGZKt169YsX77c7Riu8uUeRwMgRVW/V9UTwPtAxyzrKFDSuV8K2AegqkdVdTmeAjH5QKtWrdi0aROHDh2iXr16rFmzxu1IxpxTbGxsvv88hy+LozKeqwWeke4sy2wU0FNE0oF5wD053PbbzmGqkSIi51pBRBJEJElEkg4cOOBldOOG0NBQpk2bxujRo7n55psZPXo0J0+edDuWMX9x+eWXc+LEiXw9G4Lbg+PxwBRVrQLEAe+KyIUy9VDVWsB1zq3XuVZS1bdUNUZVY8qXL5+roY1vde3alXXr1rFixQqaNGlCcnKy25GMOUtE8v1ehy+LYy9QNdPjKs6yzPoBswBUNREIAcqdb6Oqutf5+jswHc8hMZPHVK5cmc8//5w77riDxo0bM27cONv7MH7DisN31gDVRSRSRILxDH5n/eRMGtAaQESuxlMc2R5XEpEgESnn3C8E3Axs8UF24wdEhMGDB7Ny5Uo+++wzGjZsiF073vgDKw4fUdWTwBA81/H4Fs/ZU1tFZLSIdHBWGwYMEJGNwAzgTnU+DSYiqcBLwJ0iku6ckVUYWCAim4ANePZgJvjqPRj/cMUVV/DFF19w//33c/PNN3Pffffx+++/ux3L5GPVq1cnNTXV7Riukfzwqd2YmBi131Tzhl9++YWHH36YhQsX8tprr9GpUye3I5l86OjRo5QrVy7Pz1slImtVNSbrcrcHx43xStmyZZk0aRLTpk3jscceo2PHjqSlpbkdy+QzRYsW5eTJk/n2ImVWHCYgNW/enA0bNhATE0O9evVs8NxcUiJCqVKlOHz4sNtRXGHFYQJW4cKFGTly5NnB8wYNGrBy5Uq3Y5l8olSpUhw6dMjtGK6w4jAB78zg+bBhw+jWrRvx8fF2+Mr4nO1xGBPgRIQePXqwfft2rrzySqKjo3n88cc5cuSI29FMHpWRkUFISIjbMVxhxWHylGLFijFq1Cg2bNjAd999x1VXXcWUKVM4deqU27RRwb4AABInSURBVNFMHqKq7N69m4iICLejuMKKw+RJVatW5b333uODDz5gwoQJ1KtXj4ULF7ody+QRP/30E0WLFqV48eJuR3GFFYfJ0xo1asTy5ct54oknGDx4MDfccAMbN250O5YJcKmpqfl2bwOsOEw+ICLccsstbNu2jfbt29O2bVt69eplkyeai2bFYUw+UahQIYYMGcLOnTu54ooraNKkCb1792bnzp1uRzMBJjk5mcjISLdjuMaKw+Q7JUuWZOTIkaSkpFCtWjViY2O58847SUlJcTuaCRCffPIJN954o9sxXGPFYfKtUqVK8fjjj5OSkkJkZCSNGjWiT58+fPfdd25HM34sJSWFPXv20Lx5c7ejuMaKw+R7oaGhPPHEE6SkpBAeHk7Dhg3p27cv33//vdvRjB+aPXs2t956K0FBQW5HcY0VhzGO0NBQRo0axc6dO6latSoNGjSgX79+7Nixw+1oxo/MnDmTbt26uR3DVVYcxmRRunRpnnzySZKTk6latSrNmjWjffv2LF26lPxwGQKTva1bt/LTTz/RtGlTt6O4yorDmGyUKVOGUaNGkZqaSocOHbj77rupV68e7777br6dTjs/U1UeeughHnjgAQoWLOh2HFdZcRhzAUWKFGHAgAFs3bqVZ555hqlTpxIZGcmzzz7LwYMH3Y5nLpFPP/2UXbt2cd9997kdxXVWHMbkUIECBWjXrh2LFi1i/vz5JCcnExUVxeDBg+2zIHlcRkYG999/P6+99hrBwcFux3GdFYcxF6F27dq8/fbbbN26ldKlS9O4cWM6duzIvHnzbELFPOj555+nfv36tGnTxu0ofsGuOW5MLjh27BjvvfceEyZMYP/+/fTt25e+ffsSHh7udjTzD61fv57rr7+edevWERYW5nacS8quOW6MDxUtWpQBAwawevVqPvvsMw4ePEi9evW44YYb+OCDD2wwPUClp6fToUMH/u///i/flcb5WHEYk8vq1KnDa6+9Rnp6OnfccQevv/46VatW5aGHHmL79u1uxzM5dPDgQW666Sbuvfdebr31Vrfj+BUrDmN8pEiRIvTo0YNly5bx9ddfU6BAAVq0aEGzZs2YMmVKvr3saCA4dOgQbdu25frrr+fBBx90O47fseIw5hK44ooreP7559mzZw8PPPAAc+bMoWrVqnTs2JHp06fz+++/ux3ROPbu3Uvbtm1p2rQpL774IiLidiS/Y8VhzCVUqFAhOnfuzCeffEJaWhq33HIL06ZNo0qVKnTp0oVZs2Zx9OhRt2PmW/PmzaN+/fp06NCBcePGWWlkw6fFISI3isgOEUkRkUfP8XyYiCwVkfUisklE4pzlZZ3lR0Tk9Wy2PVdEtvgyvzG+FBoaSu/evZk3bx7ff/897dq1Y+LEiVSqVInu3bszZ84cjh8/7nbMfOHPP//k4Ycf5q677mLWrFmMGDHCSuM8fFYcIlIQeANoB9QA4kWkRpbVRgCzVDUa6A6Md5YfB0YC5zy4KCK3AEd8kdsYN5QtW5Z+/fqxcOFCUlJSaNGiBa+++ioVKlQgPj6eadOmceDAAbdj5kmpqak0a9aMrVu3sn79epo1a+Z2JL/nyz2OBkCKqn6vqieA94GOWdZRoKRzvxSwD0BVj6rqcjwF8hciUhwYCozxVXBj3FS+fHkGDhzI0qVL2b59Oy1btuTDDz8kKiqKBg0a8MQTT7Bq1Sr7oOE/dOjQIUaOHEn9+vXp0qULn376KeXKlXM7VkDwZXFUBvZkepzuLMtsFNBTRNKBecA9OdjuU8BY4FguZDTGr1WoUIGEhATmzJnDgQMHeP7558nIyGDAgAFUqFCBHj162N6Il37//XfGjBlDVFQUe/fuJSkpiWHDhlGggA355pTbP6l4YIqqVgHigHdFJNtMIlIXqKaqcy60YRFJEJEkEUmyf1QmLwgODqZly5a88MILbN68mXXr1tG8efO/7I38+9//Zt68efz6669ux/U7x44d48UXXyQqKopvv/2WlStXMnny5Hx97fCL5ctLWO0FqmZ6XMVZllk/4EYAVU0UkRCgHPBTNtuMBWJEJBVP9stEZJmqtsi6oqq+BbwFnilHLv5tGOOfqlatSkJCAgkJCZw4cYIVK1awdOlSxo4dy+rVqwkPD6dJkyY0adKEpk2bEhkZme8GfE+ePMmSJUuYMWMGn3zyCa1atWLJkiVcc801bkcLaD6bq0pEgoBkoDWewlgD3K6qWzOtMx+YqapTRORqYDFQWZ1QInInEKOqQ86x/QjgM1WteaEsNleVyW/+/PNPNm7cyIoVK87eTp8+fbZImjRpQq1atShSpIjbUXOdqrJq1SqmT5/O7NmzCQsLIz4+nq5du1K5ctaj5eZ8spuryqeTHDqn174MFAQmq+rTIjIaSFLVuc5ZVhOA4ngGyh9W1YXOa1PxDJwHA4eAtqq6LdO2I7DiMCZHVJXdu3efLZGVK1eyY8cOwsLCqFWrFjVr1qRmzZrUqlWLatWqBdT1tFWVHTt2kJiYSGJiIosWLSIkJITbb7+d7t27U716dbcjBixXisNfWHEY83d//vknycnJbNmyhS1btrB582a2bNnCvn37uPLKK88WylVXXUV4eDjh4eGEhoa6HZtff/2VtWvXni2Kb775hhIlShAbG0tsbCwtWrSgVq1a+e6wnC9YcVhxGJMjR48eZdu2bWcLZceOHezevZvdu3cjIoSHhxMWFkalSpWoVKkSFStWpFKlSpQvX55ixYr95Va0aNEcna106tQpMjIyOH78OEePHmXv3r2kpaWd/b5n7qelpXH69Gnq1q1LbGwsjRo1IjY2looVK16Cn0z+Y8VhxWHMP6KqHDp0iNTUVPbs2cP+/fvZt28f+/btY//+/Rw4cICjR4/+5ZaRkUFISMhfiiRzSRw/fpyMjAxOnTpFkSJFCAkJoUiRIlSuXPnsXk5YWNhf7oeGhtrexCWSXXEEzoFMY4yrRITSpUtTunRpoqOjc/Sa06dPk5GRcbZIjh07RlBQECEhIWdLIiQkhEKFClkZBBArDmOMzxQoUODs3obJO9z+AKAxxpgAY8VhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxis+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nec3nIrJRRLaKyJsiUtCX78EYY8xf+aw4nP/Q3wDaATWAeBGpkWW1EcAsVY0GugPjneXHgZHAg+fYdFdVrQPUBMoDt/kgvjHGmGz4co+jAZCiqt+r6gngfaBjlnUUKOncLwXsA1DVo6q6HE+B/PUFqr85d4OAYGcbxhhjLhFfFkdlYE+mx+nOssxGAT1FJB2YB9yTkw2LyALgJ+B34INs1kkQkSQRSTpw4ICX0Y0xxmTH7cHxeGCKqlYB4oB3ReSCmVT1BqAiUBholc06b6lqjKrGlC9fPjczG2NMvubL4tgLVM30uIqzLLN+wCwAVU0EQoByOdm4qh4HPuHvh7+MMcb4kC+LYw1QXUQiRSQYz+D33CzrpAGtAUTkajzFke1xJREpLiIVnftBwE3Adh9kN8YYk40gX21YVU+KyBBgAVAQmKyqW0VkNJCkqnOBYcAEEXkAzyD3naqqACKSimfgPFhEOgFtgV+AuSJSGE/pLQXe9NV7MMYY83fi/D+dp8XExGhSUpLbMYwxJqCIyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4JV+McYjIAWC32zmyUQ742e0QXrC8vhdomS2vb7mZN1xV//ZBuHxRHP5MRJLONfjkryyv7wVaZsvrW/6Y1w5VGWOM8YoVhzHGGK9YcbjvLbcDeMny+l6gZba8vuV3eW2MwxhjjFdsj8MYY4xXrDiMMcZ4xYojl+XgOutDRWSbc431xSISnum5UyKywbnNzbRcRORpEUkWkW9F5F4/z/t1puX7RORjP8/bWkTWOcuXi0iUn+dt5eTdIiLvODNF+0PeMBFZ6Pwd3SYiEc7ySBH5xtnmTGe2bH/OO8TZnopIji7z4HLe95xtbhGRySJSKDczn5Oq2i2XbnhmAf4OuBzPZW03AjWyrNMSKOrcHwTMzPTckWy22weYChRwHl/mz3mzvP5D4A5/zgskA1c79+/Gc3Exv8yL55e9PcAVzuPRQD8/ybsMuN65XzzTerOA7s79N4FBfp43GogAUoFyuZHVx3njAHFuM3Lr53u+m+1x5K4LXmddVZeq6jHn4So8F7i6kEHAaFU97WzjJz/PC4CIlMRzhcbc2uPwVV7FM4U/QClgnx/nLQucUNVk5/Ei4Fa384pIDSBIVRc56x1R1WMiInj+Dpy5xPM7QCd/zevcX6+qqbmU8VLknacOYDVe/Bu9WFYcuSsn11nPrB8wP9PjEPFcJ32VeK5BckY1oJvz3HwRqe7nec/oBCxW1d/+eVTAd3n7A/NEJB3oBTznx3l/BoJE5Mwnibvw1yttupX3CuCQiHwkIutF5EURKYin6A6p6skcbtPtvL7k07zOIapewOe5mPmcfHYhJ3N+ItITiAGaZ1ocrqp7ReRyYImIbFbV7/BcW/24qsaIyC3AZOA6P857Rjww8VLmPMPLvA8Acar6jYg8BLyEp0z8Mq+IdAfGieeCZguBU5cyazZ5g/D8nYzGc2XPmcCdeC7v7Dov8k5yI19WF5l3PPCVqn7t63y2x5G7cnKddUSkDTAc6KCqf5xZrqp7na/f4zmeGe08lQ585NyfA9T287w4g4oNgP/mUlaf5BWR8kAdVf3GWW0m0Nhf8zqPE1X1OlVtAHyFZ4zG7bzpwAbnMMxJPIcn6+G5amdopgH8c27Tj/L6ks/yisgTQHlgqI+y/5WvB1Hy0w3PbwXfA5H8b/DrmizrROMZIKueZXlpoLBzvxywE2fgDM+hk77O/RbAGn/O6ywbCLzj7z9fZ5s/87/B5n7Ah/6a13l8mfO1MLAYaOUHeQs665d3Hr8NDHbuz+avg+N3+3PeTOukkruD4776+fYHVgJFcivrBd/LpfpG+eWG5wyHZOcPf7izbDSe3x4AvgB+BDY4t7nO8sbAZucvx2YynSkDhOL5zX0zkIjnN2S/zes8vwy4MUB+vp0zPbcMuNzP874IfAvsAO73h5+v89z1wCYn7xQg2Fl+OZ5B2xQ8JVLYz/Pei+c3/JN4TpSY6Od5TzrbO/Oax3P7313Wm005Yowxxis2xmGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMach4hUEZFPRGSniHwnIq/k5uyuxgQiKw5jsuFM0PcR8LGqVsczX1Bx4GlXgxnjMisOY7LXCs8cYW8DqOopPPNa9RWRu0XkYxFZJCKpzjUchjoT0K0SkTIAIlJNRD4XkbXiuU7JVZmWrxKRzSIyRkSOOMuLO9dhWOc81zGbbIhIhIhsF5Ep4rlWy3si0kZEVjh7SA18/hMy+ZIVhzHZuwZYm3mBemb6TcMzfURN4BbgWjx7IcdUNRrPp/vvcF7yFnCPqtYHHsQzER3AK8ArqloLz6eUzzgOdFbVeniuzTDW2fPJThQwFrjKud0ONHW+178v4j0bc0E2O64xF2+pqv4O/C4ih4FPneWbgdoiUhzP1CGzM/3fX9j5Gsv/rksxHfh/zn0BnhGRZsBpPNNu/wv4IZsMu1R1M4CIbMUzjb2KyGY8FyMyJtdZcRiTvW14rndxlnNxqjA88wP9kemp05ken8bzb6sAnmtR1PXie/bAM8tpfVX9U0RSgZDzrH+hDMbkOjtUZUz2FgNFReQOAOfCOWPxTDB37DyvA84e1tolIrc5rxcRqeM8vYr/Xbmve6aXlQJ+ckqjJRCeG2/EmNxkxWFMNtQzA2hn4DYR2YlnVtPjeDd20APoJyIbga3871Kh9wNDRWQTnnGKw87y94AY51DTHcD2f/xGjMllNjuuMS4QkaJAhjMe0R2IV9Vsz6Ayxp/YMVBj3FEfeN05Y+oQ0NflPMbkmO1xGOPnRKQsnvGWrFqr6i+XOo8xVhzGGGO8YoPjxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO88v8Bjugk/8WdHIIAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dEXC2lIlE5IN",
-        "colab_type": "text"
-      },
-      "source": [
-        "And just to reinforce this point and demonstrate further audodiff magic, let's try to derive the same matrix differently, using the usual formula for constant\n",
-        "covariance:\n",
-        "\n",
-        "$$ F_{\\alpha, \\beta} = \\sum_{i,j} \\frac{d \\mu_i}{d \\theta_\\alpha} C^{-1}_{i,j} \\frac{d \\mu_j}{d \\theta_\\beta} $$\n",
-        "\n",
-        "What we need in this expression, is the covariance matrix, which we already have\n",
-        "and the Jacobian of the mean with respect to parameters. Normally you would need to use finite differencing, but luckily we can get that easily with JAX:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WKn4COsdlKfs",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# We define a parameter dependent function that computes the mean\n",
-        "def mean_fn(p):\n",
-        "  cosmo = jc.Planck15(Omega_c=p[0], sigma8=p[1])\n",
-        "  # Compute signal vector\n",
-        "  m = jc.angular_cl.angular_cl(cosmo, ell, probes)\n",
-        "  return m.flatten() # We want it in 1d to operate against the covariance matrix"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Be381gp6Gjqx",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# We compute it's jacobian with JAX, and we JIT it for efficiency\n",
-        "jac_mean = jax.jit(jax.jacfwd(mean_fn))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "t3kVMfEaGyuJ",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 139
-        },
-        "outputId": "339ec1c1-4f47-43e9-f692-9c9070f5f0a2"
-      },
-      "source": [
-        "# We can now evaluate the jacobian at the fiducial cosmology\n",
-        "dmu = jac_mean(params)"
-      ],
-      "execution_count": 28,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-            "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-            "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-          ],
-          "name": "stderr"
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "H6uzzV-jHnNe",
-        "colab_type": "code",
-        "outputId": "ed61a0df-5f6f-485b-ebbc-33ddaaa15c20",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "dmu.shape"
-      ],
-      "execution_count": 29,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "(500, 2)"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 29
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "X9ZDB3RtHFnG",
-        "colab_type": "code",
-        "outputId": "07f53328-fb3a-4ead-bdaf-d6528136a8aa",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        }
-      },
-      "source": [
-        "# For fun, we can alsi time it\n",
-        "%timeit jac_mean(params).block_until_ready()"
-      ],
-      "execution_count": 30,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "10 loops, best of 3: 31.6 ms per loop\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ej3RdeaeHWy6",
-        "colab_type": "text"
-      },
-      "source": [
-        "Getting these gradients is the same order of time than evaluating the forward function!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "F3UMqqdLHQX7",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Now we can compose the Fisher matrix:\n",
-        "F_2 = np.einsum('ia, ij, jb', dmu, np.linalg.inv(cov), dmu)"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "zUv4GmcVH1z8",
-        "colab_type": "code",
-        "outputId": "4b7fb3e2-3271-4492-f781-45c205c2e57c",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 282
-        }
-      },
-      "source": [
-        "# We can now plot contours obtained with this \n",
-        "plot_contours(F, params, fill=False,color='black',lw=4);\n",
-        "plot_contours(F_2, params, fill=False, color='red', lw=4, linestyle='dashed');\n",
-        "xlabel('Omega_m')\n",
-        "ylabel('sigma8');"
-      ],
-      "execution_count": 32,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3xUVfrH8c8zCUloSQRCJ4aqxNAjvQmoCK7ACgKKiqKujbW7rq67/Oyru7oquq6ggigosBZcQSxL6C10Qg09oSR0khBCMuf3x72wM0MSMpjJTXner9e8mHtu4TuUPHPvufccMcaglFJKFZXL6QBKKaXKFi0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKLwEtHCLSX0S2ikiyiDyTz/poEZknImtEZL2IDLDba9rtGSIy3mef4fa2SSLy10DmV0opdSEJ1HMcIhIEbAOuBVKAlcBIY8wmj20+BNYYY/4pIrHAbGNMjIhUBdoBcUCcMeZhe/uawBqggzEmXUQmA58aY34pLEutWrVMTExM8X9IpZQqx1atWnXYGBPl2x4cwN+zI5BsjNkJICJfAIOATR7bGCDcfh8B7AcwxmQCi0Skmc8xmwDbjTHp9vLPwM1AoYUjJiaGxMTEX/FRlFKq4hGRPfm1B7JwNAD2eSynAJ18thkH/CgiY4GqQL+LHDMZuEJEYuzjDQZCiiGrUkqpInK6c3wkMMkY0xAYAEwRkQIzGWOOAQ8AXwILgd1AXn7bish9IpIoIonp6en5baKUUuoSBLJwpAKNPJYb2m2exgDTAYwxS4EwoFZhBzXGfGeM6WSM6QJsxepHyW+7D40x8caY+KioCy7RKaWUukSBLBwrgeYi0lhEQoARwCyfbfYCfQFEpCVW4Sj09EBEatu/XgY8CEws5txKKaUKEbA+DmNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOspHG/s2LxHZjdVxHiIig4Hr7Duy3haRNvZv84IxJt8zDqWUUoERsNtxS5P4+Hijd1UppZR/RGSVMSbet93pznGllFJljBYOpZRSftHCoZRSyi9aOJRSSvlFC4dSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyixYOpZRSfgkO5MFFpD/wNhAETDTGvOazPhqYDETa2zxjjJktIjWBmcDVwCRjzMMe+4wEngUMsB8YZYw5HMjPoX6900ePcvrIEc4cP07OyZOcOXGC3FOnOHvqFLmnTpEZHExa48aEhYVRtWpVr1d1Y6gSEUFYZCTi0u86SjktYIVDRIKA94BrgRRgpYjMMsZs8tjsT8B0Y8w/RSQWmA3EANnA80Cc/Tp3zGCsQhRrjDksIq8DDwPjAvU51MUZYzh06BApmzdz9rvvOLN9O7J3L2FpaUScOEGd7GwuM4bKhRzjF2BYAesWAd0AN5ABnAoK4mhYGJnVq3OmZk3cdeoQFB1N1dhYanboQL2OHQmpVq2YP6VS6pxAnnF0BJKNMTsBROQLYBDgWTgMEG6/j8A6g8AYkwksEpFmPscU+1VVRI7Y+yYH7BOofGVmZpKYmMjSpUtZunQpy5YtIy0tjcuB3Zd4zLBC1lW1f3UB1YHqeXnUz8yEzEw4eBCSkry2dwMHXC7SqlXjyxtvpEHXrsTFxREXF0fNmjUvMaFS6pxAFo4GwD6P5RSgk88244AfRWQs1s+HfoUd0BhzVkQeADYAmcB24KH8thWR+4D7AKKjoy8hvjrn1P79bHjtNc4mJBC1YwfvnT7N+8ZcsF0qkId1zdFfhZ2NVC1kXX5cQD23m3onT9J16lSypk49v65evXrExcUxODycVuHh1OzVi8tvuIGqtWtfQmqlKqaA9nEUwUisPoy/i0gXYIqIxBlj3PltLCKVgAeAdsBO4F3gj8BLvtsaYz4EPgSIj4+/8KecKlT28eOsffVVzNSptE1JoavHum7A+/nsk4t1ytgon3VngVMinBEhx+UiJyiIs0FBnA0OJjc4mEPVqzOkfXuys7PJzMw8/8rIyCBv/37OuN2E+vkZdgBZPm0HDhzgwIED3An0APjkE9zA9tBQDjRujKtHD6JvvZVGPXtqf4pSBQhk4UjF+2dIQ7vN0xigP4AxZqmIhAG1gLQCjtnW3nYHgIhMB54pxswVWl5ODuv+8Q8yJ06k9fbtdC5guy75tFWpUoWmTZuyIjOTnVWqYBo1IqRZM6rHxREVH09UXBw1QkIK/f0HXCRfbnY2mWlpHE9O5sSWLWRs387ZPXswKSmEHDpE9aNHqZWVRR23GxfWaWlB4jzeu4DmZ87QfMsW2LIFJkzgkMvFznr1OBMfT9SgQbQYPpxKVapcJKFSFUMgC8dKoLmINMYqGCOAW3222Qv0BSaJSEusS93phRwzFYgVkShjTDpWx/vmYk9ewZzNymLp/ffTZOpU2uflXXT7xkDHmBiu6NGDzp0706VLF1q1akVwcGBPYIPDwoiIjiYiOhr69ClwuzMnT3Jw5Uoik5N57fhxNmzYwMaNG9m8eTM5OTkEA1de5Peq43ZTJzUVUlPh22/JuvtukiIiOB4XR6Vnn6XjtddSqVKlYv18SpUVYvK5Vl1sBxcZAPwD67L3x8aYl0XkBSDRGDPLvpNqAlANq6P8aWPMj/a+u7E6v0OA48B1xphNInI/8AjW1Y89wGhjzJHCcsTHx5vExMSAfMayLC8nh6UPP0yjTz7h8tzcQrdNCQoiuV07Kl9/PU1uvZWo2NgSSll8zp49S3JyMpsTE6kxYQJhycnUPXyY6LNni/xA00mgJlAlPJxrr72WAQMG0L9/f+rXrx/A5Eo5Q0RWGWPiL2gPZOEoLbRweHO73cyYMYN6Y8bQMzOzwO3SRdgUF0eNhx4i7t57y+01/xN79rB9yhQy5s4lYuNGWhw/XmCH/FfAzfm0t2nThj9GR3PltdcSO2aMXtZS5YIWDi0cACQnJzNy5EgSExO5C/jYZ302kNikCZXvuYc2jz1GcFhhN8qWT2ezstg+cybpX39NyMqVND5wgLpu636Ne4CP8tknCDiM9STrCWBTgwbkXncdcc89x2VNm5ZYdqWKkxYOLRx88cUX3HfffZw6dQqwfthtBppjXfdbGhtL80mTqHf11Q6mLH2M203KokXsmTqVaYcPM2PBAtLTvbviugML89n3LLA2KoozgwbR6vnnrf4ZpcoILRwVuHBkZWXxyCOPMHHixAvWjRThgWbNiJk4kUY9ezqQruxxu92sWrWKOXPmMGfOHJYvX87LxvDHi+x3Blhbpw65N99M6+eeo7r2i6hSTgtHBS0cybNmsWr0aG49dgzfh2MGDRrE66+/TosWLRzJVl4cOXKE9W+8QaXp07li926iivB/6jSwrn593MOG0ebZZ/UBRFUqaeGogIVj0+TJNBg9mgjgz8CLdntoaChvvfUW999/PyLiYMLyx52by5bPPyft449ptGwZTXNyLrrPPSEhZAwZwt13302/fv1wldObEFTZo4WjghWOzZ99Rr077iDS/vvNw3pg5kCLFkyfPp02bdo4mq8iMG4327/+mv1vvUXMihXEnD17wTbZQG3glL0cExPDmDFjGD16NA0bNizJuEpdQAtHBSocO+fMIXLgQGr4/N3ObtmSnitWUE1Hji1xxu1m65dfcvDtt2m6ahWN7OdmvgZ+m8/2LpeLl9q2pc/119P+T3/S23uVIwoqHHpOXM4c3ryZoJtuuqBoJHTrxg0bN2rRcIi4XFw5ciS9ly2j4ZkzJH38MQkdOvBNAaP1Greb4atX0+nVVzlavToJXbuy57//LeHUSuVPzzjKkbycHJJq1aL1qVNe7QkdO9Jr6dJy+wBfWeZ2u1m4cCETJ05k5syZZGdnA9AHa44SX6svu4zsUaO4+rXX9CxEBZyecVQAi+6444KisbB5cy0apZjL5aJXr15MmTKF/fv3M378eNq0acO9BWzf/tgxur77Lunh4SQMHMiJPXtKNK9SoGcc5cbhzZsJvuqq853hYH07jdu7V2fDK2OMMWz+7DMOv/IK7bZsoXoh254CVrdtS5O339bncFSx0zOOcm7z4MFeReMUUO/HH7VolEEiQuztt9Nz82bkwAEWjh7NhgL+HqsDvdaupX6vXixt2JAN//pXyYZVFZIWjnJg40cf0WPbNq+2VQMGUC/+gi8KqoypVrcuPT75hFanTrH9q69YcNVVF0xOBdbwMV1SU7nq/vsZ3K4d06dPJ/ciIx4rdam0cJRxxu2GRx7xatsREkLXL790KJEKlOZDhtBz40ZOb93KvH79OJRPv9Us4Nu1axk+fDjNmjXj7bff5vTp0yUfVpVrWjjKuO1ff02cz9DoJ158US9RlWM1W7Tgmp9+IvLYMRbdcw9bPUYwftNjuz179vDoo4/SpEkTq4D43Dih1KXSwlHG7X/rLa/lVTVq0P7ppx1Ko0pSaHg43SdMoEVmJqtff51vLr883xF6Dx48yHuPPsqxyEjm33wzp48eLfGsqnzRwlGGGWN4Yv9+7gJ+AHKB07/N7zlkVZ6Jy0X7p55i8O7dJCUlce+99xIaGuq1zfNAfbebXl99xYmoKOYPHUr28ePOBFZlnt6OW4atWbOG9u3bn1+uV6kSm3btIrJBAwdTqdIgLS2Nv/3tb7z33ns0zMpiE1YHuqcDLhfbhgyh08SJhEVGOhFTlXJ6O2459KVPB3h8//5aNBQAtWvX5vXXX2fXrl08f+ONnMlnm3puN73+/W+O1azJ/GHDOHPyZInnVGWTFo4y7IcffvBaHj58uENJVGlVu3ZtRn33HZkbNpDQoUO+t/LWc7vpNXMmaTVrsmTsWNx6G6+6CC0cZZQxhl27dnm19e3b16E0qrSLioujd2JioQWkUW4uXcePZ0tEBGvffrvEM6qyQwtHGXX8+HFOelxaCAsLo06dOg4mUmXBuQKSsW4dCe3bk98THrFZWbR99FGW163LzjlzSjyjKv20cJRRKYmJDAOuBqKAmMsv19n8VJHVbt2a3qtWcWrdOua3asWFU0zB1YcOUX/AAKb36cNRvYVXedDCUUZl/vwz04EVQBrwif7HVpegduvW9Fq/ntQff2Spz40VLqAS8NK8eTRr1ox3332Xs/nMYqgqHi0cZVT21q1eyzlRUQ4lUeVBzLXX0iUlhQ0ffOA1oOJEYANw7Ngxfv/739OmTRvmzp3rWE5VOgS0cIhIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jIeI/tq4vIWo/XYRH5RyA/Q6mVlua16NbCoYpBq9/9jrgTJ1j22GNsqlSJ533Wb968mf79+zN8+HAO+NycoSqOgBUOEQkC3gNuAGKBkSIS67PZn4Dpxph2wAjgfbs9G+th1yc9NzbGnDLGtD33AvYAXwXqM5Rq1X1macjK7z4ZpfwnLhed33yTJidO8Pirr+Y73fC66dMJbtqUBSNH6u27FVAgzzg6AsnGmJ3GmBzgC2CQzzYGCLffRwD7AYwxmcaYRVgFJF8i0gKoDfkOz1PuuWrU8F7WAexUMQurXJlnnnmGbdu2cffdd3vdfPEBEGUMPb/4gqTLLmPbzJnOBVUlLpCFowGwz2M5xW7zNA4YJSIpwGxgrB/HHwF8aQoYM0VE7hORRBFJTE9P9+OwZUOQT+EI9hkhV6niUq9ePT766CNWrFhB+/btuQPo7bG+VUYGTYYNI6FTJzJ9LqGq8snpzvGRwCRjTENgADBFRIqaaQQwraCVxpgPjTHxxpj4qHJ4/T/E5zOF6KUqFWDx8fEsX76c20eMwPf8NhjovWIFRxs0YOULLzgRT5WgQBaOVKCRx3JDu83TGGA6gDFmKRAG1LrYgUWkDRBsjFlVPFHLntDatb2Xz+Q3GpFSxSs4OJh+06ZxavlyltWrd8H6Rrm5XP2Xv7AkOppDa9c6kFCVhEAWjpVAcxFpLCIhWGcIs3y22Qv0BRCRlliFoyjXlUZSyNlGRVClYUOv5TpZWdZsgEqVgPodO9J5/36WPfMM+4N8x92Frvv2Edq+PUt8ZqdU5UPACocxJhd4GJgLbMa6eypJRF4QkZvszZ4A7hWRdViFYPS5PgsR2Y01odloEUnxuSPrFip44bi8Xz+v8YZqu92kLlniWB5VMXV+9VWq791LQrt25PmsizSGru+8w+KYGI7rrbvlis7HUYati4igjcd4VUsefpiu777rYCJVkW36/HO47z5i8+lvO+Bysf/VV+mgs1OWKTofRzl0rGVLr+WzCxY4lEQpiL3tNlocPUpCPvN/1HO7+fAPf+DRRx/l9On8hlZUZYkWjjKs8jXXeC1HJSc7lEQpS3BoKL2/+469X33F1rCw8+3/AT4E3n77bTp06MDq1asdy6h+PS0cZViT227zWm6elcVpHexQlQLNhwwh5tAhEjp14iBwj8e6zZs306lTJ1555RVy9anzMkkLRxkWFRfHvMqV+RcwGogDEpYtczaUUrbQ8HB6L1vGztmzqRwT47UuNzeX5557jj49e5K6cqUzAdUl08JRxk297TbuByYD24BPp0xxOJFS3rrecAPr1q3j7rvvvmDdDUuXEtapE4mvvOJAMnWptHCUcaNGjfJa/uabbzh+/LhDaZTKX3h4OB999BFff/01tWpZz/jeBPwRqGkM7Z97joQ+fXTAxDJCC0cZ16NHD2I8LgNkZ2czffp05wIpVYjBgwezceNGbr/mGiZ7tLuA3vPmsap+fY5u3+5UPFVEWjjKOJfLxR133OHVNnny5AK2Vsp5derUYdKPP7L2uusueGjw6vR0slq2ZNOnnzqSTRWNFo5ywLdwrFqyhB16u6MqxVzBwfSeO5d1r79Ousdw7QAN8/JoeuedLBg1SofRKaW0cJQDTZs2pUf37nTGmifhILDv4YcdTqXUxbV/6ilyly/3mq4WIBTo+fnnLG7RgqzDh50JpwqkhaOc+L+WLVkK/A6IBNotXarjA6kyod7VV3PFgQPMb9PmgnXdd+xgb3Q0B/SW3VJFC0c5ET9uHEc9TvkjgLW33+5cIKX8EFKtGr3WrmXJ2LFk+Ky78vRp6NyZrXrTR6mhhaOcqF6/Puuvu86rrcPixRzZutWhREr5r+s773Dw22/ZERLi1V7P7ab+8OGsfPFFh5IpT1o4ypH4SZO8OhqrAxv0rEOVMc1uuonau3axvG5dr/aqwKvjxvGvf/3LmWDqPC0c5Ui1unVJGjjQq63jypWkb9zoUCKlLk31+vWJ37PHq9/jceBrt5v777+fP/zhD7j1jivHaOEoZzp+8gmHXP/7a60CbPK5XVepsiAoJIRea9cyf8gQ3gbe9lj3+uuvM2LECB2i3SFaOMqZKrVqsWXIEK+2TmvWsE/n6lBlVK+vviLmm2+oXLmyV/uMGTPo27cv6elFmW1aFadCC4eINBGRj0XkJRGpJiITRGSjiMwQkZiSiaj81WniRK95oMOAg0OH6sNUqswaNGgQ8+fPp06dOl7tS5cu5dMrr2T/8uUOJauYLnbGMQlYCWQAy4AtwA3AD8DHAU2mLllYZCQ7fC5PXZ2ezrKnnnIokVK/3tVXX82yZcto6THz5evAE0ePktu9OymLFjkXroIpdM5xEVljjGlnv99rjInOb11pV17nHC+MOzeXDTVres1JftDlovKuXURERxeyp1Kl2/Hjx7n5t7+lz7x5POfRnhoURO7cuVzet69j2cqbS51z3C0iLUTkaqCKiMTbB2sGBBW+q3KSKziYqlOmkOPRVtftZt311zuWSaniEBkZyZzvv6dPgwZe7Q3y8gi57jp2zpnjULKK42KF42ngO+BTYDDwRxFJBpYAzwc4m/qVmt10E0u6dvVqy9qyhZ++/96hREoVj5DKlbk6OZnFPmfP9dxuqt14IztmzXIoWcVQ6KWqfHcQqQUcM8b4johcalXES1XnnD56lAP16lEzJ4fHsTqmGjVqxMaNGwkPD3c6nlK/Sl5ODktiY+mxY4dX+2ERjn75JS2GDXMoWflwqZeqPA8QJyK3AAOA20REHw4oAyrXqEHGRx/RWuT83Qz79u1j7Nix+PulQanSJigkhG5btrDgiiu82msZQ63hw9n8+ecOJSvfilQ4ROQvwLv26xqsmxluCmAuVYxajxrFLU884dX26aefMnHiRIcSKVV8XMHBdN+4kflxcV7tNYyh/qhRbJs506Fk5VdRzziGAn2Bg8aYu4A2WAOwFkpE+ovIVhFJFpFn8lkfLSLzRGSNiKwXkQF2e027PUNExvvsEyIiH4rINhHZIiI3F/EzVGgvvPCC122MAA8//DCrVq1yKJFSxccVHEzPdetIaOd9o2cEED58OCmLFzsTrJwqauE4bYxxA7kiEg6kAY0K20FEgoD3sJ77iAVGikisz2Z/Aqbbt/WOAN6327OxOt+fzOfQzwFpxpgW9nHnF/EzVGiVK1dm5syZVK1a9XxbTk4OU/v355jP9WGlyiJxueiVmEhCp05e7XXdbnL69OHItm0OJSt/ilo4EkUkEpgArAJWA0svsk9HINkYs9MYkwN8AQzy2cYA53poI4D9AMaYTGPMIqwC4utu4FV7O7cxRqcHK6LY2FgmTJgAQGWspzv/fvgwyV264M7NdTKaUsVCXC56LVnC/LZtvdqb5OSwv0MHMo8edShZ+VKkwmGMedAYc9wY8wFwLXCnfcmqMA2AfR7LKXabp3HAKBFJAWYDYws7oF28AF4UkdX20Cd1CttHeRs5ciTPjh7NUuBOu+3q9HQW9O/vZCylio24XPRYuZIljbwvinyWkcHw228nV78k/Wr+3FXVWkRuAtoDzUTkt8Xw+48EJhljGmLdrTVFRArLFAw0BJYYY9pjnfX8rYC894lIoogk6iBo3v7y7ru4fOZ47vnLL6x67TWHEilVvFzBwXTYuJHVkZHkYn1Jeh34fvZsfve73+kdhb9SUe+q+hjrEYCbgd/Yrxsvslsq3v0gDe02T2OA6QDGmKVY4/HVKuSYR4As4Ct7eQZWIbuAMeZDY0y8MSY+KirqIlErlpBq1aj5888c9pj0yQXEPPssu3/6yblgShWj0PBwmq5fz/1Nm/KpR/vHH3/M88/r88u/RlHPODrbP4TvNMbcZb/uvsg+K4HmItJYREKwOr99H+fci3W3FiLSEqtwFHh6YKyvCd8Bve2mvsCmIn4G5aF+p07sfe01PMfLrWkMrgEDSFu/3rFcShWniEaNeHHhQmJiYrzaX375ZZ1J8FcoauFYms8dUYUyxuQCDwNzgc1Yd08licgL9iUvgCeAe0VkHTANGG0XB0RkN/AmMFpEUjx+/z8A40RkPXC7fQx1Cdo//TQL+vXzaovOzeVI586c2r/foVRKFa969eoxd+5catXyvpgxduxYVi5c6FCqsq1IQ46ISC+ss4WDwBlAsE4AWgc2XvGoyEOOXIxxu1ncvDndd+70al9Vowat9uwhxKcvRKmyavny5fTp04esrCzA+sY5NiiIaklJ1PR58lxZfu2QIx9hfbvvz//6N35TfPGUU8TlotOGDaz0+TbW4ehRVsbF6W26qtzo1KkTkydPJhyYiXVXzeV5eezq1o28nJyL7K08FbVwpBtjZhljdhlj9px7BTSZKjGVqlSh5YYNJHk8HAjQbc8eFnTu7FAqpYrf0KFDmdqtG57DTcQfOcLC665zLFNZVNTCsUZEporISBH57blXQJOpElWtbl3qrFzJrkqVvNp7r1pFwm/05FKVH9f9+CPrq1f3aus5fz4rX3jBoURlT1ELR2Wsvo3rKPrtuKqMqdWyJcE//8whl/c/izb/+Q9T3nnHoVRKFa9KVapQOyGBdJ/b0ZuOG6djWhVRUZ8cvyuf18Vux1VlUKOePTn22Wecm3D2FNZgY3c88ggffPCBg8mUKj5127cn9e9/x3NSoRrGcPK668jJyHAsV1kRXJSNRCS/r5sngERjzLfFG0k57cqRI1mdkkLM009zE7Dcbn/ggQfIycnh97//vZPxlCoWbR97jISffqK3x1SzsVlZJAwYQO8FCxxMVvoV9VJVGNAW2G6/WmM9CT5GRP4RoGzKQe2feopln3/OCp8+j0ceeYQ33njDoVRKFa9e//kPy+vW9WrrvnChTgB1EUUtHK2Ba4wx7xpj3gX6AVcCQ7D6PVQ5NODWW/nmm28IDQ31an/66ad59f/+z6FUShUfcbm4YvFiDnr06wUDrnvu0UtWhShq4bgM8HwSrCpQw553/Eyxp1KlxoABA/juu++oXLny+bYqQPdx40jo2RPjdhe8s1JlQGSTJux99lmvtiuys1midxMWqKiF43VgrYh8IiKTgDXAGyJSFfg5UOFU6XDttdcye/ZsqlatShjWEAI9gN4LFzK/a1ctHqrM6/jiiyxq3NirrUtCAjs9+j/U/xRpyBEAEamHNTkTwEpjTJkZzEiHHCkeixcv5lDv3vzW52nyBbGxdF21iuCwMIeSKfXrHduxg7MtWlDb44vQ6ssuo93hw4iryDNQlCuXNOSIiFxp/9oeqIc1MdM+oK7dpiqQbt260eKDDzjh095z0ybWREeTcfCgI7mUKg6XNW1K8oMPnl8+BUw+dozPpkxxLlQpVegZh4h8aIy5T0TmeTSf38EY0yeQ4YqLnnEUr82ffUbdO+7gMp9/O5srV+ayRYuo216/U6iyybjdrI6KYvfRozyCNYFQ3bp12blzp1c/X0VxSWccxpj77Lf/BAYZY64B5mE9w/FksadUZULLUaM4/O9/kxoU5N1++jTujh3Z9u9/O5RMqV9HXC4uW7CAUWFh52edO3jwIP/85z8dzVXaFPXC3Z+MMSdFpDvQB5iIVUxUBdV8yBCCVqxgs8+3sPp5edQdOpRVr77qUDKlfp0mV111wUOur732GpmZmQ4lKn2KWjjOPZk/EJhgjPkeCAlMJFVW1G3fnkY7d7Kidm2v9nCgzbPPsuCOO5wJptSv9NRTT1HNYy6a9BMzqHIAABs5SURBVPR0xo8f72Ci0qWohSNVRP4FDAdmi0ioH/uqcqxa3bp02LeP+a1aebUHAz2nTCGhSxed00OVObVq1eKRRx7xanv9r3/l5JEjDiUqXYr6w/8WrClgrzfGHAdqAE8FLJUqU4JCQui5di3zBw/G94mO3suW8UVcHMePH3ckm1KX6vHHHyc8PBywZrD74dgxVt9yi7OhSomijo6bZYz5yhiz3V4+YIz5MbDRVFkiLhe9vv6aFU8/TZZHewrw6NatxMfHs3btWqfiKeW3GjVq8NKdd7IYmANcDbT77385sUfnsNPLTapYdf7rX9n18ceki5ADDAXSgR07dtClSxcmTZrkbECl/HDHk0/S0mPejghgzUMPOReolNDCoYrdVXfdRc7ixfyladPzQ7IDZGdnc9ddd3HfffeRnZ3tWD6liioiOpp1fft6tTX4+ecKP8yOFg4VEA26dGFcUhIPPPDABesmTJjAg23asE/nPFBlwFVvvYXn7R3Nz5xhy7RpjuUpDbRwqIAJDQ3l/fff59NPP/V66rYR8Pq2bVTr3ZuVOjy7KuWi4uJY7XPLeVoFn5NGC4cKuNtvv51ly5bRrFkzQoAZQC3gMmO4etw4Enr0IFcvXalSLO+227yW49avr9DzdWjhUCWidevWJCYm8lbbtnTyWdd70SK21KrF7p9+ciSbUhfT7s9/5rhHJ3lNY1jz8ssOJnKWFg5VYiIiInhg1SoSBgw4PxTBOXGZmURddx3zb7utwnc8qtInLDKS9bGxXm1m8mSH0jgvoIVDRPqLyFYRSRaRZ/JZHy0i80RkjYisF5EBdntNuz1DRMb77JNgH3Ot/arte1xVeonLRe/vv2fDW2+R5jPHQVWg19SprKxbl0P6zIcqZWo89pjXcpsDBziblVXA1uVbwAqHiAQB7wE3ALHASBGJ9dnsT8B0Y0w7YATwvt2eDTxPwSPw3maMaWu/0oo/vQq0to8+iqxfz/K6dS9Y1zE9neD27Vn6lA5OoEqPq+66iwMeX3YqA9tnznQukIMCecbREUg2xuw0xuQAXwCDfLYxWGPigfVszX4AY0ymMWYRVgFR5VTUVVfRMTWVhaNHc8pnXU1j6PK3v7GwWTNO7N3rSD6lPInLxe569bza0mfNciiNswJZOBpgzRZ4Tord5mkcMEpEUoDZwNgiHvsT+zLV8yIePVYeROQ+EUkUkcT09HQ/o6uSIi4XPT75hGPz5rEuPPyC9T127OBkkyasfecdB9Ip5S2nXTuv5UorVzqUxFlOd46PBCYZYxoCA4ApInKxTLcZY1oBPezX7fltZIz50BgTb4yJj4qKKtbQqvhF9+5NXHo6Cf37k+OzrlFeHuMfeYQHH3xQB0tUjqoxcKDXcnRqagFblm+BLBypWM96ndPQbvM0BpgOYIxZCoRh3eJfIGNMqv3rKWAq1iUxVQ4EhYTQe84cdn3xBdtDQ8+3zwI+Av75z3/SsmVLpk+fTmFTHisVKM1HjCAH2IN17f2NvDwOVMDiEcjCsRJoLiKNRSQEq/Pb94LgXqAvgIi0xCocBV5XEpFgEallv68E3AhsDEB25aArhg+n0cGDJHTowEHgXo91Bw8eZPjw4QwcOJBdu3Y5FVFVUGGRkfymfXtisC6XvAMsr4CXqwJWOIwxucDDWPN4bMa6eypJRF4QkZvszZ4A7hWRdcA0YLSxv0qKyG7gTWC0iKTYd2SFAnNFZD2wFusMZkKgPoNyTlhkJL0TE0n+7jvCmzW7YP2cOXO4JjaWeTfeWGFviVTOiG7f3mv54MGDDiVxTnAgD26MmY3V6e3Z9meP95uAbgXsG1PAYTsUVz5V+nW/8UY29OvHK6+8wmuvvcbZs2fPr3s5O5trvv+ebTVrkvPuu8Tdc4+DSVVFERkZ6bVcEfvdnO4cV+qiwsLCeOGFF1i3bh09evQAoB9wbvSgFtnZxN57Lwvi4nSSHRVwERERXssnTpxwKIlztHCoMqNly5YkJCTw0cSJvBYU5LXOBfRMSuJMkyYsvOsunedcBYwWDi0cqoxxuVzcPWYMl69fz+ImTS5YX9vtpsekSWwND2fd+PH5HEGpX8f3UtUJvVSlVNlQKzaWbjt2sOaNN9hdqdIF61uePk2bsWNZ2qiRThililXj1FQ2YN0SegJ45JdfHE5U8rRwqDKt3ZNPUjctjYSePTmdz/ouKSlE9epFQseO2v+hioXs20cc1kNq4YDb57JpRaCFQ5V5YZGR9J4/nyOLFrGkUaML1wO9V64kr3Fj5t52Gzk5vs+mK1V0Z7dv91rO9hm/qiLQwqHKjYbdutF1717Wv/8+m6pUuWB9DWOYPHWqPn2ufhXXvn1eyxIT40gOJ2nhUOVO6wce4MoTJ1h0zz1ew2AnYg0TsXPnToYPH0779u359ttvtYAov1RN857JIezKKx1K4hwtHKpccgUH033CBCIOHSKhXz9OYU3u4lki1q5dy+DBg+nQoQP/fe89nXlQFUmNU96TAFzmM2JuRaCFQ5VrVWrVovdPP5G9bRtXPfggQfl0ZKasWUPnhx9mS7VqLH/uOS0gqkDHd+2iocfoBQB1Ola8cVa1cKgKIap5c9577z2SkpIYNmyY17qngSpYt/B2euUVtlSrxornn9cCoi6w4cUX8bz5e1elSkRERzuWxylaOFSFcsUVVzB9+nTWr1/P0KFDqQ086LNNy9On6fjSS2yuXp0Vf/6zFhB1XmWfGf/2dO7sUBJnaeFQFVKrVq2YMWMG83/4gXUNfCemtMRmZdHxxRfZXL06S8aO1VF4K7gjW7fS9sgRr7aGTzzhUBpnaeFQFdqV119Pl5QUtk2fzrL69fPdJjYri67jx5MWHk7CjTfqg4QVVNKLL3oNJ749NJRmgwY5lsdJWjiUAloMG0bn1FS2fvklywp4oKtBXh69v/8eV0wM89u106FMKpCcjAwazJjh1ZbaLd8ZISoELRxKebjillvovH8/W7/4osACUh3otXYtb/TuzbBhw1i6dGnJhlQlbsnw4TT1GXHg8qefdiiN87RwKJWPK4YPp/P+/eycPZsFsbH49m4cBz42hpkzZ9K1a1e6dOnCjBkzyNXh3Mud1NRUJv3yC4c82ha2aEHj6693LJPTtHAoVYgmN9xAz6QkTm/Zwry+fTlkP4n+LyDTY7tly5Zxyy23EBMTw5RbbyVl0SJH8qri99RTTzH5zBmuAP4BpIvQ8ptvnI7lKC0cShVBzSuu4Jqffyby2DEWjhnDzwUMM3E4NZUB06ZRv0cPEmvVYunjj5OTkVHCaVVxmT17NtOmTQOsIdQfA77529+o1bKlo7mcpoVDKT+EhofTY+JEfty0iZ9++okbbrjBa/1goCbWf6z4I0fo8tZbnAwPJyE+nh3/+Y8TkdUlWr9+PSNGjPBqa9u2LXc/8ohDiUoPLRxKXQIRoV+/fsyePZukpCTuvfdeqlSpwj35bFvLGHqvWkXT3/yG9eHhLLr3XrIOHy7xzKro9uzYwcCBAznlMS6ViPDee+/lO2xNRaOFQ6lfKTY2lg8//JAD+/dT6fbbSapatcBtW586RfeJEzkbFcXCFi1IfPllfbCwlNm/fDk5LVsSl5Li1f7mm2/StWtXh1KVLlo4lCom4RER9Pr0U67KyGDrl18yv1Urjovku20E0GP7duL/9CdOVqvGgpYtWTBrFnl5eSUbWnnZNnMmZ7t3p/nZs3wD3Gi3P/TQQzyil6jOk4owF0F8fLxJTEx0OoaqgE4fPcrq556j6rRptD1xosDt0oD6QK06dRg6dCjDhw+nW7duuFz63a4kGLebhaNG0XHaNMI82nOA/+vbl//74QeCg4ML2r3cEpFVxpj4C9q1cChVMnbNncueP/+Zq1auJMrn/937wEM+2zdo0IBhw4ZxR9eutBkyBFcF/MFVEk7s3cumbt3o4nNpCmBpgwbEb99OpcqVHUjmvIIKR0C/zohIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jI+AKOPUtENgYyv1LFqfH119N7+XIiMzJIfOklFjZvfv5S1pf5bJ+amsqH//gHLW65hSMhISxq2pQlY8dy1GfOa3XpNk6cyPGmTfMtGgtbtCB+27YKWzQKE7AzDhEJArYB1wIpwEpgpDFmk8c2HwJrjDH/FJFYYLYxJkZEqgLtgDggzhjzsM+xfwsMBVobY+IulkXPOFRplZORwdq//533tm/n61mzvO7iARgGTPfZJw/YVK0aRzp2pPadd3Llrbfq2Yifts2cydHf/57OBw5csO4UsP7BB+n23nslH6yUceKMoyOQbIzZaYzJwZru2XcoSQOE2+8jgP0AxphMY8wiINv3oCJSDXgceClQwZUqKSHVqtHxL39h8mefkZaWxjfffMPIkSOpat+ZNTyffYKAVhkZ9P7vf4m98049G/HDztmzWRIdbQ1qmU/R2FK5Mkd+/FGLxkUEsnA0APZ5LKfYbZ7GAaNEJAWYDYwtwnFfBP4OFwwfpFSZFhYWxqBBg5g6dSppaWnMnDGDmjExFNylbokyhu47d9J1/HhqtGhBclgYC1u25Ks33mDHjh1UhH7MwhhjWLFiBf+Ji+PygQPpum9fvtvNb9WKmP37ibn22hJOWPY4fcvGSGCSMaYhMACYIiIFZhKRtkBTY8zXFzuwiNwnIokikpienl58iZUqAVWqVOHmoUPpvWsXVTIzWffOOyR07szWsLCL7tvszBl6bNnCk08/TbNmzahXrx4333wzb775JsuXLyfHZ5TX8mrTpk08//zzNG/enE6dOrEmKYn8Ht3bWLUqq//6V3qtX09YZGSJ5yyLAtnH0QUYZ4y53l7+I4Ax5lWPbZKA/saYffbyTqCzMSbNXh4NxJ/r4xCRB4Dnse6SCwZqA0uMMb0Ly6J9HKo8OZCYSPL48QT//DOxqalE5LcN1u29+XkxOJgbq1blePPmBLdtS81evYgZMIDKNWoEMHXgGbebPb/8wtdLljD5669Zt26d1/orgc0ey1sqV+bkk09y9bhxiN72nK8Svx1XRIKxOsf7AqlYneO3GmOSPLaZA3xpjJkkIi2BX4AGxg7lWzh8jh8D/Ec7x1VFdjYri6QJEzg+bRp116+nxenTuICZWB3r+VkA9PBpywP2VqrEoagosps1I7RDB+r060d0nz4EF+EsxwmZaWlsnzaN43PmUHndOpocOkSUMTwAfFDAPmuAaqGhpI8dS6dXX9WbCi7Ckec47Ntr/4HVn/exMeZlEXkBSDTGzLLvpJoAVMPqKH/aGPOjve9urI7zEKzpD67zuSMrBi0cSnk5sXcv26dMYU1yMtP27GH58uVkeQxpEoI1ymtRS0E2sDcsjGMREZxs0IB1I0dy+eWXEx0dTYMGDahTpw6VKlUKwCexuHNzObxpE2krV3IqKYkz27bh2rWLqF27aH76NPn92F8A9PJpCwkJYeDAgfyub1/63XsvQSEhActcnugDgFo4VAV09uxZ1q1bx+LFi1m8eDFZ8+bxn0scYDEJ6/54TyJCVFQU/zp7lkYinA0NJTcsDHdYGO4qVaBKFahaFalenaDwcFzVq0NuLnkZGbhPnyYzKIg1sbFkZ2eTnZ3N6dOnycjIICUlhXcXLqRxTk6Ri5ynaCDV5aJv376MHDmSIUOGEKn9F37TwqGFQymM203qkiXsnT6dnNWrqbxjB3UPH+byIsxcOBsYWMC6ZKDpJeTZALQuYN0mwN9ZLzKA7ZGRbL3nHno/8QR169a9hFTqnIIKh17gU6oCEZeLht2707B7d6/2jIMH2TNnDkcXLCBv/Xqq795Nw+PHqeN2n99mTyHHzX929osr7GxiLxcvHLsrVSKlUSPcHTtSZ/Bgmg4aRLuwMNpdYh5VNFo4lFJUq1uXq+66C+66y6v9yNatHFi0iJMbN1I9N5eHjGH37t2kpKRw4MAB0tLSiACqXOLvW1jhOFeoTgAHw8I4ER7O6Tp1MA0bUqVDB5rceisxLVsSc4m/t7p0eqlKKXXJzp49y6GUFE4kJJC1bx+5J06Qd/IkeadOYU6dgsxMyMjAdfo0ruxsgs6cwbhc5IWEYEJDya5WjYS+fQkLCyMsLIzKlSsTFhZGvXr1aFK9Og0aNyYiOtrpj1lh6aUqpVSxq1SpEg0bN6Zh48aXfIzrijGPKhn61ItSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyS0ALh4j0F5GtIpIsIs/ksz5aROaJyBoRWS8iA+z2mnZ7hoiM99nnBxFZJyJJIvKBiAQF8jMopZTyFrDCYf9Afw+4AYgFRopIrM9mfwKmG2PaASOA9+32bOB54Ml8Dn2LMaYNEAdEAcMCEF8ppVQBAnnG0RFINsbsNMbkAF8Ag3y2MUC4/T4C2A9gjMk0xizCKiDeOxhz0n4bDITYx1BKKVVCAlk4GgD7PJZT7DZP44BRIpICzAbGFuXAIjIXSANOATML2OY+EUkUkcT09HQ/oyullCqI053jI4FJxpiGwABgiohcNJMx5nqgHhAK9Clgmw+NMfHGmPioqKjizKyUUhVaIAtHKtDIY7mh3eZpDDAdwBizFAgDahXl4MaYbOBbLrz8pZRSKoACWThWAs1FpLGIhGB1fs/y2WYv0BdARFpiFY4CryuJSDURqWe/DwYGAlsCkF0ppVQBggN1YGNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOrlHG2MMgIjsxuo4DxGRwcB1wBFgloiEYhW9ecAHgfoMSimlLiT2z+lyLT4+3iQmJjodQymlyhQRWWWMifdtd7pzXCmlVBmjhUMppZRftHAopZTyS4Xo4xCRdGCP0zkKUAs47HQIP2jewCtrmTVvYDmZ93JjzAUPwlWIwlGaiUhifp1PpZXmDbyyllnzBlZpzKuXqpRSSvlFC4dSSim/aOFw3odOB/CT5g28spZZ8wZWqcurfRxKKaX8omccSiml/KKFQymllF+0cBSzIsyz/riIbLLnWP9FRC73WJcnImvt1yyPdhGRl0Vkm4hsFpHfl/K8Cz3a94vIN6U8b18RWW23LxKRZqU8bx8770YRmWyPFF0a8kaLyI/2v9FNIhJjtzcWkeX2Mb+0R8suzXkfto9nRKRI0zw4nPdz+5gbReRjEalUnJnzZYzRVzG9sEYB3gE0wZrWdh0Q67PNNUAV+/0DwJce6zIKOO5dwKeAy16uXZrz+uz/b+CO0pwX2Aa0tN8/iDW5WKnMi/Vlbx/Qwl5+ARhTSvImANfa76t5bDcdGGG//wB4oJTnbQfEALuBWsWRNcB5BwBiv6YV159vYS894yheF51n3RgzzxiTZS8uw5rg6mIeAF4wxrjtY6SV8rwAiEg41gyNxXXGEai8BmsIf4AIYH8pzlsTyDHGbLOXfwJudjqviMQCwcaYn+ztMowxWSIiWP8Gzk3xPBkYXFrz2u/XGGN2F1PGksg729iAFfjxf/RSaeEoXkWZZ93TGGCOx3KYWPOkLxNrDpJzmgLD7XVzRKR5Kc97zmDgF2PMyV8fFQhc3nuA2SKSAtwOvFaK8x4GgkXk3JPEQ/GeadOpvC2A4yLylYisEZE3RCQIq9AdN8bkFvGYTucNpIDmtS9R3Q78UIyZ8xWwiZxU4URkFBAP9PJovtwYkyoiTYD/isgGY8wOrLnVs40x8SLyW+BjoEcpznvOSGBiSeY8x8+8jwEDjDHLReQp4E2sYlIq84rICOAtsSY0+xHIK8msBeQNxvo32Q5rZs8vgdFY0zs7zo+8HzmRz9cl5n0fWGCMWRjofHrGUbyKMs86ItIPeA64yRhz5ly7MSbV/nUn1vXMdvaqFOAr+/3XQOtSnhe7U7Ej8H0xZQ1IXhGJAtoYY5bbm30JdC2tee3lpcaYHsaYjsACrD4ap/OmAGvtyzC5WJcn22PN2hnp0YGf7zFLUd5AClheEfkLEAU8HqDs3gLdiVKRXljfCnYCjflf59dVPtu0w+oga+7TfhkQar+vBWzH7jjDunRyt/2+N7CyNOe12+4HJpf2P1/7mIf5X2fzGODfpTWvvVzb/jUU+AXoUwryBtnbR9nLnwAP2e9n4N05/mBpzuuxzW6Kt3M8UH++9wBLgMrFlfWin6WkfqOK8sK6w2Gb/Zf/nN32Ata3B4CfgUPAWvs1y27vCmyw/3FswONOGSAS65v7BmAp1jfkUpvXXp8A9C8jf75DPNYlAE1Ked43gM3AVuDR0vDna6+7Flhv550EhNjtTbA6bZOxikhoKc/7e6xv+LlYN0pMLOV5c+3jndvnz8X9/873pUOOKKWU8ov2cSillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VCqECLSUES+FZHtIrJDRN4uztFdlSqLtHAoVQB7gL6vgG+MMc2xxguqBrzsaDClHKaFQ6mC9cEaI+wTAGNMHta4VneLyIMi8o2I/CQiu+05HB63B6BbJiI1AESkqYj8ICKrxJqn5EqP9mUiskFEXhKRDLu9mj0Pw2p73aACsiEiMSKyRUQmiTVXy+ci0k9EFttnSB0D/iekKiQtHEoV7CpglWeDsUb63Ys1fEQc8FvgaqyzkCxjTDusp/vvsHf5EBhrjOkAPIk1EB3A28DbxphWWE8pn5MNDDHGtMeam+Hv9plPQZoBfweutF+3At3t3+vZS/jMSl2Ujo6r1KWbZ4w5BZwSkRPAd3b7BqC1iFTDGjpkhsfP/lD71y78b16KqcDf7PcCvCIiPQE31rDbdYCDBWTYZYzZACAiSVjD2BsR2YA1GZFSxU4Lh1IF24Q138V59uRU0VjjA53xWOX2WHZj/d9yYc1F0daP3/M2rFFOOxhjzorIbiCskO0vlkGpYqeXqpQq2C9AFRG5A8CeOOfvWAPMZRWyH3D+stYuERlm7y8i0sZevYz/zdw3wmO3CCDNLhrXAJcXxwdRqjhp4VCqAMYaAXQIMExEtmONapqNf30HtwFjRGQdkMT/pgp9FHhcRNZj9VOcsNs/B+LtS013AFt+9QdRqpjp6LhKOUBEqgCn7f6IEcBIY0yBd1ApVZroNVClnNEBGG/fMXUcuNvhPEoVmZ5xKFXKiUhNrP4WX32NMUdKOo9SWjiUUkr5RTvHlVJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX/4fiMNLKoYl9uIAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "51gfhl9cIzMC",
-        "colab_type": "text"
-      },
-      "source": [
-        "The red dashed is our second derivation of the Fisher matrix using the jacobian, the black contour underneath is our first derivation simply taking the Hessian of the likelihood.\n",
-        "\n",
-        "They agree perfectly, and they should, because they are both analytically computed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JrpDmbNfJUJ4",
-        "colab_type": "text"
-      },
-      "source": [
-        "## Conclusions and going further\n",
-        "\n",
-        "We have covered some of the most important points of `jax-cosmo`, feel free to \n",
-        "go through the [design document](https://github.com/DifferentiableUniverseInitiative/jax_cosmo/blob/master/design.md) for background and further explanations of how things work. You can also follow this [JAX document](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) to go deeper into JAX.\n",
-        "\n",
-        "\n",
-        "`jax-cosmo` is still very young and lacks many features, but hopefuly this notebook demonstrates the power of automatic differentiation, and given that the entire code is in simple Python, feel free to contribute missing features that would be necessary for your work ;-) "
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[?25l\r",
+      "\u001b[K     |█▌                              | 10kB 28.3MB/s eta 0:00:01\r",
+      "\u001b[K     |███                             | 20kB 3.0MB/s eta 0:00:01\r",
+      "\u001b[K     |████▍                           | 30kB 4.0MB/s eta 0:00:01\r",
+      "\u001b[K     |█████▉                          | 40kB 4.3MB/s eta 0:00:01\r",
+      "\u001b[K     |███████▎                        | 51kB 3.5MB/s eta 0:00:01\r",
+      "\u001b[K     |████████▊                       | 61kB 3.9MB/s eta 0:00:01\r",
+      "\u001b[K     |██████████▏                     | 71kB 4.3MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████▋                    | 81kB 4.5MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████                   | 92kB 4.9MB/s eta 0:00:01\r",
+      "\u001b[K     |██████████████▌                 | 102kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████                | 112kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████▌              | 122kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████             | 133kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████▍           | 143kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████▉          | 153kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████████▎        | 163kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████▊       | 174kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |██████████████████████████▏     | 184kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |███████████████████████████▋    | 194kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |█████████████████████████████   | 204kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |██████████████████████████████▌ | 215kB 4.8MB/s eta 0:00:01\r",
+      "\u001b[K     |████████████████████████████████| 225kB 4.8MB/s \n",
+      "\u001b[?25h  Building wheel for jax-cosmo (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "# Installing jax-cosmo\n",
+    "!pip install --quiet jax-cosmo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "xvIGKcbXFEFO"
+   },
+   "source": [
+    "For efficient computation on GPU (if you have one), you might want to make sure that JAX itself is installed with the proper GPU-enabled backend. See [here](https://github.com/google/jax#installation) for more instructions.\n",
+    "\n",
+    "Now that `jax-cosmo` is installed, let's import it along with JAX tools:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "AZkSj6XNcFkE",
+    "outputId": "6a325574-7540-4d62-bbfc-fcfaf00f009d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pylab inline\n",
+    "import jax\n",
+    "import jax_cosmo as jc\n",
+    "import jax.numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "bKuyf8bzFmSR"
+   },
+   "source": [
+    "**Note that we import the JAX version of NumPy here**. That's all that you have to do, any numpy functions you will use afterwards will be JAX-accelerated and differentiable.\n",
+    "\n",
+    "And for the purpose of this tutorial we also define a few plotting functions in the cell bellow, please run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "cellView": "form",
+    "colab": {},
+    "colab_type": "code",
+    "id": "8yvBIf1mm_h-"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Defining some plotting functions [run me]\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.patches import Ellipse\n",
+    "\n",
+    "def plot_contours(fisher, pos,  nstd=1., ax=None, **kwargs):\n",
+    "  \"\"\"\n",
+    "  Plot 2D parameter contours given a Hessian matrix of the likelihood\n",
+    "  \"\"\"\n",
+    "  \n",
+    "  def eigsorted(cov):\n",
+    "    vals, vecs = linalg.eigh(cov)\n",
+    "    order = vals.argsort()[::-1]\n",
+    "    return vals[order], vecs[:, order]\n",
+    "\n",
+    "  mat = fisher\n",
+    "  cov = np.linalg.inv(mat)\n",
+    "  sigma_marg = lambda i: np.sqrt(cov[i, i])\n",
+    "\n",
+    "  if ax is None:\n",
+    "      ax = plt.gca()\n",
+    "\n",
+    "  vals, vecs = eigsorted(cov)\n",
+    "  theta = degrees(np.arctan2(*vecs[:, 0][::-1]))\n",
+    "\n",
+    "  # Width and height are \"full\" widths, not radius\n",
+    "  width, height = 2 * nstd * sqrt(vals)\n",
+    "  ellip = Ellipse(xy=pos, width=width,\n",
+    "                  height=height, angle=theta, **kwargs)\n",
+    "\n",
+    "  ax.add_artist(ellip)\n",
+    "  sz = max(width, height)\n",
+    "  s1 = 1.5*nstd*sigma_marg(0)\n",
+    "  s2 = 1.5*nstd*sigma_marg(1)\n",
+    "  ax.set_xlim(pos[0] - s1, pos[0] + s1)\n",
+    "  ax.set_ylim(pos[1] - s2, pos[1] + s2)\n",
+    "  plt.draw()\n",
+    "  return ellip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "nXjimh6KGFWm"
+   },
+   "source": [
+    "## Defining a Cosmology and computing background quantities\n",
+    "\n",
+    "We'll beginning with the basics, let's define a cosmology:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "R0wxmnuBG9EC"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a cosmology with default parameters\n",
+    "cosmo = jc.Planck15()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "by_0gcYKG9Ag"
+   },
+   "outputs": [],
+   "source": [
+    "# Alternatively we can override some of the defaults\n",
+    "cosmo_modified = jc.Planck15(h=0.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "d-VI1BFuI3w1",
+    "outputId": "8ed049c5-20bc-4874-87a2-db3e4ed49a4e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.6774"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Parameters can be easily accessed from the cosmology object\n",
+    "cosmo.h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "8RhqkfHjHgTT"
+   },
+   "source": [
+    "All background quantities can be computed from the `jax_cosmo.background` module, they typically take the cosmology as first argument, and a scale factor\n",
+    "argument if they are not constant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 403
+    },
+    "colab_type": "code",
+    "id": "bdcm_oReG89o",
+    "outputId": "07e4ff00-3bfb-4bfd-bc61-70350a062435"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lib/xla_bridge.py:116: UserWarning: No GPU/TPU found, falling back to CPU.\n",
+      "  warnings.warn('No GPU/TPU found, falling back to CPU.')\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAEICAYAAACnL3iHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3xV9f3H8dcnCYQ9QsIMEJCNgECYggsH7l1HrWhtqavqT2vHr0urrfWn1dZWa617a60DcRVRVGTI3lM2BAiEjYGMz++Pe9BoA+SYe3Nzc9/Px+M+7j3nnvE5BvPJd5u7IyIiEkZKvAMQEZHEo+QhIiKhKXmIiEhoSh4iIhKakoeIiISWFu8AqkJmZqbn5OTEOwwRkYQyY8aMLe6eVd53SZE8cnJymD59erzDEBFJKGa2+mDfqdpKRERCU/IQEZHQlDxERCQ0JQ8REQlNyUNEREJT8hARkdCUPEREJDQlj0PYsP0L7np7EZt3FcY7FBGRakXJ4xD27CvmHx+v4J15G+MdiohItaLkcQidWzSkW8uGvDlnQ7xDERGpVpQ8DuPMPq2Zvnob67d/Ee9QRESqDSWPwzijdysA3pqr0oeIyAFKHofRvll9+mQ35s05efEORUSk2lDyqIAz+7Rm3vodrNyyJ96hiIhUC0oeFXB6UHU1Vg3nIiKAkkeFtGpcl4E5Gbypdg8REUDJo8LO7NOKpZt2s2TjrniHIiISd0oeFXRqr1akGBrzISKCkkeFZTZI5+hOmbw5dwPuHu9wRETiSskjhDN7t2b11r3MW78j3qGIiMSVkkcIp/RsSa1UU9WViCQ9JY8QGterxbFdshg7N4/SUlVdiUjyqtLkYWb/Y2YLzGy+mb1gZnXMrIOZTTWz5Wb2kpnVDo5ND7aXB9/nlLnOL4L9S8zslKp8hjP7tCZvRyEz1myrytuKiFQrVZY8zKwNcAOQ6+5HAqnAxcDdwP3u3gnYBlwVnHIVsC3Yf39wHGbWIzivJzASeMjMUqvqOU7s3oI6tVJUdSUiSa2qq63SgLpmlgbUA/KAE4BXgu+fAs4JPp8dbBN8P8LMLNj/orvvc/eVwHJgYBXFT/30NEZ0a8Hb8/IoLimtqtuKiFQrVZY83H09cC+whkjS2AHMALa7e3Fw2DqgTfC5DbA2OLc4OL5Z2f3lnPMlMxttZtPNbHp+fn5Un+XMPq3Ysns/U1YURPW6IiKJoiqrrZoSKTV0AFoD9YlUO8WEuz/i7rnunpuVlRXVax/XtTmN6qTx1ORVUb2uiEiiqMpqqxOBle6e7+5FwKvA0UCToBoLIBtYH3xeD7QFCL5vDGwtu7+cc6pEnVqpXDWsI+MWbmK+xnyISBKqyuSxBhhsZvWCtosRwELgQ+CC4JhRwBvB5zHBNsH3H3hkaPcY4OKgN1YHoDPwWRU9w5euODqHRnXS+Mv4ZVV9axGRuKvKNo+pRBq+ZwLzgns/AvwMuNnMlhNp03gsOOUxoFmw/2bg58F1FgAvE0k87wLXuXtJVT3HAY3r1lLpQ0SSliXDPE25ubk+ffr0qF93xxdFDL/7AwZ1bMY/L8+N+vVFROLJzGa4e7m/3DTCvBJU+hCRZKXkUUlq+xCRZKTkUUkqfYhIMlLyiAKVPkQk2Sh5RIFKHyKSbJQ8okSlDxFJJkoeUaLSh4gkEyWPKDpQ+rj3P0u0zrmI1GhKHlHUuG4tbhjRmQlL8nlvwaZ4hyMiEjNKHlF2xdAcurVsyO1vLmD3vuLDnyAikoAqnDwOLA8rh5aWmsLvz+1F3o5C/jxuabzDERGJiTAljylm1itmkdQg/ds35ZKBbXli0ioWbtgZ73BERKIuTPL4EfCcmf3km1+Y2bvRC6lm+NnIbjSuW4tfvj6P0lI1notIzVLh5OHu04BBQD8zG29m15rZP8zswPTqUkaTerX55WndmbVmOy9OW3v4E0REEkiYNo87gflAb2AT8GuCpWTd/eTYhJfYzuvXhkEdMrj73cVs2b0v3uGIiERNmBLDFcAAdz/S3S8lkkQaAveaWaNYBJfozIzfn3ske/cX84e3F8U7HBGRqAmTPLq4e8GBjWAt8rOBCcCUaAdWU3Rq3pAfDu/IqzPXM/nzrfEOR0QkKsK0eew9yP5/AGdFLaIa6McndCa7aV1++fo8vthf5SvmiohEXVQaut19eTSuU1PVrZ3KXef1YkX+HlVfiUiNoF5SVWR45yyuGtaBZ6asZvwiTV0iIolNyaMK/XRkV7q1bMitr8xl867CeIcjIvKthemqa2Z2mZn9JthuZ2YDYxdazZOelspfL+nLnn3F/ORfczV4UEQSVpiSx0PAEOCSYHsX8GDUI6rhOrdoyK9O787HS/N5avKqeIcjIvKthEkeg9z9OqAQwN23AZos8Vu4bHB7RnRrzl3vLGbxRs19JSKJJ0zyKDKzVMABzCwLKI1JVDWcmXH3Bb1pVKcWN74wm8Iidd8VkcQSJnk8ALwGNDez3wMTgbtiElUSyGyQzr0X9mbJpl388Z3F8Q5HRCSUtIoe6O7PmdkMYARgwDnurkELlXBc1+ZcMTSHJyetYnDHDEYe2SreIYmIVEiY3lZPARvd/UF3/xuw0cwej11oyeEXp3XjqLZNuOXlOSzbtCve4YiIVEiYaqve7r79wEbQYN43+iEll/S0VB6+rD91a6cx+pkZ7PiiKN4hiYgcVpjkkWJmTQ9smFkGIaq95OBaNq7DQ9/tx9qCvfzPS7M1/kNEqr0wyeNPwGQzu8PM7gAmAf8Xm7CSz8AOGfz2zB58sHgzfx6/LN7hiIgcUpgG86fNbDpwQrDrPHdfGJuwktNlg9szd90OHhi/jCNbN+Lkni3jHZKISLlCVTsFyUIJI0bMjDvOOZIlm3Zx88tzeP26BnRq3iDeYYmI/Jcwva3SzexSM/tfM/vNgVcsg0tGdWpFGtDT01IY/cx0dhaqAV1Eqp8wbR5vAGcDxcCeMi+JstZN6vLgd/uxZutern12JkUlGsgvItVLmGqrbHcfGbNI5GsGd2zGH87rxU9fmcsvXp3HPRf0xsziHZaICBCu5DHJzHpV5mZm1sTMXjGzxWa2yMyGmFmGmY0zs2XBe9PgWDOzB8xsuZnNNbN+Za4zKjh+mZmNqkxM1dl3ctty44jOvDJjHQ+M12KNIlJ9hEkew4AZZrYk+GU+z8zmhrzfX4B33b0b0AdYBPwcGO/unYHxwTbAqUDn4DUa+Dt8Ob7kt8AgYCDw27LjT2qam07szPn9srn//aW8MmNdvMMREQHCVVudWpkbmVlj4BjgCgB33w/sN7OzgeOCw54CJgA/I9K+8rS7OzAlKLW0Co4d5+4FwXXHASOBFyoTX3VlZtx1Xi827Szk5/+eS8tGdRjWOTPeYYlIkqtwycPdVwM7gRZA+zKviuoA5ANPmNksM3vUzOoDLdw9LzhmY3B9gDbA2jLnrwv2HWz/15jZaDObbmbT8/PzQ4RZ/dROS+Ghy/rRqXkDrn52BovytAaIiMRXmK66PwA+Bt4Dbg/ebwtxrzSgH/B3d+9LpKfWz8seEJQyojI3h7s/4u657p6blZUVjUvGVaM6tXjiygE0SE/jyiemkbfji3iHJCJJLEybx43AAGC1ux9PZFLE7Yc+5WvWAevcfWqw/QqRZLIpqI4ieN8cfL8eaFvm/Oxg38H213itGtfliSsHsHtfMZc/9hkFe/bHOyQRSVJhkkehuxdCZMCguy8Gulb0ZHffCKw1swPnjCAyWn0McKDH1Cgi40kI9l8e9LoaDOwIqrfeA042s6ZBQ/nJwb6k0L1VIx4dlcuagr1c/vhUDSIUkbgIkzzWmVkT4HVgnJm9AawOeb8fA88FvbSOAv4A/BE4ycyWAScG2wBvAyuA5cA/gWsBgobyO4Bpwet3BxrPk8Xgjs14+Hv9WbJxF99/Yhp79xfHOyQRSTIWaWYIeZLZsUBj4B13r/Z/+ubm5vr06dPjHUbUvT0vj+ufn8nRnTJ5dFQu6Wmp8Q5JRGoQM5vh7rnlfRemwfzuA5/d/SN3HwPcGYX45Fs6rVcr7j6/N58s28INL8yiWNOYiEgVCVNtdVI5+yo19kMq78Lcttx2Zg/eW7CJW1+Zq4WkRKRKHHaQoJldQ6S94YgyI8oNaAh8GsPYpIKuOLoDe/aXcM97S6hbO5U7zz6SlBTNgyUisVOREebPA+8Ad/H1cRm7kq2hujq77vhO7N1fzIMffo47/P4cJRARiZ3DJg933wHsMLNXgQJ332VmvwL6mdkd7j4r5lFKhfzk5K4Yxt8+XE5pqXPXeb2UQEQkJsLMbfVrd/+XmQ0j0qX2HuBhIhMUSjVgZtxychdSUowHxi+jxJ27z+9NqhKIiERZmORREryfDjzi7m+ZmXpbVTNmxs0ndSHVjPvfX0ppqXPPhX2UQEQkqsIkj/Vm9g8iva7uNrN0wvXWkip044mdSU2Be/+zlBJ3/nRhH9JS9eMSkegIkzy+Q2Tq83vdfXswD9WtsQlLouH6EzqTkmL837tLKC51/nzRUdRSAhGRKKhw8nD3vcCrZbbzgLyDnyHVwbXHdSItxfjD24vZu6+Yh77bn7q1NRJdRCrnsH+GmtnE4H2Xme385nvsQ5TKGn3MEfzh3F5MWJrP5Y9PZccX1X5GGRGp5g6bPNx9WPDe0N0bffM99iFKNFw6qB1/vaQvs9du55JHppC/a1+8QxKRBFaREeY3H+p7d78veuFILJ3RuzUN69Ti6mdmcOHDk3jmqkG0zagX77BEJAFVpPW0YfDKBa7hq6VgryaymJMkkGO7ZPHsDwZRsGc/Fz48mWWbdsU7JBFJQBWptrrd3W8nsmJfP3e/xd1vAfoD7WIdoERf//ZNefnqIZS4c+E/JjNj9bZ4hyQiCSZMv80WQNl1T/cH+yQBdWvZiH9fPZQmdWtx6T+n8O78jfEOSUQSSJjk8TTwmZndZma3AVOBJ2MRlFSNds3q8e9rhtKjdSOueW4GT3y6Mt4hiUiCqHDycPffA1cC24LXle5+V6wCk6rRrEE6z/9gMCd1b8Htby7kzrELtSaIiBxWmBHmuPtMYGaMYpE4qVs7lb9f1p87xi7k0YkrydtRyJ++04c6tTSYUETKFyp5SM2VmmL89sweZDety51vLWLTzkL+eXkuTevXjndoIlINaaIj+ZKZ8YPhHXnw0n7MXb+Dcx76lOWb1ZVXRP6bkof8l9N7t+KFHw5mz75izn1wEh8tzY93SCJSzZh7xRpHDzLSfAcww91nRzWqKMvNzfXp06fHO4yEs27bXn7w1HSWbtrFb87owaihOZhpXRCRZGFmM9w9t7zvwpQ8comMKj8wwvxHRKZo/6eZ/bTSUUq1k9000pX3hG4tuO3Nhfzq9fkUlZTGOywRqQbCJI/yRpg3B44BrohBbFIN1E9P45Hv9efqY4/gualrGPX4Z2zfu//wJ4pIjRYmeTQHyk7FWgS0cPcvvrFfapiUFOPnp3bj3gv7MH3VNs7626cs3qjZ+EWSWZjk8Rww1cx+G4wwnwQ8b2b1gYWxCE6qlwv6Z/PC6MEUFpVw7oOTGDt3Q7xDEpE4qXCDOYCZ5QJHAw5McveEaIVWg3l0bd5ZyDXPzWTG6m386JiO3HpKV62PLlIDRaXB3MzSgS5AfaAJcJqZ/SY6IUoiad6oDi/8cDCXDW7HPz5ewRVPTGPbHrWDiCSTMH8uvgGcDRQDe8q8JAnVTkvhznN6cff5vfhsZQFn/m0i89fviHdYIlJFwkxPku3uI2MWiSSkiwa0o2vLRlz9zAzO//skfnd2T76T21bjQURquDAlj0lm1itmkUjCOqptE8beMIwBORn87N/z+Mm/5vLF/pJ4hyUiMRQmeQwDZpjZEjOba2bzzGxurAKTxJLZIJ2nvj+QG0Z05tVZ6zjnwU/5PH93vMMSkRgJMz1J+/L2u/vqqEYUA+ptVbU+XprPTS/NZl9RCX88vzdn9mkd75BE5FuISm8rd19d3it6YUpNcUyXLN66YRjdWjXixy/M4jdvzKewSNVYIjXJYZOHmU0M3neZ2c4yr11mpmHGUq5Wjevy4ujB/GBYB56evJrzHpqkaiyRGuSwycPdhwXvDd29UZlXQ3dvFPaGZpZqZrPMbGyw3cHMpprZcjN7ycxqB/vTg+3lwfc5Za7xi2D/EjM7JWwMUjVqpabwqzN68NioXPJ2fMEZD0zk5elrCTMwVUSqpzCDBG82s2hUXt8ILCqzfTdwv7t3IrI2+lXB/quAbcH++4PjMLMewMVATyKz+j5kZlovtRob0b0F79x4DH3aNuanr8zlxhdns6uwKN5hiUglhOlt1RAYZ2afmNn1ZtYi7M3MLBs4HXg02DbgBOCV4JCngHOCz2cH2wTfjwiOPxt40d33uftKYDkwMGwsUrVaNq7Dcz8YzC0ndWHs3A2c/sBEZq/dHu+wRORbCtNgfru79wSuA1oBH5nZ+yHv92fgp8CBRSGaAdvdvTjYXkdkrRCC97XBvYuJLDzVrOz+cs75kpmNNrPpZjY9P18r4VUHqSnGj0d05uUfDaGk1Lng75N48MPllJSqGksk0Xyb2ew2AxuBrUSmaa8QMzsD2OzuM77FPUNz90fcPdfdc7OysqrillJBuTkZvH3DcE7u2YJ73lvCxY9MZm3B3niHJSIhhGnzuNbMJgDjiZQAfujuvUPc62jgLDNbBbxIpLrqL0ATMzswTUo2sD74vB5oG9w7DWhMJGF9ub+ccyRBNK5Xiwcv7cefLuzDorxdnPqXT3h15jo1poskiDAlj7bATe7e091vc/dQa3i4+y/cPdvdc4g0eH/g7t8FPgQuCA4bRWQCRoAxwTbB9x945DfLGODioDdWB6Az8FmYWKR6MDPO75/NOzcOp3urhtz88hyuf2GWVioUSQBh2jx+AXjQWH69mfWJUgw/A242s+VESjSPBfsfA5oF+28Gfh7EsQB4mcgCVO8C17m7RqAlsLYZ9Xhx9BB+OrIr783fyMg/f8Iny9ROJVKdhZme5AZgNPBqsOtc4BF3/2uMYosaTU+SOOat28FNL83i8/w9XDqoHf97WncapIeZ/FlEouVQ05OESR5zgSHuvifYrg9MDtnuERdKHomlsKiEP/1nCY9OXEmbJnW554I+DDmiWbzDEkk6UZnbCjCgbPVQSbBPJKrq1Erll6f34OUfDSE1xbjkn1O4bcwCTfMuUo2ESR5PAFPN7DYzux2YCjwem7BEYEBOBu/cOJxRQ9rz5KRVnPbAJ0xfVRDvsESEENVWAGbWj0iXW4BP3H12TKKKMlVbJb5Jn2/h1n/NZcOOLxg1JIdbT+lKfbWFiMRUtNo8coFfAjl8tXytq81DqsrufcXc8+5inp6ymtaN63LXeb04posGgIrESrSSxxLgVmAeX00vosWgpMpNW1XAz/49lxX5e7igfza/Pr0HjevVindYIjVOtBrM8919jLuv1GJQEk8DgulNrj3uCF6btZ4T7/+Id+fnxTsskaQSpuQxAriEyPQk+w7sd/dXD3pSNaGSR801f/0OfvrKXBbm7eSkHi24/ayetG5SN95hidQI0aq2ehboBizgq2ord/fvRyXKGFLyqNmKSkp5fOJK7n9/Kalm3HJyV0YNzSE1RT3JRSojam0e7t41qpFVESWP5LC2YC+/en0+Hy3Np3d2Y/5wbi+ObNM43mGJJKxotXlMClbxE6mW2mbU48krB/C3S/uyYXshZ/1tIneOXciefcWHP1lEQgnTUX4wMNvMVhJp8zASpKuuJA8z44zerRneOYu7313MoxNXMnZuHr8+owen9WpJZDFKEamsMNVW7cvbnwg9rlRtlbxmrtnGr1+fz4INOxneOZPbz+pJx6wG8Q5LJCFEpc0jkSl5JLeSUufZKau59z9L2FdUyuhjOnLd8Z2oWzs13qGJVGvRavPAzPrEYD0PkZhKTTFGDc3hg1uO44zerfjbh8s58b6PeHf+Rq1cKPIthVmG9kbgOSLrljcHnjWzH8cqMJFoy2qYzn0XHcVLowfTID2Nq5+dwWWPTWXppl3xDk0k4Wg9D0lKxSWlPDd1DfeNW8rufcVcPqQ9N53YhcZ1Nc2JyAFaz0PkG9JSUxg1NIcPf3IcFw9oy5OTVnH8vRN4fuoaSkpVlSVyON92PY/bgCloPQ9JcBn1a/P7c3sx9sfD6JTVgP99bR5n/nUikz7fEu/QRKq1b7Oex7Bg8xN3nxWTqKJM1VZSEe7Om3PzuPudxazf/gUndm/BL0/vTofM+vEOTSQuojU9yVPAje6+PdhuCvxJc1tJTVNYVMJjE1fy0IfL2VdcyuVDcrhxRGdN+y5JJ1ptHr0PJA4Ad98G9K1scCLVTZ1aqVx3fCcm3Ho8F+Zm8+SklRx774c8PnEl+4tLD38BkSQQJnmkBKUNAMwsg3DTm4gklKyG6dx1Xm/eumE4PVs34ndjF3LifR8xdu4GjQ+RpBcmefwJmGxmd5jZHcAk4P9iE5ZI9dG9VSOevWoQT145gHq1U7n++Vmc8+CnTFmxNd6hicRN2AbzHsAJweYH7r4wJlFFmdo8JFpKSp1XZ67jvnFLydtRyIhuzfnZqd3o0qJhvEMTiTrNbaXkIVFWWFTCE5+u4qEPl7NnfzHn9G3D/5zYhbYZ9eIdmkjUKHkoeUiMFOzZz98nLOepyatxdy4d2I7rT+hMVsP0eIcmUmlKHkoeEmN5O77ggfHLeHn6OmqnpvD9YTmMPuYITXciCU3JQ8lDqsiK/N3c//4y3pyzgcZ1azH6mI5cMTSH+unqmCiJp1LJw8x2AeUddGAlwUaVDzG2lDykqi3YsIP7/rOU8Ys3k1G/Nlcf25HvDc7RGiKSUFTyUPKQOJm1Zhv3jVvKJ8u2kNUwnWuPO4JLBrajTi0lEan+opY8gkGCnYE6B/a5+8eVjjDGlDwk3j5bWcB945YwZUUBLRvV4drjj+A7uW2VRKRai9bcVj8AbgSygdnAYCLreZxwyBOrASUPqS4mLd/CfeOWMn31Npo3TOfqY4/g0kEqiUj1FK25rW4EBgCr3f14IvNabT/0KSJS1tBOmfzr6iE8/8NBdMisz+/GLmTY3R/y6Ccr2Lu/ON7hiVRYmC4ghe5eaGaYWbq7LzazrjGLTKSGMjOGHpHJ0CMymbJiK3/9YBl3vrWIv0/4nKuGd+B7g9vTsI66+Er1FiZ5rDOzJsDrwDgz2wasjk1YIslhcMdmDO7YjOmrCnjgg+X837tLeHjC54wamsOVR3cgo37teIcoUq5v1dvKzI4FGgPvuvv+Cp7TFngaaEGk6+8j7v6XYHbel4AcYBXwHXffZmYG/AU4DdgLXOHuM4NrjQJ+FVz6Tnd/6lD3VpuHJIq567bz0Ief8+6CjdStlcqlg9rxw+Edadm4zuFPFomyatFV18xaAa3cfaaZNQRmAOcAVwAF7v5HM/s50NTdf2ZmpwE/JpI8BgF/cfdBQbKZDuQSSUIzgP7B+iLlUvKQRLNs0y7+PuFz3pizgVQzzu/fhh8O70jHrAbxDk2SSKUazM1sYvC+y8x2fvO9okG4e96BkoO77wIWAW2As4EDJYeniCQUgv1Pe8QUoEmQgE4Bxrl7QZAwxgEjKxqHSCLo3KIh9110FBN+chwX5mbz75nrGXHfR/zomenMXHPQv5NEqsxh2zzcfVjwHrU5p80sh0hvralAC3fPC77aSKRaCyKJZW2Z09YF+w62X6TGaZtRj9+f24ubTuzC05NX8fTk1by3YBMDczL40bEdOb5rc1JSLN5hShI6bPIws5sP9b273xfmhmbWAPg3cJO774w0bXx5LTezqNSjmdloYDRAu3btonFJkbjJapjOLSd35epjj+ClaWt5bOJKrnpqOp2bN+CqYR04p28bjRWRKlWRcR4Ng1cucA1f/fV/NdAvzM3MrBaRxPGcu78a7N4UVEcdaBfZHOxfD7Qtc3p2sO9g+7/G3R9x91x3z83KygoTpki1VT89je8P68CEW4/j/ov6UCs1hZ+/Oo+j//gBf35/KVt274t3iJIkwoww/xg4PWivIGj0fsvdj6ng+UakTaPA3W8qs/8eYGuZBvMMd/+pmZ0OXM9XDeYPuPvAoMF8Bl8lrplEGswLDnZvNZhLTeXuTF6xlcc+Wcn4xZupnZbCeX3bcNWwDnTW6oZSSYdqMA8zzqMFULZb7n6+ap+oiKOB7wHzzGx2sO9/gT8CL5vZVUTGjXwn+O5tIoljOZGuulcCuHtBsIb6tOC43x0qcYjUZGUHHC7fvJvHP13Jv2es48VpaxneOZMrj87huC5qF5HoC1Py+CWRX+yvBbvOAV529z/EKLaoUclDkknBnv08P3U1z0xZzaad++iQWZ9RQ9pzQW5bGmhdEQkhmrPq9gOGB5sfu/usKMQXc0oekoyKSkp5e14eT05axaw122mQnsaFudmMGpJDTmb9eIcnCUBTsit5SJKbvXY7T366krfm5VFU4hzTJYvLB7fn+G7NSVWVlhyEpmRX8hABYPPOQl74bC3Pfxap0mrTpC7fHdyOi3Lb0qxBerzDk2omWsljHpEp2ae4+1Fm1g34g7ufF71QY0PJQ+TrikpKeX/hJp6evJrJK7ZSOy2F03u14tJB7cht35Sy468keUWrt5WmZBepIWqlpnBqr1ac2qsVyzbt4pkpq3lt5npem7WeLi0acOnAdpzbL5vGdTU1vJQvTMnjNSLdZW8CTgC2AbXc/bTYhRcdKnmIHN7e/cW8OWcDz09dw5x1O6hTK4Uzerfm0kHt6Nu2iUojSajS1VbBAL9sd18bbIeekj2elDxEwpm/fgfPf7aGN2atZ8/+Erq0aMBFA9pxbt82WmMkiUStzcPde0U1siqi5CHy7ezeV8zYORt4cdpaZq/dTu3UFE7u2YKLB7Rj6BHNNPiwhotWm8dMMxvg7tMOf6iI1AQN0tO4eGA7Lh7YjsUbd/LiZ2t5bdZ6xs7NI7tpXc7vl80F/bNpm1Ev3qFKFQtT8lgMdCIyhcgewIhMhNs7duFFh0oeItFTWFTCfxZu4uVpa/n08y24w5COzbigfzan9mpJvdoaxV5TRKvaqn15+9292q9jruQhEhvrt3/BqzPW8crMdazeupcG6ZhqemIAAAznSURBVGmc3qsV5/fPJrd9U1VrJbhqsQxtPCl5iMSWu/PZygJembGOt+blsXd/CdlN63Je3zac2y+bDpoOJSEpeSh5iFSZvfuLeW/BRl6duZ5Pl2+h1KFvuyac1y+bM3q1oql6ayUMJQ8lD5G42LijkDdmr+fVmetZsmkXaSnGsV2yOLtvG07s3lztI9WckoeSh0hcuTsL83YyZvYGxszZQN6OQurVTuWUni0566jWDOuUSa3UiixsKlVJyUPJQ6TaKC11PltVwBuz1/PW3Dx2FhbTtF4tTu3VijN7t2ZghwzN9FtNKHkoeYhUS/uKS/hoST5vzs3j/YWb+KKohKyG6ZzeqxVn9mlF37bqsRVPSh5KHiLV3t79xXyweDNj5+TxwZLN7C8upXXjOpzaqxWn9WpF37ZNlEiqmJKHkodIQtlVWMS4hZt4e14eHy/dwv6SUlo1rsPII1tyeq9W9GunEklVUPJQ8hBJWDsLixi/aBNvzd3Ix8vy2V9cSotG6ZzSsyUje7ZkYIcM0tTYHhNKHkoeIjXCrsIiPli8mbfn5fHR0nwKi0ppWq8WJ3ZvwcgjW3J0p0zq1EqNd5g1hpKHkodIjfPF/hI+WprPews28v6iTewqLKZ+7VSO7ZrFST1acELXFjSup8WsKiNas+qKiFQbdWunMvLIlow8siX7i0uZvGIr786PJJK3520kNcUYmJPByT1bcFKPFmQ31cy/0aSSh4jUKKWlzpx12xm3cBPjFm5i2ebdAHRr2ZAR3ZszonsLjspWz62KULWVkodI0lq5ZQ/jFm7k/UWbmbF6GyWlTmaD2hzftTkjujdneOcs6qerEqY8Sh5KHiICbN+7n4+W5jN+0WYmLNnMzsJiaqemMLBDBsd1zeL4bs3pmFlf67UHlDyUPETkG4pKSpm+ahsTlmzmwyWbWbopUr3VLqMex3fN4rhuzRncoRl1aydv7y0lDyUPETmMtQV7mbA0nwmLN/Pp51soLCqldloKgzpkcGyXLI7rmsURWQ2SqlSi5KHkISIhFBaVMHVlAR8vzeejpfksDxrd2zSpyzFdMhneOYujj8is8V2BlTyUPESkEtZv/yKSSJbk8+nyLezaV0yKQe/sJgzvHEkmfds1qXHTyit5KHmISJQUl5QyZ912Pl66hU+W5TN77XZKHerXTmVQx2Yc3SmTozs1o2uLhglfxaXkoeQhIjGy44siJn++lU+W5TPp862s3LIHgMwG6Qw9ohnDOmUytFOzhBykqBHmIiIx0rhurS9HukOkiuvT5VuYtHwLE5dvZcycDQBkN63LkI7NGNqpGUM6ZtKycZ14hl1pKnmIiMSIu7Ns824mLd/C5BVbmbqygO17iwDokFmfwR0zGNShGYM6ZtCqcd04R/vfVG2l5CEi1UBpqbNo404mf76VKUEy2VVYDETGlwzqkMGgjs0Y1CGD7KZ1495mouSh5CEi1VBJqbMobydTVxYwdcVWPlv1VcmkVeM6DMjJYECHDAbmZNC5eYMqn49LyUPJQ0QSQGmps3TzLqauKOCzVQVMW1nA5l37AGhSrxa57ZuSm5NBbvum9MpuTHpabEe/18gGczMbCfwFSAUedfc/xjkkEZFKSUkxurVsRLeWjRg1NAd3Z03BXqat2sa0lQVMW1XA+4s2A1A7LYXebRrTP6cpA9pn0K99UzLq166yWBOy5GFmqcBS4CRgHTANuMTdF5Z3vEoeIlJTbNm9jxmrtzFj9TamrSpg/vodFJVEfo93zKxPv/ZN6d++Kf3aNa10VVdNLHkMBJa7+woAM3sROBsoN3mIiNQUmQ0i67ef0jPSNbiwqIS563Z8mVA+XLyZV2asA6BhnTQuym3Lr87oEfU4EjV5tAHWltleBwwqe4CZjQZGA7Rr167qIhMRqUJ1aqUysEMGAztkAJHuwau37o0kkzXbaN0kNl2AEzV5HJa7PwI8ApFqqziHIyJSJcyMnMz65GTW5/z+2TG7T6LO4rUeaFtmOzvYJyIiVSBRk8c0oLOZdTCz2sDFwJg4xyQikjQSstrK3YvN7HrgPSJddR939wVxDktEJGkkZPIAcPe3gbfjHYeISDJK1GorERGJIyUPEREJTclDRERCU/IQEZHQEnJuq7DMLB9YHeKUTGBLjMKpzpLxuZPxmSE5nzsZnxkq99zt3T2rvC+SInmEZWbTDzYZWE2WjM+djM8MyfncyfjMELvnVrWViIiEpuQhIiKhKXmU75F4BxAnyfjcyfjMkJzPnYzPDDF6brV5iIhIaCp5iIhIaEoeIiISWlInDzMbaWZLzGy5mf28nO/Tzeyl4PupZpZT9VFGXwWe+2YzW2hmc81svJm1j0ec0XS4Zy5z3Plm5mZWI7p0VuS5zew7wc97gZk9X9UxRlsF/n23M7MPzWxW8G/8tHjEGU1m9riZbTaz+Qf53szsgeC/yVwz61fpm7p7Ur6ITOX+OdARqA3MAXp845hrgYeDzxcDL8U77ip67uOBesHnaxL9uSvyzMFxDYGPgSlAbrzjrqKfdWdgFtA02G4e77ir4JkfAa4JPvcAVsU77ig89zFAP2D+Qb4/DXgHMGAwMLWy90zmksdAYLm7r3D3/cCLwNnfOOZs4Kng8yvACDOzKowxFg773O7+obvvDTanEFmpMZFV5GcNcAdwN1BYlcHFUEWe+4fAg+6+DcDdN1dxjNFWkWd2oFHwuTGwoQrjiwl3/xgoOMQhZwNPe8QUoImZtarMPZM5ebQB1pbZXhfsK/cYdy8GdgDNqiS62KnIc5d1FZG/WBLZYZ85KMa3dfe3qjKwGKvIz7oL0MXMPjWzKWY2ssqii42KPPNtwGVmto7ImkA/rprQ4irs//eHlbCLQUnsmdllQC5wbLxjiSUzSwHuA66IcyjxkEak6uo4IiXMj82sl7tvj2tUsXUJ8KS7/8nMhgDPmNmR7l4a78ASSTKXPNYDbctsZwf7yj3GzNKIFHG3Vkl0sVOR58bMTgR+CZzl7vuqKLZYOdwzNwSOBCaY2SoidcJjakCjeUV+1uuAMe5e5O4rgaVEkkmiqsgzXwW8DODuk4E6RCYPrMkq9P99GMmcPKYBnc2sg5nVJtIgPuYbx4wBRgWfLwA+8KD1KYEd9rnNrC/wDyKJI9HrwOEwz+zuO9w9091z3D2HSDvPWe4+PT7hRk1F/o2/TqTUgZllEqnGWlGVQUZZRZ55DTACwMy6E0ke+VUaZdUbA1we9LoaDOxw97zKXDBpq63cvdjMrgfeI9JD43F3X2BmvwOmu/sY4DEiRdrlRBqjLo5fxNFRwee+B2gA/CvoH7DG3c+KW9CVVMFnrnEq+NzvASeb2UKgBLjV3RO2dF3BZ74F+KeZ/Q+RxvMrEv2PQjN7gcgfAZlBW85vgVoA7v4wkbad04DlwF7gykrfM8H/m4mISBwkc7WViIh8S0oeIiISmpKHiIiEpuQhIiKhKXmIiEhoSh4iIhKakoeIiISm5CFSCWa2O+TxN5jZIjN77lvcq4mZXRv2PJFY0CBBkUows93u3iDE8YuBE9193be4Vw4w1t2PDHGOEfn/XJP+SVSp5CFJy8zqm9lbZjbHzOab2UXB/suD1dbmmNkzwb7XzWxGsNre6INc7zIz+8zMZpvZP8ws9RvfP0xkkaJ3gqkxDnrd8mIA/ggcEVz/nuC4m4PY55vZTcG+nGAlvaeB+Xx9QjzM7IJg+vU5ZjbRzLIq/19Tkk68V8DSS694vYDzgX+W2W4M9CQys2xmsC/jG+91ifxCbhZs7w7euwNvArWC7YeAy8u556oD1z7YdQ8RQw5lVooD+gPzgPpE5iJbAPQNjisFBh/kuZuV+fxb4Lp4/yz0SryXSh6SzOYBJ5nZ3WY23N13ACcA/3L3LQDufmB1thvMbA6RGXfb8t/Tlo8g8st8mpnNDrY7ViCG8q57sBi+aRjwmrvvcffdwKvA8OC71R5ZMa48VwQlpDlEllquKSsnShVK2ll1Rdx9abCC4GnAnWY2Htj2zePM7DjgRGCIu+81swlEpvH+2mHAU+7+i4rev4LX/bb2HOSelxNZqvUEd99tZh8TKbGIhKKShyQtM2sN7HX3Z4lMQ98P+AC40MyaBcdkEKnO2hb8gu9GZLGobxoPXGBmzQ+cZ2btDxPCwa5bXgwAu4gsXHXAJ8A5ZlbPzOoD5wb7DqUXMClIHOcDQ4mUwERCUclDklkv4B4zKwWKgGs8svbD74GPzKwEmAX8CLjazBYBS4hUMX2Nuy80s18B/7HIsrZFwHXA6kPc/93yrnuQGK5w960WWWt8PvCOu99qZk8CnwXXe9TdZwW9sg7mSeBVM/su8B9ghbuXW0oRORR11RURkdBUbSUiIqEpeYiISGhKHiIiEpqSh4iIhKbkISIioSl5iIhIaEoeIiIS2v8DuFryT/2S7Y4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Let's define a range of scale factors\n",
+    "a = np.linspace(0.01, 1.)\n",
+    "\n",
+    "# And compute the comoving distance for these scale factors \n",
+    "chi = jc.background.radial_comoving_distance(cosmo, a)\n",
+    "\n",
+    "# We can now plot the results:\n",
+    "plot(a, chi)\n",
+    "xlabel(r'scale factor $a$')\n",
+    "ylabel(r'radial comoving distance $\\chi$');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "z30Karo4Jdnw"
+   },
+   "outputs": [],
+   "source": [
+    "# Not sure what are the units of the comoving distance? just ask:\n",
+    "jc.background.radial_comoving_distance?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yihFIALbJ24Q"
+   },
+   "source": [
+    "## Defining redshift distributions\n",
+    "\n",
+    "On our path to computing Fisher matrices, we need to be able to express redshift distrbutions. In `jax-cosmo` n(z) are parametrized functions which can\n",
+    "be found in the `jax_cosmo.redshift` module. \n",
+    "\n",
+    "For the purpose of this tutorial, let's see how to define a Smail type distribution:\n",
+    "$$ n(z) = z^a \\exp(- (z/z_0)^b) $$\n",
+    "which depends on 3 parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2D7ouxvVIR7M"
+   },
+   "outputs": [],
+   "source": [
+    "# You can inspect the documentation to see the \n",
+    "# meaning of these positional arguments\n",
+    "nz1 = jc.redshift.smail_nz(1., 2.,  1.)\n",
+    "nz2 = jc.redshift.smail_nz(1., 2.,  0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 281
+    },
+    "colab_type": "code",
+    "id": "Ef2oNlQ7Lmdi",
+    "outputId": "799bb7a6-1e67-45d8-dfd3-ff3b27ce6f81"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAEICAYAAABRSj9aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deXxV5bX4/8/KHCAESEIYwhAIg4xRUqCCA1gtWAW11qJ2sEr9abV667fe6tdf9VZvqy3eXmuVa61za7W2dcBb5wlFpQIKyAwymDBkJExJyLS+f+wdPIYMJ8k5Z5/ss96v13ntkz2ddfDlypPnefZ6RFUxxhjjX3FeB2CMMSa8LNEbY4zPWaI3xhifs0RvjDE+Z4neGGN8LsHrAFqSmZmpw4cP9zoMY4zpNlatWlWmqlktHYvKRD98+HBWrlzpdRjGGNNtiMiu1o5Z140xxvhcuy16EXkEOAcoUdUJLRy/Ebg04H4nAFmqWiEiO4FDQANQr6oFoQrcGGNMcIJp0T8GzGntoKouUtV8Vc0HbgaWqmpFwCmz3OOW5I0xxgPttuhV9V0RGR7k/S4GnupKQMYYA1BXV0dRURE1NTVehxJVUlJSyMnJITExMehrQjYYKyI9cFr+1wbsVuA1EVHgD6r6YBvXXwlcCTB06NBQhWWM6aaKiopIS0tj+PDhiIjX4UQFVaW8vJyioiJyc3ODvi6Ug7HnAu8367aZqaonAXOBa0Tk1NYuVtUHVbVAVQuyslqcIWSMiSE1NTVkZGRYkg8gImRkZHT4r5xQJvoFNOu2UdXd7rYEeA6YGsLPM8b4nCX543Xm3yQkiV5E0oHTgBcC9vUUkbSm98BZwLpQfF5E7V0Dqx6D6v1eR2KMMZ3SbqIXkaeAD4ExIlIkIleIyFUiclXAaecDr6nqkYB92cAyEVkDfAT8U1VfCWXwYffuIvjDqfDi9XDPJNiz2uuIjDEeWrVqFRMnTiQvL4/rrruOYNfzKC8vZ9asWfTq1Ytrr722/QtCrN1Er6oXq+pAVU1U1RxVfVhVH1DVBwLOeUxVFzS7bruqTnZf41X1l+H4AmGz71N4+04YNx8ufw2SesGzP4TaKq8jM8Z45Oqrr+aPf/wjW7duZevWrbzySnBt15SUFO644w7uvvvuMEfYMnsytjUv/wxS+8K5v4Oh0+C8xVC2BZYv9joyY0wEPPDAA+Tn55Ofn09ubi6zZs3i4MGDTJ8+HRHhe9/7Hs8//3xQ9+rZsyczZ84kJSUlzFG3LCpr3XiudAvseh/OvMNJ9gAjZ8GIWbDiYZhxPcQHP4fVGNM1v3hxPRv2HAzpPccN6s1t545v9fhVV13FVVddRV1dHbNnz2b27NksXbr02PGcnBx2794NwKJFi3jyySePu8epp57KvffeG9K4O8MSfUvWPg0SB5Mu+vL+6VfDXy6CjUtgwje9ic0YE1HXX389s2fPZu7cuV9K9IFuvPFGbrzxxghHFjxL9M01NsLaZ2DkbEgb8OVjeWdCn2HwyZOW6I2JoLZa3uH02GOPsWvXLu677z6Ki4spKio6dqyoqIjBgwcD1qLvfko2wIFCOP3m44/FxTmDs8v/B6orIbVP5OMzxkTEqlWruPvuu3nvvfeIi4tj4MCB9O7dm+XLlzNt2jSeeOIJfvzjHwPR36K3wdjmdrzrbEec1vLxE+ZBYx1sfS1yMRljIu6+++6joqKCWbNmkZ+fz8KFC1m8eDELFy4kLy+PkSNHMnfu3KDvN3z4cG644QYee+wxcnJy2LBhAwALFy4M+/ob1qJvbsdS6DcS0nNaPj54CvQa4PTTN+/DN8b4xqOPPtri/nXrOvfc586dO1vc/9BDD3Xqfh1hLfpADfWw833IbbUkj9N9M/rrsH2pc74xxkQ5S/SB9q6B2kNtJ3pwunWOHnTON8aYKGeJPtCej53tkHZqrw0/xdnuaHmqlTHGRBNL9IH2rIYemdB7cNvn9eoP/cd9MXBrjDFRzBJ9oL2rYVA+BFMGNPdU+Hw51NeGPy5jjOkCS/RN6qqhZCMMzA/u/CHToL4aij8Nb1zGGNNFluibFK8HbXBa9MFo6scvCu/8V2NM9OhsmWKAO++8k7y8PMaMGcOrr77a4jmXXXYZubm5x4qprV4dmtLoluib7HX/QYNt0afnQNogKPwofDEZY6JKZ8sUb9iwgaeffpr169fzyiuv8KMf/YiGhoYWz120aBGrV69m9erV5OcHmY/aYYm+SckmSO7d+oNSLckpgCJL9Mb4USjLFL/wwgssWLCA5ORkcnNzycvL46OPIpc77MnYJqWbIHN0cAOxTYZMdZ6QPVQMadnhi82YWPfyTc5iQKE0YCLMvavVw6EsU7x7926mT5/e4rXN3XLLLdx+++2cccYZ3HXXXSQnJ3f2Gx5jLfomZVsga0zHrhk8xdnag1PG+FZgmeLW3Hjjjce6WwJfHa1ceeedd7Jp0yZWrFhBRUUFv/71r7saPmAtekf1fjhc3PFEn+2WTt23FkafFfq4jDGONlre4RSqMsWDBw+msLCwxWsDDRw4EIDk5GR+8IMfhGzpQUv04KwoBZDZwUSfkg59h4f+T0pjjOdCWaZ43rx5XHLJJdxwww3s2bOHrVu3MnXq8U/g7927l4EDB6KqPP/880yYMCEk36XdRC8ijwDnACWqetynisjpwAvADnfXs6p6u3tsDvA7IB54SFW9+bXcnrLNzjZrdMevHTDREr0xPhRYphigoKCAxYsXc9lll1FdXc3cuXODLlM8fvx4LrroIsaNG0dCQgL3338/8fHxAJx99tk89NBDDBo0iEsvvZTS0lJUlfz8fB544IGQfJdgWvSPAfcBT7Rxznuqek7gDhGJB+4HzgSKgBUiskRVN3Qy1vAp3QwJKc7qUR01YBJsfBGOHoLktNDHZozxRKjLFN9yyy3ccsstx+1/6aWXjr1/6623OnXv9rQ7GKuq7wIVnbj3VGCbqm5X1VrgaWB+J+4TfuXbnBr0cfEdv3bARGdbvD60MRljTIiEatbNV0VkjYi8LCJNizsOBgoDzily97VIRK4UkZUisrK0tDREYQVp/07ol9u5a5sSvXXfGGOiVCgS/cfAMFWdDPweCO4JgmZU9UFVLVDVgqysrBCEFaTGRifR9x3euet7D4bUvs7MG2NMSHWkxECs6My/SZcTvaoeVNXD7vuXgEQRyQR2A0MCTs1x90WXw/ugvqbzLXoRG5A1JgxSUlIoLy+3ZB9AVSkvLyclJaVD13V5eqWIDACKVVVFZCrOL49yoBIYJSK5OAl+AXBJVz8v5CrcyUJ9O5nowRmQ/eiPztKC8TZj1ZhQyMnJoaioiIh35Ua5lJQUcnI6UKqF4KZXPgWcDmSKSBFwG5AIoKoPABcCV4tIPVANLFDnV3C9iFwLvIozvfIRVY2+Ecv9bqLvbIsenBZ9w1Eo3wr9TwhNXMbEuMTERHJzu/D/pTmm3USvqhe3c/w+nOmXLR17CXippWNRo2IHSDykD2n/3NYEDshaojfGRBmrdbN/h1OxMj6x8/fIHA3xyTYga4yJSpboK3Z0rdsGnF8SmaOdUsfGGBNlLNEfKOzcE7HNZY3+opSCMcZEkdhO9HXVcKS0a/3zTbLGQuXnUHuk6/cyxpgQiu1Ef8Cd1t8nFInerXxZtqXr9zLGmBCK8UTvVmjoyPKBrcka62xLrfvGGBNdYjzRu4sIhKLrpt8IiEtwliQ0xpgoEuOJvhAQ6D2o6/eKT4SMvC8WMTHGmCgR44m+CNIGdm0OfaCsMdaiN8ZEnRhP9IWhGYhtkjXWeQCrriZ09zTGmC6K7URfWRiagdgmWWNAG52FTIwxJkrEbqJvbISDu0MzENukaXFx674xxkSR2E30VeXQUOssHBIqGXkgcTaX3hgTVWI30R/a42x7DwzdPRNTnLr21qI3xkSR2E30B/c627QQTK0MlDXWHpoyxkSV2E304WjRg1PcrHybs9qUMcZEgdhN9Af3Ov3pPfuH9r4Zo6CxHip3hfa+xhjTSbGb6A/tcZJ8qNd4zRzlbG2KpTEmSsRuoj+4N/TdNuDMvAEo2xr6extjTCfEbqI/tDf0A7EAPfpBaj9r0Rtjoka7iV5EHhGREhFZ18rxS0VkrYh8KiIfiMjkgGM73f2rRWRlKAPvsoN7wtOiB6dVb4neGBMlgmnRPwbMaeP4DuA0VZ0I3AE82Oz4LFXNV9WCzoUYBnXVUFPpFDQLh8xR1nVjjIka7SZ6VX0XqGjj+Aequt/9cTkQwuIxYXKwaWplGLpuwGnRH94HRw+F5/7GGNMBoe6jvwJ4OeBnBV4TkVUicmVbF4rIlSKyUkRWlpaWhjisZg4XO9u0AeG5f9OArHXfGGOiQMgSvYjMwkn0PwvYPVNVTwLmAteIyKmtXa+qD6pqgaoWZGVlhSqslh3a52x7hSnRH5ti+Vl47m+MMR0QkkQvIpOAh4D5qlretF9Vd7vbEuA5YGooPq/LDpc4217Z4bl/31xArJ/eGBMVupzoRWQo8CzwXVXdErC/p4ikNb0HzgJanLkTcYeLnfVdU/uG5/6JKdBnKJRbojfGeK/dx0JF5CngdCBTRIqA24BEAFV9ALgVyAAWiwhAvTvDJht4zt2XAPxFVV8Jw3fouMPFTms+LoyPEdgUS2NMlGg30avqxe0cXwgsbGH/dmDy8VdEgcPF0CvENW6ayxwFn/wLVMH5ZWeMMZ6IzSdjm1r04ZSRB7WHnSdwjTHGQ7GZ6A9FoEVvUyyNMVEi9hJ9YwNUlYVvamWTpimWNvPGGOOx2Ev0R8pAG8Pfok8bBAmpNpfeGOO52Ev0h5selgpzH31cnDvzxlr0xhhvxWCiD/PDUoEyRlrXjTHGczGY6N06N+HuugGnn75yF9TXhv+zjDGmFTGY6Jta9BFI9BmjnPGA/TvC/1nGGNOK2Ev0VeWQ2AOSeob/s2yKpTEmCsReoj9SCj0yI/NZGSOdrfXTG2M8FIOJvgx6RijRp/aBnlk288YY46kYTPSlkUv04PTT21x6Y4yHYi/RV5U7rexIycyzrhtjjKdiK9Grun30GZH7zIw8p+RC9f72zzXGmDCIrUR/9BA01Ea2RZ9hywoaY7wVW4n+iLvoeET76N0pltZ9Y4zxSGwl+ip3OdtItuj7DgeJt7n0xhjPxFaiP1LmbCPZR5+Q5CR7m2JpjPFIjCX6pq6bCLbowa1iaX30xhhvxFair3Jb9JHsowenuFn5Z9DYGNnPNcYYgkz0IvKIiJSIyLpWjouI3Csi20RkrYicFHDs+yKy1X19P1SBd8qRMkjqBYmpkf3cjDyor4aDRZH9XGOMIfgW/WPAnDaOzwVGua8rgf8BEJF+wG3ANGAqcJuI9O1ssF12pCyy/fNNrLiZMcZDQSV6VX0XqGjjlPnAE+pYDvQRkYHA14HXVbVCVfcDr9P2L4zwOlIa+f55CFg/1hK9MSbyQtVHPxgoDPi5yN3X2v7jiMiVIrJSRFaWlpaGKKxmqiJY0CxQr2yny8ha9MYYD0TNYKyqPqiqBapakJUVplZ3JCtXBhKx9WONMZ4JVaLfDQwJ+DnH3dfa/shTdfvoPUj04HTfWNeNMcYDoUr0S4DvubNvpgMHVHUv8Cpwloj0dQdhz3L3RV7NAWis86aPHpwW/YFCqKv25vONMTErIZiTROQp4HQgU0SKcGbSJAKo6gPAS8DZwDagCviBe6xCRO4AVri3ul1V2xrUDZ9j5Q88atFn5AEKFdshe7w3MRhjYlJQiV5VL27nuALXtHLsEeCRjocWYl4UNAvUNPOmfJslemNMREXNYGzYHatz41Gi72frxxpjvBFDid6jOjdNkntB2iCbYmmMibjYSfRe1bkJlDHSEr0xJuJiJ9EfKYPk3pCQ7F0MmaOcrhtV72IwxsSc2Er0XtS5CZQxCmoqocqbiUfGmNgUQ4neozo3gY4VN7MBWWNM5MROoq+q8L5Fn2nrxxpjIi+GEn2594m+zzCIS7QBWWNMRMVOoq+ugB7elcIHIC4e+o2wRG+Miaignozt9mqroL4GUvt5GkbxwRrq4geTtHM9dzz1CYlxwsA+KUwc3IeZozLplRwb/zmMMZEVG5ml2p3l0sObRL+2qJLfvbGVtzaX8LP4nlweX8j6wnKONsZRfLCG+kYlOSGOeZMHcfXpIxmR1cuTOI0x/hQbib5pOmOEW/TVtQ388qUNPPmvz+mTmsi1s/KYn3QaSe+8yFsLR0C/ERytb+CTzytZsmYPz328m2c/2c0VM3O54czRpCTGRzReY4w/xUai96BFX7S/ioWPr2TTvkP8YMZwbjhzNGkpifD5fngHpzZ9vxEkJ8QzfUQG00dk8JOvjea3r2/mwXe38/amEv772/lMGJwesZiNMf4UG4OxEW7Rby0+xDf/5wP2VFbz+OVTue3c8U6SB8gc7WzLthx3XVZaMndeMInHfvAVDtbU8c3/+YCXP90bkZiNMf4VG4k+gi36nWVHuOShf9Go8LerTua00c0e0urRz3lwq3RTq/c4fUx/Xr7+VMYP6s2P/vIxDy/bEeaojTF+FhuJvmq/sw1zi/5QTR2XP76ChkblLwunMWZAWssnZo5psUUfqF/PJP7yw+mcNS6bO/53A/e/bVMyjTGdExuJvroCknpBQlLYPqKxUfk/z6xhV3kViy89iVHZrSR5gKwxTou+neJmKYnxLL50CuflD2LRq5t59H1r2RtjOi42BmOrKsLemr//7W28tqGYn58zjukj2nkCN2uMs4bt4WJIG9DmqfFxwt3fmkx1XQO/eHEDvZIT+FbBkDavMcaYQLHTog/jU7Friyr57ze2MD9/EJfPGN7+BVljnG3p5qDunxAfx70Xn8jMvEz+73Of8q/t5Z0P1hgTc4JK9CIyR0Q2i8g2EbmpheP/LSKr3dcWEakMONYQcGxJKIMPWhhb9HUNjfz739eS2SuZ2+dPQETavyizY4keIDkhnvsvPYkh/Xpw9ZMfU1hR1cmIjTGxpt1ELyLxwP3AXGAccLGIjAs8R1V/oqr5qpoP/B54NuBwddMxVZ0XwtiDV10Rthk3f1j6GZv2HeI/z5tAempicBelDYDkdCgLPtEDpKcm8vD3v0JDo3LF4yuoqq3vRMTGmFgTTIt+KrBNVberai3wNDC/jfMvBp4KRXAhU1Uelhb99tLD3PvmNr4xcSBnjW+7r/1LRCBrdIda9E1yM3ty/yUnsbXkMD9/fn2HrzfGxJ5gEv1goDDg5yJ333FEZBiQC7wVsDtFRFaKyHIROa+1DxGRK93zVpaWlgYRVpAa6p2BzzC06O96eRNJCXHcNm9c+yc31zTzphNmjsrkutmj+MfHRfxtZWH7FxhjYlqoB2MXAH9X1YaAfcNUtQC4BLhHREa2dKGqPqiqBapakJUVwpWgatzhghDXol+xs4LXNhRz1Wkj6J+W0vEbZI11Vr3q5LKC150xiq+OyODnL6xja/GhTt3DGBMbgkn0u4HA+Xw57r6WLKBZt42q7na323GqvJzY4Si7IgzlD1SVX720kezeyVwxc0TnbtKJAdlA8XHC7xbk0zMpgZ88s5q6hsbOxWGM8b1gEv0KYJSI5IpIEk4yP272jIiMBfoCHwbs6ysiye77TGAGsCEUgQftWPmD0E2vfGXdPj75vJIbzhxNalInK0w2TbHs4IBsoP69U/jl+RNZt/sgv3/Lnpw1xrSs3USvqvXAtcCrwEbgGVVdLyK3i0jgLJoFwNOqX3rc8wRgpYisAd4G7lLVyCb6ELfoGxuV376+hVH9e/HNk3I6f6P0IZDYo9Mt+iZzJgzgghMHc//b21hbVNn+BcaYmBPUk7Gq+hLwUrN9tzb7+T9auO4DYGIX4uu6EBc0e2NjMVtLDvO7BfkkxHdhiCMuDjJHQcnGLsd027zxfPBZOTc8s4b//fFMq2NvjPkS/z8ZG8IWvapy/zufMbRfD74xcWCX70f/8VDS9T9w0lMT+c2Fk9hWcpi7X+3aXwjGGP/xf6KvroC4BEhuo8hYkD78rJw1hZVceeqIrrXmm2SPc+rdHOl6SYNTR2fxnelDefj9HXzy+f6ux2aM8Q3/J/qm8gfBlCZox+J3PiMrLZkLp3Shbz5Qf3f+fUloHnz62ZyxZKelcPOzn9osHGPMMf5P9CEqf7Bhz0GWbSvj8hm5oesDz57gbItDk+jTUhK5ff54Nu07xEPvWUljY4zD/4m+an9I+uf/tHwnKYlxXDJ1aAiCcvXq7zzIFaJED3DW+AF8fXw297yxhV3lR0J2X2NM9+X/RB+CFv2Bqjqe+2Q35+UPJr1HkIXLgiHidN+EYEA20C/mTSAxPo5bnluHtrO4iTHG//yf6KsqILVrD0v9bVUhNXWNfPerw0IUVIDsCc4Uy8bQ9akPSE/h3+eMYdm2Mp5f3dpDzMaYWOHvRK/a5RZ9Y6Pyp+W7KBjWl/GD0kMYnCt7HNRVwf7Q9qlfOm0Y+UP68Mt/buRAdV1I722M6V78nehrj0BDbZf66N/dWsqu8iq+d/Lw0MUVqP94Zxvi7pv4OOGO+RMoP1LLf7/e9kLkxhh/83eiD8FTsU9/VEhGzyTmdKTefEf0HwtISAdkm0zMSefSaUN54sOdbNhzMOT3N8Z0D/5O9F18Krb88FHe3FTM+ScOJikhTP9UST2hX25YEj3AT88aQ3pqIrctsYFZY2KVvxN9Uy36Tg7GPr96D3UNyrcKhrR/cleEYeZNkz49krhp7lhW7NzPc5/YwKwxscjfib7aLQWQ2qfDl6oqf1tZyOScdMYM6Hr5hDZlj4fyz6A2PAt+f2vKEPKH9OFXL23iYI0NzBoTa3ye6N0WfUrHE/36PQfZtO8QF4a7NQ8wYCKgYWvVxx0bmD1qA7PGxCB/J/oudN38bWUhSQlxzJs0KMRBtWDgZGe755OwfUTTwOzjH9jArDGxxt+Jvno/xCdBYmqHLqtraGTJmj2cNS47tE/CtiZ9iDNgvHdNWD/GBmaNiU0+T/SVTrdNBytXvre1lP1VdZx/4uAwBdaMiNOq37s6rB8TODD77Mc2MGtMrPB3oq+p7FS3zZLVe0hPTeSUUVlhCKoVg/KdUgj1R8P6MU0Ds3e+bAOzxsQKfyf66v0dnnFTXdvAaxuKOXvigPDNnW/JwMnQWB+2+fRNbGDWmNjj80Rf2eEZN29uKqaqtoFzJ0dgEDbQwHxnG+Z+erCBWWNiTVCJXkTmiMhmEdkmIje1cPwyESkVkdXua2HAse+LyFb39f1QBt+uTnTdLFm9h/5pyUzLzQhTUK3oOxxS0sPeT9/kp2eNoU+PJG59wQZmjfG7dhO9iMQD9wNzgXHAxSIyroVT/6qq+e7rIffafsBtwDRgKnCbiHStZnBHVFd2qOvmQHUd72wu5ZxJg4iP6/rSgx1ybEA2/C16cAZmfzZnDCt32cCsMX4XTIt+KrBNVberai3wNDA/yPt/HXhdVStUdT/wOjCnc6F2UGMDHD3Yoa6b1zcUU9vQyLmTB4YxsDYMzHf66OtrI/JxXwzMWiljY/wsmEQ/GCgM+LnI3dfcN0VkrYj8XUSaHicN9lpE5EoRWSkiK0tLS4MIqx01B5xtB7puXlm3l0HpKeQP6fiTtCExcLJTVrl0U0Q+Li5O+M/zrJSxMX4XqsHYF4HhqjoJp9X+eEdvoKoPqmqBqhZkZYVgWmMH69wcPlrPu1vL+PqEAUgH592HzKATnW2E+ukBJgy2UsbG+F0wiX43EFjwJcfdd4yqlqtq0wTwh4ApwV4bNh2sc/PWphJq6xuZO8GjbhuAvrnOgOzuVRH9WBuYNcbfgkn0K4BRIpIrIknAAmBJ4AkiEpgd5wEb3fevAmeJSF93EPYsd1/41TS16IPrunll3V4yeyUzZVjkxoqPExcHOV+Bwo8i+rF9eiRx05yxNjBrjE+1m+hVtR64FidBbwSeUdX1InK7iMxzT7tORNaLyBrgOuAy99oK4A6cXxYrgNvdfeHX1KIPouumuraBtzeV8vXx2ZGfbdNczlTnCdmmMYYIuXBKjg3MGuNTQfXRq+pLqjpaVUeq6i/dfbeq6hL3/c2qOl5VJ6vqLFXdFHDtI6qa574eDc/XaEFTH30QXTdLt5RSXdfgbbdNkyFTAYWilRH9WBuYNca//PtkbE3wLfpX1++jT49Epo3o/NqyITN4CiAR774BZ2D2O9OG8cSHO1m/J7J/URhjwse/ib66EhJ7QEJym6fVNzTy9uYSZo/pT2J8FPxzpPR2Vpwqinyihy8GZn/+/DoaG21g1hg/iILMFiZB1rlZtWs/lVV1nHFCdgSCClLOV5yum8aGiH90eo9Ebp47lo8/r+TJjz6P+OcbY0LPv4k+yDo3b24qITFeOHV0ZgSCCtKQac5TvRF6cKq5C6fkMCMvg1+/vIl9B2o8icEYEzr+TfRB1rl5Y2Mx00dkkJYSgZWkgjVkqrP1oJ8eQET41fkTqWto5Oc2t96Ybs/HiX5/u103O8qOsL30CGeM7R+hoILUbwT0yPAs0QMMy+jJT84czesbinll3T7P4jDGdJ1/E30QXTdvbiwGiK7+eXAqWQ6ZBoXLPQ1j4cxcxg/qza1L1tvcemO6Mf8m+iC6bt7YWMyY7DSG9OsRoaA6YNgMqNgOB4o8CyEhPo67LphE+eGj3PXyxvYvMMZEJX8m+vpaqDvSZtfNgao6VuzczxknRFm3TZMRpznb7Us9DWNiTjoLTxnBUx8Vsnx7uaexGGM6x5+JPoiHpd7ZUkJDo/K1cVHWbdOk/3inn36Ht4ke4CdfG83Qfj342T/WUlVb73U4xpgO8meiP1bnpvU++jc3lpDZK4n8HI9qz7cnLg5yT3Va9B7PeklNiuc3F07i84oq7nzJmymfxpjO82mib7vOTV1DI+9sLmHWmP7EeV3ErC25p8HhfVC21etImD4ig8tn5PKn5bt4b2sIFoYxxkSMPxN9O103q3bt52BNffTNtmmuqZ8+CrpvAG78+hjy+vfixr+ttVk4xnQj/kz07XTdvLO5lIQ4YeaoKHoatiV9cyF9KGx/x+tIAEhJjOe3F02m9PBRfrFkvdfhGGOC5NNE33bXzdItpRQM70uv5IQIBtUJIjDiVE4uNlAAABKSSURBVNj5nid1b1oyKacP18zK49lPdvPPtXu9DscYEwR/JvqmrpuU9OMOFR+sYePeg5w2OkqnVTaXe7qzCEkE15Ftz49n53Hi0D7c9OxaCiuqvA7HGNMOfyb66kpI7g3xx7fYl25xBhJPGx2CBcgjYeRskDjY/IrXkRyTGB/HvQuchcx//NQn1DU0ehyRMaYtPk30rde5WbqllP5pyZwwMC3CQXVSzwwY+lXY9E+vI/mSIf16cNcFk1hdWMl/vWYrUhkTzfyZ6GsqIfX4bpv6hkaWbS3jtNFZiETxtMrmxpwNJeuhYofXkXzJNyYN5JJpQ3lg6We8u8WmXBoTrfyZ6KtbLmi2pqiSA9V1nDamm3TbNBl7trPd/JK3cbTg1nPGMSY7jX/762qK9lt/vTHRKKhELyJzRGSziGwTkZtaOH6DiGwQkbUi8qaIDAs41iAiq93XklAG36pWum6Wbi4lTmBmXpRPq2yu3winJMKm6Ev0KYnxLP7OSdTVN3LVn1dRUxcds4OMMV9oN9GLSDxwPzAXGAdcLCLjmp32CVCgqpOAvwO/CThWrar57mteiOJuW03LlSuXbiklf0gf+vRIikgYITX2bPj8A6iq8DqS44zM6sU9C/JZv+cgNz/7qS1UYkyUCaZFPxXYpqrbVbUWeBqYH3iCqr6tqk1/ty8HckIbZgeotth1U374KGt3H+D0Md1kWmVzY78B2ghbomf2TaAzTsjmJ18bzXOf7OaR93d6HY4xJkAwiX4wUBjwc5G7rzVXAC8H/JwiIitFZLmInNfaRSJypXveytLSLgzs1VVDw9Hjum7e21qGajeaVtncwHzonQMbXvA6klZdOyuPs8Zl86uXNlo9HGOiSEgHY0XkO0ABsChg9zBVLQAuAe4RkZEtXauqD6pqgaoWZGV1IRm3Uudm6ZZS+vVMYuLg42fjdAsiMPFC2Po6HC7xOpoWxcUJv/12PqP69+LqP3/Mhj0HvQ7JGENwiX43MCTg5xx335eIyNeAW4B5qnq0ab+q7na324F3gBO7EG/7Wqhz09iovLe1lJl5mdFdrbI9+ZeANsDaZ7yOpFW9khN49AdfoVdyAj947CN2V1Z7HZIxMS+YRL8CGCUiuSKSBCwAvjR7RkROBP6Ak+RLAvb3FZFk930mMAPYEKrgW3Ss/MEXLfrNxYcoO1wb/UXM2pM1BgYXwOonPa9R35aB6ak8dvlXqDrawGWPfMSBKqt0aYyX2k30qloPXAu8CmwEnlHV9SJyu4g0zaJZBPQC/tZsGuUJwEoRWQO8DdylquFN9E0FzQK6bpZtLQO64bTKluRfAiUbYO8aryNp09gBvfnD96aws/wIP/zTSqprbdqlMV4Jqo9eVV9S1dGqOlJVf+nuu1VVl7jvv6aq2c2nUarqB6o6UVUnu9uHw/dVXC103SzbVsaIrJ4M6pMa9o8PuwkXQHwyrP6L15G06+SRmfzXRfms2FnBD59YaXPsjfGI/56MbdZ1c7S+gX/tKOcUP7TmwfkFNvZs+PQZqKvxOpp2zZs8iEUXTub9z8q48k/2QJUxXvBfoq/eD4hTvRL4eFclNXWNzBzVTadVtmTKZc73XPd3ryMJyoVTcvj1BZN4d0spV/95FUfrLdkbE0k+TPTuU7Fxzldbtq2U+Dhh2oh+HgcWQrmnOSURlj8Q1YOygS76yhB+df5E3t5cysLHV3L4aL3XIRkTM/yX6GsqvzTjZtnWMvKH9KF3SqKHQYWYCEy/Goo/he1vex1N0C6ZNpTfXDiJDz4r5+IHl1N66Gj7Fxljusx/ib56/7EZNweq6li7+wAz/NI/H2jSRZA2CN692+tIOuSigiH88XtT2FpyiAsf+IBd5Ue8DskY3/Nhov+izs0HnzllD07p7vPnW5KQDDOuh13vw85lXkfTIbPHZvOXH07nYHUdFyz+gI92RF+hNmP8xH+JPqDrZtm2MnomxZM/pOXVprq9Kd+HtIHwxi+6TV99k5OG9uXvV59M79RELvnjch59f4dVvTQmTPyX6AO6bpZtK2P6iAwS4/33NQFITIXTb4aij2Dji15H02Ejs3rxwrUzOH1Mf37x4gb+7a+r7cEqY8LAXxkwoERxYUUVu8qrun/Zg/bkXwpZJ8Brt0Bt91vhqXdKIg9+dwo/PWs0S9bsYd59y/i06IDXYRnjK/5K9LWHnaJfKX1Yts1HZQ/aEp8A3/gvqPwc3l3U/vlRKC5OuHb2KJ64fCoHa+o4f/H73PPGFuoaGr0OzRhf8FeiD6hzs2xbGdm9k8nr38vbmCJh+AynZf/+72D3Kq+j6bRTRmXx2r+dxjmTBnLPG1u5YPEHrNttrXtjuspnid4pf9CY0ocPtpUxIy8TkW5clrgjvv4rSBsAz/5/cPSw19F0WnqPRO5ZcCKLLz2JPZXVnHvfMv7vc59ScaTW69CM6bb8lejdOje7jiSxv6rOn9MqW5PaB87/A1R8Bi9c0+1m4TR39sSBvPXT07ns5OH8dUUhs+5+h0ff32HlE4zpBH8lerfrZkWxk+RmjIyhRA+QewqccRtseB5ev7XbJ/v01ERuO3c8L19/CuMH9eYXL27gtN+8wxMf7rTiaMZ0gM8SvdOif6+ojjHZafTvneJxQB6YcT18ZSF8cG+3e2q2NaOz03hy4TSeXDiNIf1SufWF9Zy+6B3+sPQz9luXjjHtSvA6gJCqaUr0DXxzeoy15puIwNxFUHsE3v5PZ9+pP3X2d2Miwoy8TE4emcGHn5Xzuze3cufLm/jt61uYnz+I704fzoTBvWNnTMaYDvBXoq/eT6MkUFmf6P9plW2Ji4N594E2Osm+eB3Mvx+Su/8MJBHh5LxMTs7LZNO+gzzx4S6e+3g3z6wsIq9/L87LH8S8yYMZmtHD61CNiRo+S/SVVMenkRgfx9RcH5Ul7oz4BGdwdsBEp7++dBOccw8M+6rXkYXM2AG9+dX5E/nZnLEsWbOHF1fv4e7XtnD3a1sYP6g3s8f25/Qx/ckf0of47rwovDFd5K9EX1NJRWNPThzal57J/vpqnSICJ/8YsifAkh/Do3Ng8sVw+k3Qd7jX0YVMemoi350+jO9OH8buympeXLOHNzcWc//b2/j9W9vo0yORgmH9KBjel4JhfZkwOJ2UxHivwzYmYnyVDesOV1Ban+KfZQNDZeQsuOZf8N5/wfv3wtq/wgnnQsEVMGyG0/r3icF9UrnqtJFcddpIKqtqeW9rGe9uKWXlrv28sbEYgKT4OMYP7s3YAWmMyU5jzADnfd+eSR5Hb0x4SDAVA0VkDvA7IB54SFXvanY8GXgCmAKUA99W1Z3usZuBK4AG4DpVfbW9zysoKNCVK1d27JsAlfeczCflCaT/8AVOGtq3/Qti0YHd8NGDsOpRqDkAPTJgzFwYNhOGTnda+j4d0Cw7fJRVu/azatd+VhdWsnnfIQ5U1x073q9nEkP6ppLTrwdD+vZgSL9UBqankNUrhcy0JDJ6JpOU4K+JasY/RGSVqha0eKy9RC8i8cAW4EygCFgBXKyqGwLO+REwSVWvEpEFwPmq+m0RGQc8BUwFBgFvAKNVtc1J0J1N9OW/OoEPa0cw5+cvkuDXipWhUnsEtr0BG5bA1tfhqFtqICkNMkZCRh70GwG9+kPPLGebku5UzEzs8cWrG/81oKqUHDrK5n2H2LzvEDvKj1BYUUVhRRW7K6upazj+/40+PRLJ7JVMn9RE0lISSEtpvk2gR1ICyQlxzisxnhR3G7gvOSGOhDghLk6IFyE+zn2Js8+Yjmor0Qfzf+lUYJuqbndv9jQwH9gQcM584D/c938H7hNnntt84GlVPQrsEJFt7v0+7MwXaYuqklh7gJ69My3JByOpJ4yb77waG6F0IxT+C0o2Qfk2p/Txun8A7fzFF5cI8UkQF+/8JSDx7vuArYjznnYSWJt/SYT+WgGygWwRTg080AO0B9Q3NFLfqDQ06rFtQ2Mj9dVKY5XSoNDYqDSq0qgEVU+/3n21t66WuN+pKfKWvp4c98PxJwX7K8Onf8R1O1Xx6Yy75f2Q3zeYRD8YKAz4uQiY1to5qlovIgeADHf/8mbXDm7pQ0TkSuBKgKFDhwYT+5ccrWtgW/rJ9B45vcPXxry4OMge77wCNdRDVTkcKYUjJXD0ENRVO38N1FW7ryPQUAeNDc50Tm1w3zc4v0AC97WpjSTZbgIN/bUCJLqvYH35F0LTLwCloRHnfaPScGzr/GJQN0RFna06MTWoG5n7SwScewTzFbWFH7SV76nNLujez1J3f/WJaWG5b9T83a2qDwIPgtN109HrU5ISOOknfw95XDEtPgHSsp2XaVe8+zIm2gTTx7EbGBLwc467r8VzRCQBSMcZlA3mWmOMMWEUTKJfAYwSkVwRSQIWAEuanbME+L77/kLgLXU6LJcAC0QkWURygVHAR6EJ3RhjTDDa7bpx+9yvBV7F+cv0EVVdLyK3AytVdQnwMPAnd7C1AueXAe55z+AM3NYD17Q348YYY0xoBTWPPtI6O73SGGNiVVvTK20eojHG+JwlemOM8TlL9MYY43OW6I0xxueicjBWREqBXZ28PBMoC2E43YF9Z/+Lte8L9p07apiqZrV0ICoTfVeIyMrWRp79yr6z/8Xa9wX7zqFkXTfGGONzluiNMcbn/JjoH/Q6AA/Yd/a/WPu+YN85ZHzXR2+MMebL/NiiN8YYE8ASvTHG+JxvEr2IzBGRzSKyTURu8jqeSBCRR0SkRETWeR1LJIjIEBF5W0Q2iMh6Ebne65jCTURSROQjEVnjfudfeB1TpIhIvIh8IiL/63UskSAiO0XkUxFZLSIhreroiz76YBYw9yMRORU4DDyhqhO8jifcRGQgMFBVPxaRNGAVcJ6f/zu7ay/3VNXDIpIILAOuV9Xl7Vza7YnIDUAB0FtVz/E6nnATkZ1AgaqG/CExv7Tojy1grqq1QNMC5r6mqu/i1P+PCaq6V1U/dt8fAjbSyhrEfqGOw+6PTcvYdv/WWTtEJAf4BvCQ17H4gV8SfUsLmPs6AcQ6ERkOnAj8y9tIws/twlgNlACvq6rvvzNwD/DvQKPXgUSQAq+JyCoRuTKUN/ZLojcxRER6Af8A/k1VD3odT7ipaoOq5uOsuTxVRHzdTSci5wAlqrrK61gibKaqngTMBa5xu2ZDwi+J3hYhjxFuP/U/gCdV9Vmv44kkVa0E3gbmeB1LmM0A5rl91k8Ds0Xkz96GFH6qutvdlgDP4XRJh4RfEn0wC5ibbs4dmHwY2Kiqv/U6nkgQkSwR6eO+T8WZcLDJ26jCS1VvVtUcVR2O8//yW6r6HY/DCisR6elOMEBEegJnASGbTeeLRK+q9UDTAuYbgWdUdb23UYWfiDwFfAiMEZEiEbnC65jCbAbwXZwW3mr3dbbXQYXZQOBtEVmL06B5XVVjYrphjMkGlonIGuAj4J+q+kqobu6L6ZXGGGNa54sWvTHGmNZZojfGGJ+zRG+MMT5nid4YY3zOEr0xxvicJXpjjPE5S/TGGONzluiNr4hIg/sg1ToRebHpqdIOXP8fIvLTVo4Nb632v4h8EPD+OhHZKCJPikgfEflRx76FMaFlid74TbWq5rv1+SuAayLxoap6csCPPwLOVNVLgT7uz8Z4xhK98bMPcctVi8h33JWaVovIH9zFanCP3SIiW0RkGTDG3ddTRP7pruy0TkS+7Z4eLyJ/dFd7es2tP4OIHHa3DwAjgJdF5CfAXcBI93MXNQ9QRN4KKOdQIyIXhfHfw8QoK4FgfEVEDqtqLzeRP41TBG0X8BvgAlWtE5HFwHJVfUJEpgCPAdOABOBj4AFgBzBHVX/o3jcd6Atsw1kFaLWIPAMsUdU/N32ue+5O95wyt27+/7a3ApiIXA3MwlkZrSGE/yTGWIve+E6qu0jHPpxCUa8DZwBTgBXusTNwWt0ApwDPqWqVW9u+qerpp8CZIvJrETlFVQ+4+3eo6mr3/SpgeFcDFpHv4dQgv9SSvAmHBK8DMCbEqlU1X0R64FQzvQZn5Z7HVfXmYG+iqltE5CTgbOA/ReRN4AngaMBpDUBqV4IVkW8BlwLzVbWuK/cypjXWoje+pKpVwHXA/wGWAheKSH8AEeknIsPcU98FzhORVLce+LnuOYOAKlX9M7AIOKmToRwC0lo64K6k9COcLqWaTt7fmHZZi974lqp+4tZxnwz8/zjrccYBdTgt/V2q+rGI/BVYg7Mm6wr38onAIhFpdM+/upMxlIvI++60zJdV9caAw4/jzAx631lThd+r6sOd+Rxj2mKDscYY43PWdWOMMT5nid4YY3zOEr0xxvicJXpjjPE5S/TGGONzluiNMcbnLNEbY4zP/T/zuHRbtUFTrQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# And let's plot it\n",
+    "z = np.linspace(0,5,256)\n",
+    "\n",
+    "# Redshift distributions are callable, and they return the normalized distribution\n",
+    "plot(z, nz1(z), label='z0=1.')\n",
+    "plot(z, nz2(z), label='z0=0.5')\n",
+    "legend();\n",
+    "xlabel('Redshift $z$');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "0eG0GXjCLmhz",
+    "outputId": "283348ed-0a18-45b4-a584-a58db0a72c39"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray(0.99999976, dtype=float32)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can check that the nz is properly normalized\n",
+    "jc.scipy.integrate.romb(nz1, 0., 5.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZUYVlhKkMLpl"
+   },
+   "source": [
+    "Nice :-D "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "PGCY4irsNI9B"
+   },
+   "source": [
+    "## Defining probes and computing angular $C_\\ell$\n",
+    "\n",
+    "Let's now move on to define lensing and clustering probes using these two n(z).\n",
+    "In `jax-cosmo` a probe/tracer of a given type, i.e. lensing, contains a series of parameters, like redshift distributions, or galaxy bias. Probes are hosted in\n",
+    "the `jax_cosmo.probes` module.\n",
+    "\n",
+    "$C_\\ell$ computations will then take as argument a list of probes and will compute all auto- and cross- correlations between all redshift bins of all probes. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "-YUfaBhzNINW"
+   },
+   "outputs": [],
+   "source": [
+    "# First we define a list of redshift bins\n",
+    "nzs = [nz1, nz2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "R3qUxP9wO6fH"
+   },
+   "outputs": [],
+   "source": [
+    "# And now we define 2 probes \n",
+    "probes = [ jc.probes.WeakLensing(nzs, sigma_e=0.26), \n",
+    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.)) ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "t40aS024QFHx"
+   },
+   "source": [
+    "Given these probes, we can now compute tomographic angular power spectra for these probes using the `angular_cl` tools hosted in the `jax_cosmo.angular_cl` module. For now, all computations are done under the Limber approximation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 139
+    },
+    "colab_type": "code",
+    "id": "QWedY8i6cFkw",
+    "outputId": "d8b34187-8daf-4218-84a1-e6093a5868f2"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Let's define a range of \\ell\n",
+    "ell = np.logspace(1,3)\n",
+    "\n",
+    "# And compute the data vector\n",
+    "cls = jc.angular_cl.angular_cl(cosmo, ell, probes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "VSKlZxxARxYO",
+    "outputId": "3d39a4d7-165e-428d-d2a8-d482353d2064"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10, 50)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Let's check the shape of these Cls\n",
+    "cls.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "X-Vnim-cSQSh"
+   },
+   "source": [
+    "We see that we have obtained 10 spectra, each of them of size 50, which is the length of the $\\ell$ vector. They are ordered first by probe, then by redshift bin. So the first cl is the lensing auto-spectrum of the first bin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 303
+    },
+    "colab_type": "code",
+    "id": "-Xc458aidYL8",
+    "outputId": "960b3f8d-8bb4-4018-f45d-869de305ca19"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEeCAYAAACdYvI/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3zV9b3H8dcni5AAgZCwCXsKAhJmgrjFgQwVcTFEERneVju0t95qb1vb26tWBUVUQMGBTAWtVK2KhBmWbMPehBlmgITv/SOxjVxGTjjJ75yT9/PxyKM953fGO338mje/3+/7+37NOYeIiEhhhXkdQEREgouKQ0REfKLiEBERn6g4RETEJyoOERHxiYpDRER8ouIQERGfqDhERMQnKg4Rj5nZFjO7wescIoWl4hApwMy+MbNDZlbG6yxFZWblzexPZrbBzI6a2WYzG2lmiV5nk9Cg4hDJZ2Z1gS6AA+7wNMwlmFnEBZ6vCHwHNAVucc6VJ+93igTqlFxCCWUqDpF/6wcsAMYD/QtuyD+d9Asz+97MssxskplF52+7ysyW5f/rfnL+tj8UeK8zs4YFHo8vuP2c73nKzDbmf9YaM+t1ToZfm9n3wPELlMdLwEHgLudcBoBzbodz7lHnXHpR/4cRKUjFIfJv/YD38n9uNrOq52zvA3QD6gFXAgPMLAqYTl7ZxAMfAL0ouo3kHSHEAc8BE82seoHt9wK3ARWdczkF32hmtYEHgf90zp29jAwiF6XiEAHMLJW8UzkfOeeWkPcH/L5zXvaKc26Xc+4gMBNoDXQEIvK3nXHOTQMWFTWHc25y/necdc5NAjKA9udk2O6cO3met98A7HPOzS/q94sUhopDJE9/4B/Ouf35j9/nnNNVwJ4C//0EUA6oAex0P12fYHtRQ5hZPzNbbmaHzeww0AJIKORnVwW2XeLzh5rZvKLmE4G8fymJlGpmVpa801DhZvZjOZQBKppZK+fciou8fTdQ08ysQHnUJu+I5UcngJgCj6sBO86Tow7wJnA9MN85l2tmywEr8LKLLaCzLT9L2EVOVd0M6IhELouOOESgJ5ALNCfv9FNroBl5o5P6XeK98/PfO9zMIsysBz89tQSwHLjPzMLNrBvQ9QKfFUteMewDMLOB5B1xFNas/P/8s5lVyP+Mxmb2spkl5F+gz+Q8pSXiCxWHSN4pqXHOuW3OuT0//gAjgfsvNPQVwDl3GugNDAIOAw+Q9wf8VIGX/QfQPX/7/cCMC3zWGuAF8spoL9ASSCvsL+GcOwJcBzQGMvJPdU0HjuefgmtB3oX9twr7mSLnY1o6VsS/zGwhMNo5N87rLAWZWX/yrsu8rlFXcjl0xCFymcysq5lVyz9V1Z+8obqfe52rIDMzoC551zh+7m0aCXa6OC5y+ZoAH5F3jWITeTff7fY20k/lX7h/zuscEhp0qkpERHyiU1UiIuITFYeIiPikVFzjSEhIcHXr1vU6hohI0FiyZMl+59x5p+IvFcVRt25d0tM1MaiISGGZ2dYLbdOpKhER8YmKQ0REfKLiEBERn6g4RETEJyoOERHxSUgXh5l1N7MxWVlZXkcREQkZIV0czrmZzrnBcXFxRXr/dxn7WLDpANsPnuB0jiYTFRGBUnIfR1H918er2bz/OABmUKV8GWpWLEuNimWpVSmG+gmx1E+MpV5CLPGxUeRNQCoiEtpUHBcxdkA7dh46ya7DJ9mZ/7Pr8ElW7cxi9uo9nMn99wSRcWUjqZcQS4PEcjSrXp5m1SvQrHoF4mOjPPwNRET8T8VxEfUS8o4mzicn9yw7Dp1k8/7jbNx3jM37j7N5/3HmZOxj6tJ/r8xZtUKZf5VIq1oVuSqpIlUqRJfUryAi4ncqjiKKCA+jbkIsdRNiubZplZ9s23/sFGt3H8n/Ocra3UeYm7GfnLN5Ryg1K5alde2KtEmqSOvaFWlZK44yEeFe/BoiIj5TcRSDhHJl6NIokS6N/j0/WPaZXFbvOsKybYdYvv0wy7Yd5tOVeWv9lIkIo22dSnSsX5lODSrTqlZFoiJCetyCiASxUrGQU3JysgvESQ4zj2azbNthFm46yIJNB1i75wjOQXRkXpGkNEzgmsZVaFa9vC68i0iJMrMlzrnk825TcQSOwydOs3BzXonM33iAdXuOAnnXSbo2TuSaJlVIbZRAhehIj5OKSKhTcQRJcZwr80g23/ywj2/X72NOxj6OZucQHmYk16lEtxbVuPmKatSoWNbrmCISglQcQVocBeXknmXptsN8sz6TL9fu5Ye9xwBoVSuOm1tUo9sV1aifWM7jlCISKlQcIVAc59q47xizV+9h9qo9rNiRN6VKk6rluaN1De5oVYPa8TEeJxSRYKbiCMHiKGjn4ZP8Y/UePv1+N+lbDwGQXKcSPdrU5LaW1XUTooj4TMUR4sVR0PaDJ/hkxS5mLNtJRuYxIsKMro0TuTu5Ftc1raphviJSKCqOUlQcP3LOsXb3UT5evpMZy3ey98gpEspFcedVtejTrjYNdD1ERC5CxVEKi6Og3LOOOT/s48PF2/hqbSY5Zx3t68ZzT7va3NqyOmWjdNe6iPyUiqOUF0dBmUezmbZ0J5MWb2fz/uPElY2kb7vaPNCxji6oi8i/lNriMLPuQPeGDRs+kpGR4XWcgOKcY8Gmg0xYsIXZq/dy1jmub1qF/p3rktowQXeqi5RypbY4fqQjjovbnXWS9xZs44NF2zhw/DT1E2MZ2Lkud7WtrdNYIqWUikPFUSincnL59PvdvDNvCyt2ZFEpJpIHO9Wlf6c6VC5Xxut4IlKCVBwqDp8451i85RBj5mzky7WZlIkI4+7kWjycWp+6F1ifRERCy8WKQ9Oqy/9jZrSvF0/7evFsyDzKm3M289HiHby3cBu3tKjGsGsbckWNoq3jLiLBT0ccUiiZR7IZP28LE+Zv5eipHG5oVoUR1zWiVe2KXkcTkWKgU1UqDr/JOnmGd+Zt4e25m8k6eYaujRN5/PpGtK1TyetoIuJHKg4Vh98dzT7DhAVbeeu7zRw8fpqUhpV54sYmKhCREKHiUHEUmxOnc3hvwTbemLOR/cdOc33TKjx5UxOa16jgdTQRuQwqDhVHsTt+Kofx87bwxrcbOZKdw+1XVufnNzbWnFgiQUrFoeIoMVknz/DmnE2MTdtM9plc7ryqFj+/sbFWKhQJMioOFUeJ23/sFK99vZGJC7diwEOp9XjsmgZaL10kSKg4VBye2XHoBC/84wemL9tJpZhIHr++Efd3qKN1QUQC3MWKQ//vlWJVq1IML93TmlkjUmlWvQLPzVzDTS99y2crd1Ma/tEiEopUHFIiWtSM472HOzBuQDuiIsIY+t5S7ho9n5X566WLSPBQcUiJMTOubVqFzx7vwvO9W7L1wHHuGDWXX01ZQebRbK/jiUghqTikxEWEh3Fv+yT++YtreKRLfaYv28l1//stb3y7kVM5uV7HE5FLUHGIZypER/KbW5sx+2dX06FePM//fR03vzSHr9bu9TqaiFyEikM8Vz+xHG8PaMf4ge0IDzMGvZPOw+8sZvvBE15HE5HzUHFIwLimSRU+/9nV/ObWpszbeIAbXvyWV77KIPuMTl+JBBIVhwSUyPAwBl/dgK+e7MoNzary4hc/0O1vc/j2h31eRxORfCoOCUjV48oy6v6rePeh9oSZ0X/sIoZMWMLurJNeRxMp9VQcEtCubpzI33/WhV/e3ISv12dy44tzGJ+2mdyzunlQxCsqDgl4ZSLCGXZtQ774eVfaJFXk2Zlr6P36PNbsOuJ1NJFSScUhQSOpcgzvPtSel/u2ZuehE3QfOZfnP1vLidM5XkcTKVVUHBJUzIwerWvy5RNdubttLd6Ys4mbXprDHF08FykxKg4JShVjovjznVcyaXBHoiLC6Dd2Eb+YvIKsE2e8jiYS8oKuOMwsycxmmNlYM3vK6zzirQ71K/PZ410Ydm0Dpi/byQ0vfcvnq/Z4HUskpJVoceT/sc80s1XnPN/NzNab2YZClEFLYIpz7iGgTbGFlaARHRnOL29uysfDUkgsV4YhE5cw7L2l7Dt6yutoIiGpRBdyMrOrgWPAu865FvnPhQM/ADcCO4DFwL1AOPD8OR/xEJALTAEcMME5N+5S36uFnEqPM7lnGTNnEy9/mUHZqHCeu+MKerSugZl5HU0kqATUCoBmVheYVaA4OgHPOuduzn/8NIBz7tzS+PH9vwAWOefmmNkU59xdF3jdYGAwQFJSUtutW7f6+1eRALYh8xi/mrKCpdsOc1PzqvyxV0sSy5fxOpZI0Aj0FQBrAtsLPN6R/9yFfA48bmajgS0XepFzboxzLtk5l5yYmOiXoBI8GlYpx+QhnfnNrU355od93PTSt8xcscvrWCIhIcLrAL5yzq0CznuUIVJQeJgx+OoGXNe0Ck9O/p4RHyzj81V7+H2PK6hcTkcfIkUVCEccO4HaBR7Xyn9OxC8aVinP1CGd+FW3JnyxZi83vTSHz1ft9jqWSNAKhOJYDDQys3pmFgX0BT7xxwebWXczG5OVpXWtS7uI8DCGXtOQmSNSqV4xmiETl/LkRys4kq37PkR8VdLDcT8A5gNNzGyHmQ1yzuUAw4HZwFrgI+fcan98n3NupnNucFxcnD8+TkJAk2rlmT40hceva8j0ZTu45W/fsWDTAa9jiQSVEh9V5QUNx5XzWbrtEE9MWs7Wgyd4pEt9nrixMdGR4V7HEgkIgT6qSsQTVyVV4rP/6MJ97ZMYM2cTPUamacZdkUJQcUipFhMVwR97tWTcwHYcPHGanqPSeOu7TZzVeh8iF6TiEAGubVKF2T+7mq5NEvnDp2vpP24RmUeyvY4lEpBCujg0qkp8ER8bxZgH2/LHXi1YvOUgN/9tDl+s2et1LJGAE9LFoVFV4isz4/4OdZg1IpXqcWV55N10fjtjJSdP53odTSRghHRxiBRVwyrlmT6sM4Ovrs/EBdvoPnIu6/bowrkIqDhELqhMRDi/ubUZEwa1J+vkGXqMTGPigq2UhiHsIhej4hC5hC6NEvn7f3ShQ/3K/HbGKoa+t5Ssk7rjXEqvkC4OXRwXf0koV4bxA9rx9C1N+WLNXm59+TuWbjvkdSwRT4R0cejiuPhTWJjxaNcGTB7SCTO4e/R8Xv9mo+75kFInpItDpDi0SarEp493odsV1fjL5+sYOH4xB4+f9jqWSIlRcYgUQVzZSEbe14b/7tmC+RsPcNsr37Fk60GvY4mUCBWHSBGZGQ92rMO0oZ2JDA/jnjcW8NZ3mzTqSkKeikPkMrWoGcfMEalc36wKf/h0LYMnLCHrhEZdSehScYj4QVzZSEY/0JZnbm/O1+syue3V71i5Q6P5JDSFdHFoOK6UJDNjUGo9Jg/phHNw5+vz+HDRNq9jifhdSBeHhuOKF9okVWLmiFQ61I/nqWkr+dWUFWSf0VxXEjpCujhEvBIfG8X4ge0ZcV1DPkrfwV2j57H94AmvY4n4hYpDpJiEhxlP3tSEt/ols/XACW5/dS5fr8/0OpbIZVNxiBSzG5pXZdaIVGpULMtD4xfz8pcZuttcgpqKQ6QE1Kkcy7THOtOrTU1e+vIHHp24hKPZGrIrwUnFIVJCykaF88Ldrfhd9+b8c10mPUelsXHfMa9jifhMxSFSgsyMgSn1mDioA4dOnKHnyDS+1PK0EmRCujh0H4cEqk4NKjNzRCp1EmJ4+N10XfeQoBLSxaH7OCSQ1axYlilDOtO7wHWPY6dyvI4lckkhXRwigS46MpwX+rTiv27Pu+7R+7U0th3Q/R4S2FQcIh4zMx5Krcc7A9uz98gp7hg1l3kb93sdS+SCVBwiASK1UQIfD0shoVwZHnx7ERPmb9EU7RKQVBwiAaRuQizTh3ama+NEnvl4Nf85YxWnc856HUvkJ1QcIgGmfHQkb/ZL5rFrGvD+wm088PZCLU0rAUXFIRKAwsOMX3dryst9W7N8+2F6jJpLxt6jXscSAVQcIgGtR+uaTBrckZOnz9L7tXmaJFECQkgXh24AlFDQJqkSnwxPoVZ8DIPGL2bs3M26aC6eCuni0A2AEipqVCzLlCGduL5ZVX4/aw3/OWMVZ3J10Vy8EdLFIRJKYstE8MYDbf910bz/2EUcPqGL5lLyVBwiQSQs/6L5C3e3In3LIXq/No8t+497HUtKGRWHSBC6s20tJj7cgUMnTtPztTQWbT7odSQpRVQcIkGqfb14pg9NIT4mivvfWsC0pTu8jiSlhIpDJIjl3WmeQnKdeJ74aAUv/GO9pmeXYqfiEAlycTGRvPNQe/ok1+LVf27g8Q+XkX0m1+tYEsIivA4gIpcvKiKMv9x5JfUSyvGXz9ex6/BJ3uyXTOVyZbyOJiFIRxwiIcLMeOyaBrx+/1Ws3nWEXq/NY0Om1jQX/1NxiISYW1pW58PBHTlxOofer6Uxf+MBryNJiFFxiISgNkmVmD40hSoVouk3diFTl2jElfhPSBeH5qqS0qx2fAxTH+tMu7rxPDl5BS9+8YPmuBK/8Kk4zCzVzIaZWf0Cz9Xzfyz/0FxVUtrFlY1k/MC8EVevfJXBzyct51SORlzJ5fF1VFUi0B5ob2YHgPeBXwF9/B1MRPzjxxFXdSrH8tfZ69mVlc2YB9tSMSbK62gSpC55xGFmz5jZMADn3HTgIWAUsAroAqwt1oQictnMjGHXNuSVe9uwfNthzXEll6Uwp6r6AG//+MA5l+ucW5T/3mjn3O+KK5yI+NcdrWrw3iN5c1z1fn0eS7ZqjivxXWGK44xzLvs8z78LPODnPCJSzNrVjWfa0BQqREdw75sLmfX9Lq8jSZApTHGcNrPq5z7pnDsNnPF/JBEpbvUSYpk2NIUra8Yx/P1lvPbNBo24kkIrTHG8AHxsZnUKPmlmVQDtaSJBKj42iokPd6B7qxr8z+freXraSq0qKIVyyVFVzrnJZhYDLDGzBcBy8grnbuDZ4o0nIsUpOjKcl+9pTVJ8WUZ9vZGdh08y6v6rqBAd6XU0CWCFuo/DOfcOUA+YBEQC2cB9zrn3ijGbiJSAsDDjlzc35X/uvJL5Gw9w9+vz2Xn4pNexJIBZaTivmZyc7NLT072OIRLw5mbs57GJSygbFc7b/dvRspZuni2tzGyJcy75fNtCesoREfFNaqMEpg7tTGR4GH3emM+Xa/Z6HUkCkIpDRH6icdXyTB/WmUZVyzF4Qjrj0zZ7HUkCjIpDRP6fKuWj+XBwR65vVpVnZ67h2U9Wk6slaSWfikNEzismKoLRD7Tl4dR6jJ+3hUcnpHP8VI7XsSQAqDhE5ILCw4zf3t6c/+7Zgn+uy6TPG/PZk3W+iSSkNFFxiMglPdixDm8PaMeW/cfpOSqNNbuOeB1JPKTiEJFCubZJFSYP6YwZ3D16Hl+vy/Q6kngkpItDKwCK+FfzGhWYMSyFeomxDHpnsUZclVIhXRxaAVDE/6pWiOajRztxXdO8EVe/+3gVOZrjqlQJ6eIQkeIRExXBGw/mjbh6Z/5WHnk3nWMacVVqqDhEpEh+HHH1h54tmJOxn7ten6c5rkoJFYeIXJYHOtZh3IB27Dx0kp6j0lix/bDXkaSYqThE5LJd3TiRqUM7ExUexj1j5vP3lbu9jiTFSMUhIn7RuGp5ZgxLoVn1Cjz23lJGfa1VBUOVikNE/CaxfBk+eKQjd7SqwV9nr+cXk7/ndI5GXIWaS64AKCLii+jIcF7u25r6ibH87csMth86wegH2hIfG+V1NPETHXGIiN+ZGT+7oTEv923N8u2H6fVaGhv3HfM6lviJikNEik2P1jX54JGOHMvOodeoNOZm7Pc6kviBikNEilXbOpWYMSyF6nFl6T9uERMWbPU6klwmFYeIFLva8TFMeawTXRsn8syMVTz7yWpNUxLEVBwiUiLKR0fyZr/kfy0M9dA76RzJPuN1LCkCFYeIlJgfpyn5c++WzNuwn96vzWPrgeNexxIfqThEpMT1bZ/EhEEd2H/sFD1GpTF/4wGvI4kPVBwi4olODSozY2gKlWOjePDthXywaJvXkaSQVBwi4pm6CbFMH5ZCSsMEnp62UhfNg4SKQ0Q8VSE6krED2jEo/6L5wPGLyTqpi+aBTMUhIp4LDzOeub05f7mzJQs2HaDXa2ls3q+L5oFKxSEiAeOedklMHNSBwyfO0FN3mgcsFYeIBJQO9Svz8bAUqlWIpv+4RYxL26zp2QOMikNEAk7t+BimDu3M9U2r8NzMNTw1dSWncnK9jiX5VBwiEpDKlYlg9ANtefy6hkxK3859by5k39FTXscSVBwiEsDCwownbmrCqPuuYvWuLO4YOZdVO7O8jlXqqThEJODddmV1pgzpjAF3jZ7HzBW7vI5UqgVdcZhZczP7yMxeN7O7vM4jIiWjRc04Ph6eSsuacYz4YBl//vs6cs/qorkXSrQ4zGysmWWa2apznu9mZuvNbIOZPXWJj7kFeNU59xjQr9jCikjASSxfhvce7sh9HZIY/e1GBr2jmwW9UNJHHOOBbgWfMLNwYBR5hdAcuDf/qKKlmc0656cKMAHoa2Z/BSqXcH4R8VhURBh/6tWSP/ZqwdyM/fQclcaGzKNexypVrKTHR5tZXWCWc65F/uNOwLPOuZvzHz8N4Jx7/hKfEw5Mc871uMD2wcBggKSkpLZbt2rVMZFQs3jLQR6buITsM2f52z2tuaF5Va8jhQwzW+KcSz7ftkC4xlET2F7g8Y78587LzOqa2RjgXeCvF3qdc26Mcy7ZOZecmJjot7AiEjja1Y3nk+Gp1EuI5ZEJ6bzyVQZndd2j2AVCcfjEObfFOTfYOXe/c26u13lExFs1KpZl8pBO9Gxdkxe/+IEhE5dw7FSO17FCWiAUx06gdoHHtfKfExEplOjIcF7s04pnbm/OV+sy6TkqjY37jnkdK2QFQnEsBhqZWT0ziwL6Ap94nElEgoyZMSi1HhMGtefg8dP0HJnGV2v3eh0rJJX0cNwPgPlAEzPbYWaDnHM5wHBgNrAW+Mg5t9pP39fdzMZkZelOU5HSonODBD4ZnkKdhBgGvZPOy1/quoe/lfioKi8kJye79PR0r2OISAnKPpPLb6atZNqyndzQrCov3tOKCtGRXscKGoE+qkpExO+iI8N5oU8rfte9OV+vz6TnyDQy9up+D39QcYhIyDIzBqbU4/2HO3AkO4ceo9L49PvdXscKeioOEQl5HepXZtaIVJpUK8+w95fy/Gdryck963WsoBXSxaGL4yLyo2px0Uwa3IkHOibxxpxN9Bu7iAPHtL5HUYR0cTjnZjrnBsfFxXkdRUQCQFREGH/o2ZK/3nUl6VsP0f3VuSzfftjrWEEnpItDROR87k6uzdQhnTEz+oyez/sLt2ldcx+oOESkVGpZK45ZI1Lp2KAyv5m+kl9N+Z7sM1rXvDBUHCJSalWKjWLcgHY8fn0jJi/ZwZ2vz2P7wRNexwp4IV0cujguIpcSHmY8cWNj3u6fzPaDJ7j91bl8vT7T61gBLaSLQxfHRaSwrm9WlVkjulCjYlkeGr+Yl774QUvTXkBIF4eIiC+SKscw7bHO9G5Ti5e/ymDg+MUcPH7a61gBR8UhIlJA2ahw/vfuK3m+d0sWbDygIbvnoeIQETmHmXFv+ySmPtYZM7h79DwmLNiqIbv5VBwiIhfw45Dd1IYJPDNjFT+ftJwTp7W6oIpDROQiKsZE8Xb/djx5Y2M+XrFLqwsS4sWh4bgi4g9hYcaI6xvx7kPt2X/sNHe8OrdUz7Ib0sWh4bgi4k9dGiUya0QqjfNn2X1u5mpO55S+WXZDujhERPytRsWyTBrciYEpdRmXtoW+Y+azO+uk17FKlIpDRMRHURFh/K77FYy67yrW7znKba/M5buMfV7HKjEqDhGRIrrtyup8MiKVhHJR9Bu7iJe/zOBsKbjbXMUhInIZGiSWY8awFHq2rslLX/7AgFJwt7mKQ0TkMsVERfBin1b8qVfe3ea3vfIdS7cd8jpWsVFxiIj4gZlxX4e8u80jwvMWiBo7d3NI3m0e0sWh+zhEpKS1rBXHrOFduKZJFX4/aw3D3l/K0ewzXsfyq5AuDt3HISJeiIuJ5M1+bXnqlqbMXr2XO0amsW7PEa9j+U1IF4eIiFfMjCFdG/D+wx04diqHnqPSmLJkh9ex/ELFISJSjDrUr8ynj6fSpnYlfjF5BU9NDf61zVUcIiLFrEr5aCYMas+waxvw4eLt9H5tHlsPHPc6VpGpOERESkBEeBi/vLkpYwcks/PwSW5/dS6zV+/xOlaRqDhERErQdU2rMmtEKvUSYnl0whL+9NlacnKDa6JEFYeISAmrHR/D5CGdeLBjHcbM2cR9by4k80i217EKTcUhIuKBMhHh/HfPFrzctzUrd2Zx6ytzmbdxv9exCiWki0M3AIpIoOvRuiafDE8hrmwED7y1kFFfbwj4iRJDujh0A6CIBINGVcvzyfBUbruyBn+dvZ5H3k0n60Tg3m0e0sUhIhIsYstE8Erf1jx3xxXMydjH7SO/Y9XOwDxbouIQEQkQZkb/znWZ9GgncnIdvV+fx6TF27yO9f+oOEREAsxVSZWYNSKVDvXi+fXUlfxy8oqAuttcxSEiEoAqlyvD+IHtefy6hkxesoNeAXS3uYpDRCRAhYcZT9zUhHED2rEr/27zL9fs9TqWikNEJNBd27QKs0akUqdyDA+/m87/zl5ProdDdlUcIiJBoHZ8DFOGdOae5NqM/HoDA8Yt8mxtcxWHiEiQiI4M5y93Xcmfe7dk4eaDdH91Liu2Hy7xHCoOEZEg07d9ElOHdAbg7tHz+WBRyQ7ZVXGIiAShlrXimDUilY4NKvP0tJX8ekrJLRCl4hARCVKVYqMYN6AdI65ryKT07fR5Yz47D58s9u8N6eLQJIciEurCw4wnb2rCmAfbsmnfcbq/Wvyz7IZ0cWiSQxEpLW66ohofD0+hcmwUD7y1kDFzNuJc8QzZDeniEBEpTRoklmP6sBS6tajGnz5bx/D3l3H8VI7fv0fFISISQsqViWDUfVfx9C1NWbv7CDm5/j/qiPD7J4qIiKfMjEe7NqB/57pER4b7/fN1xCEiEqKKozRAxSEiIj5ScYiIiE9UHCIi4hMVh4iI+ETFISIiPlFxiE0wZNoAAANsSURBVIiIT1QcIiLiEyuuuUwCiZllARkXeUkccKGZEBOA4p0xrHhc7HcK5O8q6mf5+j5fXn+p117Odu1fJftdJbV/+fKewrzuYq8prv2rjnMu8bxbnHMh/wOMKep2IN3r/MXxOwfqdxX1s3x9ny+vv5z951LbtX+V7HeV1P7ly3sK87pL7EMlvn+VllNVMy9zezAqyd/Jn99V1M/y9X2+vP5y9x/tX4HzXSW1f/nynsK87mKvKfH9q1ScqrocZpbunEv2OoeEJu1fUpyKa/8qLUccl2OM1wEkpGn/kuJULPuXjjhERMQnOuIQERGfqDhERMQnKg4REfGJisNHZlbfzN42syleZ5HQY2Y9zexNM5tkZjd5nUdCi5k1M7PRZjbFzB4r6ueoOAAzG2tmmWa26pznu5nZejPbYGZPATjnNjnnBnmTVIKRj/vXDOfcI8AQ4B4v8kpw8XH/WuucGwL0AVKK+p0qjjzjgW4FnzCzcGAUcAvQHLjXzJqXfDQJAePxff/6bf52kUsZjw/7l5ndAXwKfFbUL1RxAM65OcDBc55uD2zIP8I4DXwI9CjxcBL0fNm/LM9fgL8755aWdFYJPr7+/XLOfeKcuwW4v6jfqeK4sJrA9gKPdwA1zayymY0G2pjZ095EkxBw3v0LGAHcANxlZkO8CCYh4UJ/v64xs1fM7A0u44gj4nLTlTbOuQPknX8W8Tvn3CvAK17nkNDknPsG+OZyP0dHHBe2E6hd4HGt/OdE/EH7lxSnYt2/VBwXthhoZGb1zCwK6At84nEmCR3av6Q4Fev+peIAzOwDYD7QxMx2mNkg51wOMByYDawFPnLOrfYypwQn7V9SnLzYvzTJoYiI+ERHHCIi4hMVh4iI+ETFISIiPlFxiIiIT1QcIiLiExWHiIj4RMUhIiI+UXGIiIhPVBwiHjGzWDMbaWYdvc4i4gsVh4h3hgDRQKrXQUR8oeIQ8U43YD2w3OsgIr5QcYh4wMyigXDgKuBbj+OI+ETFIeKNRuQVxzrn3Bmvw4j4QisAingjEWiM1rGXIKQjDhFv1ACmAmFmVsnrMCK+UHGIlDAziyDv2kY1YDSQ620iEd9oIScREfGJjjhERMQnKg4REfGJikNERHyi4hAREZ+oOERExCcqDhER8YmKQ0REfKLiEBERn/wfONPHDY6UPQ0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# This is for instance the first bin auto-spectrum \n",
+    "loglog(ell, cls[0])\n",
+    "ylabel(r'$C_\\ell$')\n",
+    "xlabel(r'$\\ell$');\n",
+    "title(r'Angular $C_\\ell$');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Ri-QjcD8UckV"
+   },
+   "source": [
+    "In addition to the data vector, we can also compute the covariance matrix using the tools from that module. Here is an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "zIdQSRgkUYC7"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     ]
+    }
+   ],
+   "source": [
+    "mu, cov = jc.angular_cl.gaussian_cl_covariance_and_mean(cosmo, ell, probes);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "yGd3NelNVZpj"
+   },
+   "source": [
+    "The data vector from this function is in a flattened shape so that it can be multiplied by the covariance matrix easily."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 265
+    },
+    "colab_type": "code",
+    "id": "WX5lmHsRVXIh",
+    "outputId": "64a404cf-9269-4e8b-ff67-3de6eb3ba183"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD4CAYAAAAKA1qZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO2dd3xb15XnfwcAwd6JRrGIoiR2qlpWsa1OUcV2YjsTK5mMk3HiccpMpu2MvbNTMjvefHbms5mSeJPxxk4yieMSx4ltSVaXYsmSbUmWrUYVqlOi2NRIUWLD3T8eQIIQAOJV4IHn+/nwI/IBwr0PJO6595TfISEEGIZhmPGJJdYTYBiGYWIHGwGGYZhxDBsBhmGYcQwbAYZhmHEMGwGGYZhxjC3WE5BDQUGBmDhxYqynwTAMYyoOHDjQKYRwhHrMVEZg4sSJ2L9/f6ynwTAMYyqI6Hy4x9gdxDAMM44xhREgogeJ6IUbN27EeioMwzAJhSmMgBDiHSHEU9nZ2bGeCsMwTEJhCiPAMAzD6AMbAYZhmHEMGwGGYZhxDBsBhmGYcQwbAYZhmCg5evkGNh65Aq83cST4TVUsxjAME0v+57pj+ODMVdROyML//cIslOSnxXpKquGTAMMwTJQkWaUl8+LV23jo+d043GL+2qWYGgEiWkREu4joR0S0KJZzYRiGiYYZJTl4+1sLkG634cs/+QjnOm/FekqqUGwEiOglImonoiNB1xuJ6AQRNRPRM2O8jADQAyAFQIvSuTAMwxiBEICFCKX56fj5k3PgFQLf/OXH6BscivXUFKPmJPBTAI2BF4jICuB5ACsBVANYS0TVRFRHROuCvpwAdgkhVgL4awDfUTEXhmEY3fEKAQtJ309yZOCfH5uGo5dv4ntbTsZ2YipQHBgWQrxHRBODLs8B0CyEOAMARPQqgIeFEN8FsCbCy10DkBzqASJ6CsBTAFBSUqJ0ugzDMKrxCgECDf+8vNqFz88uxo93ncWjM4sw1ZUZw9kpQ+uYwAQAFwN+bvFdCwkRPUJE/wng5wB+EOo5QogXhBCzhRCzHY6QctgMwzCGIARANPraX6+sREayDd9552hsJqWSmAaGhRBvCiH+SAjxeSHEznDPYxVRhmHiAX9MIJC8dDu+vXQK3m/uwgdnumI0M+VobQQuASgO+LnId41hGMb0eIW46yQAAF+4twSOzGT8+9ZTxk9KJVobgX0AphBRGRHZATwO4G21L8pS0gzDxAMCd58EACAlyYo/emAS9p7pwkdnrxo/MRWoSRF9BcBeABVE1EJETwohBgF8C8AmAE0AXhdCmNNRxjAME0S4kwAAfPHeUhRkJOMHO5qNnZRK1GQHrQ1zfQOADYpnFAIiehDAg5MnT9byZRmGYWThFQCFsQKpdiuemFeK/7PlJE539KDckWHw7JRhCtkIdgcxDBMPiIA6gVCsvbcEdqsF/7XnnGFzUospjABnBzEMEw+Eyg4KpCAjGWvqPXjjQAu67wwYODPlmMII8EmAYZh4wDvGSQAAnpg/Ebf6h/DGAXMo4ZjCCDAMw8QDUhuByFZgWnEOphVl47V9FyFE/PcdMIURYHcQwzDxwFgxAT+fm12M41e6cfhS/K9ZpjAC7A5iGCaQrp4+DA55DR93rJiAn4emFyLZZsFr+y6O+dxYYwojwDAM4+fi1V7M+qetmP6PW/Dsm4dx6fptw8aOVCcQSFZKElbVefD2J5dxuz++ZabZCDAMYyq6bvUDAKo8mfj1gRY0/ut72HjkiiFjh6sYDsXvzS5Gd98gNh01Zm5KMYUR4JgAwzB+vL5g6zcXT8a2v1iISc4MfP3lA3jrE/1lyqI9CQDAvWV5KMxOMWReajCFEeCYAMMwfvwZNxYiFOel4bWn5uLesjz8+eufYu9pfVU8RYSK4WAsFsKD0wqx61QnrvlOL/GIKYwAwzCMH68v69LvlklJsuLHT9yD0rw0fPvVg+jq6dNx7Oiyg/w8NL0Qg16BDUdadZuTWtgIMAxjKrxe/0lg5FpGsg3Pf3EmrvcO4J/WN+k2drTZQX6qPVkod6Tj7U8u6zYntbARYBjGVPhPAsFumSpPFp5eOAm/OXgJe0536jS2GKNUbDREhIemTcBH566i9YZxWUxyMIUR4MAwwzB+RmICdz/2jcWTUZSbiufWNw2fGLQdO/qYgJ810zwQAth8tE3z+WiBKYwAB4YZhvEzHBMIYQVSkqz4s2VTcfTyTWzUITUz2orhQModGSh3pGPzsfhMFTWFEWAYhvEjEP4kAACfmTEBk50Z+LetJzXX7vHKjAn4aahx44MzV3GjN/6URdkIMAxjKsLFBPxYLYRvLCrHybYe7DzZofHY0dcJBNJQ7cKQV2D7ifhzCbERYBjGVPiLxSKtxWvqC+HKSsaLu85qOraA/JgAAEwryoErKzku4wJsBBiGMRWBxWLhsNsseGL+ROxu7sSxyzc1HVtuTACQ4hfLq13YeaIDdwbiS0vIFEaAs4MYhvHj9YmHjuWb/+KcUqTZrXjpfe1OA1KPYWX/d1mVC7cHhnSvapaLKYwAZwcxTPwxMOTF3tNdeHH3Wfxg+yn89uAlXat1/Qy7g8ZYjLPTkvCZGRPwzqeXNQvIShXDyqzA3En5SLNbse14fLmEbLGeAMMw5uRvfnMYr+8f3UIxyUp4/J4SPLOyEunJ+iwvwbIRkfjCnBL88sML+M3BFnx5QZnqseVWDAeSkmTFfZMLsL2pHeJhoSi2oAemOAkwDBN/tHf3YYozAx//7XIc/5+NWPfH9+H3ZhfjFx+ex4Pf343LOun8D8cEoli9aidko74oG698pE2rR6/K11hW5cLlG3dwrFW7OIVa2AgwDKMIrwDSkm3IS7cjJcmK2gnZeO6zdfjlV+eio7sPn39hLzp1cA/JOQkAwNo5JTjR1o2PL1xXPbaakwAALK50ggjY1tSuei5awUaAYRhFhMuUmVeej59/9V603+zDn7xyEEMayzd4I8hGhOKhaYVIt1vxq/3qWz0qzQ7y48hMxrSiHGw7zkaAYZgEINx6OL04B//0mVrsOd2FH+86o+mYfpMSrU89PdmGFbVurD/cqjo90ytCy1XIYVmVE59evI727juqXkcr2AgwDKOIsTJlPje7GMurXfi3rafQcq1Xs3GjqRMI5pEZRei+M6jaDSNXRTQUSypdAIAdcXIaiKkRICILET1HRN8noidiOReGYeQhosiZ/85DNSACvrvhuGbjynUHAZKLypWVjN8cbBn7yRFQWjEcSJUnE4XZKdgaJ3EBxUaAiF4ionYiOhJ0vZGIThBRMxE9M8bLPAygCMAAAHW/HYZhDEXS0Ym8IBbmpOKr95Vh/eFWHLmkTbGnv1iMZOzJrRbCw9MnYOeJDlW1DGpjAoBkRJZWubD7VGdcVA+rOQn8FEBj4AUisgJ4HsBKANUA1hJRNRHVEdG6oC8ngAoAe4QQfw7g6yrmwjCMwQgRWb/Hz1cfmITs1CR8b8tJTcaNtlgsmM9Mn4BBr8C7R5RLOqupGA5kaZVTqh4+E/vqYcVGQAjxHoCrQZfnAGgWQpwRQvQDeBXAw0KIw0KINUFf7ZB2/9d8/zf2JpFhmKiJNl0yKyUJf7igDNuPt+NUW7cm4wLyA7RVnkyUFaRjoyojoLxiOJDh6uGm2FcPax0TmAAgMA+rxXctHG8CWEFE3wfwXqgnENFTRLSfiPZ3dGgrC8swjHIEopdV/tK8UiTbLPixBqqeSmICgOSGaax1Y++ZLly71a9obCWdxUIxqnpY454HcolpYFgI0SuEeFII8cdCiOfDPOcFAN8B8LHdbjd2ggzDhEWOayQv3Y7HZhXhNwcvoaNbXQGZ3GKxQFbWujHkFdiiYAcuopCwlkO8VA9rbQQuASgO+LnId00VLCDHMPGHkOkaefK+Mgx4vfj5B+dVjas0JgAAdROyMSEnVZFLSI3xCcXiSicAYHuMs4S0NgL7AEwhojIisgN4HMDbal+UpaQZJv6QWwg8yZGBhVMdeG3fBQwOeRWP6x9WyWJMRFhZ68buU524eUeesmikBvdKcGQmY1pxDrbGuF5ATYroKwD2AqggohYielIIMQjgWwA2AWgC8LoQ4qjaSfJJgGHiDwH5C/Hj95Sg7WYfdp5QHt9TUiwWSEONG/1DXuw+1Snr/420tVQ0bEiWVca+elhNdtBaIYRHCJEkhCgSQrzou75BCDFVCFEuhHhOi0nySYBh4g+hoN/u0ionCjKS8eq+C4rH9XrV7chnluQgOzUJ22XuwEfcUNpZgaVVsa8eNoVsBJ8EGCb+UKKomWS14HOzi7D9eDuu3FC2+x2r0fxY2KwWPDDVgZ0n2ocNSjQIjWMCwEj1cCxVRU1hBBhz8c8bj2P2P23FO59ejvVUGB1RqqPz+D3F8AooVvVUExj2s6TSgc6efhyWUcUsoG1MABipHt4Vw+phUxgBdgeZiwPnr6Gzpw9//MpBPPvmIQyoCAIy8YvSnPnS/HTML8/Ha/svytqJB44LqNuRL5wq6frLcQnpERMAgCUxrh42hRFgd5C5SLNbUVOYhW8sKscrH13EX/7qU0Ufdia+8SqICfj5/D3FaLl2G/vOBYsORDcuoG5Hnpdux4ziHOw4IccIqAtIh2NejKuHTWEEGHMhANgshL9qrMR/W1GBtz65jH/dqo1uDBNfKF2Il1W5kJpkxdsKXIZa5esvqXTiUMuNqDNzhMpYRDhiXT1sCiPA7iBz4Q1wE3xjUTk+N6sIP9jRjD3N8lLymPhGigkoWxDTk21YXu3C+sOt6B+U5y7UIiYAjBRr/S7KdFWtK4YD8VcPN7Wq11aSiymMALuDzEWg3C4R4TsP16CsIB1/9etDuN3POoGJghDRNXsPx8PTC3G9dwC7m+XVDKitE/BT7cmCOyslapfQyAlE1bAh8fce3nhUubidUkxhBBhzEawzn2a34bnP1KHl2m08v6M5hjNjtETNSQAA7p/iQHZqEt7+RJ5LSKtUTSLC4koHdp3sjCp5Ydj46GAFHJnJuLcsDxsOt2r+2mPBRoDRHCl/fPS1eeX5+Mz0Qryw64zi/HAmNH2DsTldSV22lP9/u82CVXVubDnWJusetNyRL65wortvEPvOjh2gHs4OUj9sSFbXedDc3oOTGshty8EURoBjAuYiXMepP19eAa9X4Ic7+TSgFS3XelHxPzbiH94+anhQUQtZ5YZqN271D2Hv6ejTI7Ws3F0wuQB2qyWqVFGhQ8VwICtq3SAC1h0y9jRgCiPAMQFz4Q1xEgCAkvw0PDarCK98dBGtN24bP7EEpKtH0sX/6Z5z+P52Y42rFq0W55VL6ZFbjkWfHqnFuH7Sk22YW56P7VHEBbRWEQ3GmZky7BIy0qCbwggw5kJE8BV/c/FkeIXAD3eeNnhWiYl/V5yXbsf3tpzEuwb6lL1RtpeMREqSFQ9McWBrU1vUC59XgVxFJJZWOnGm4xbOdt6K+Dw9KoaDGXEJ9eg3SBBsBBjNiZQ1UpyXhkdmTsDr+y/iRq88KV/mbvzL5ncfqcP04hz81a8PGRZzEdCm1eLyahfabvZFLeGgpkgtFEv8uv5juIT0qhgOZEWtGxYC1htozE1hBDgmYC7G6sP6lQVluDPgxWv7lStJMhL+3XNKkhX/9vnpGBjy4tk3DxniTvB6oUmUdEmlExZC1C4hrwaxiECK89IwxZkxppKnv+pdr5gAILmE5pTlYf2hy4a5hExhBDgmYC7GUoio8mRh7qQ8/GzPeVXNRZjAdElgYkE6/rKhAjtOdBimSqnFSSA33Y7ZpXnYGuWctYwJ+FlS6cSHZ7vQHUWjGb1iAn5W13lwuuOWYS4hUxgBxlxE02zky/PLcOn6bWyNkV5KohAcrHxi/kRMcqTjf21okl2JK39sZSqioVhc6URT682oXFljnTSVsKTSiYEhEbHRjFfHiuFAGms9kkvokDEqvGwEGM2JZqe2vNqFCTmpePlDdgmpIXhhSrJa8N9XVuFM5y389qDq9t4RUdJPIByLKx0AgN+djC5LR2sjMKs0F1kptohxgWGDq/Oq6chMxtxJ+Vh3yJgsITYCjOZEs1OzWgiPzSrC7uZOtFzrNWhmiUcoUbOlVU7UTsjC/93ZrKu7TcsAbYUrE57sFOw4PraEhFSfoM24fmxWCxZWOLEjQqMZreQqomFNfSHOdN7Csdabuo/FRiCBudU3GBMJZ683ug/p52YXAQDeONCi84wSl5ECppFrRIRvLZ6Mc129umaZCGgXJCUiLKpwYndz55huLD3cQYCUKtrZ049DYbKUjPwoNda6YbWQIYVjbAQSlNYbt1H/nc2o+ftN+PovDuDjC9cMGzvaxaEoNw33TS7Ar/a3cL8BhfjfteBFsaHajSnODDy/o1k3l4KSHsORWFzhQE/fIPafjyzhoEdgGAAWTnXAEqHRjJEngbx0OxZMLsA7n+qfJWQKI8ApovLp6unHkFdgRkkOPjjThUd/uAf/+M4xQ7Jx5HxIf292MS5dv433T7PMtBLCNVixWAhPLyzHybYevN+sT8eqUBpRalgwuQBJVsLOMaSd9YgJAFKW0sySXGw/HjpZQe+K4WDW1HvQcu02Pm3Rd90zhRHgFFH5+DcPX1lQht1/vQRfmluKl94/i2+8/LEhWSPRflAaalzITLHhtwe5H7ESIhUwra73IC/djp/tPafL2AJQpSIaTHqyDfeW5Y+drx9Gm0oLllQ5ceTSTbTdvDtLyV8xbJANwIpqN5KshHU69+o2hRFg5BO4Q0xPtuEfH67F3z9Yjc3H2vC3vz2i6xHTKyNwl2yzYlWtB5uOXolZo20zE0nULCXJis/fU4xtTW24dF17rSavDm6ZRRUOnGrvwcWr4ZMF5Px9yWVppQtAaJeQ17d30lM2IpDstCQ8MMWB9YdbdXWXshFIUPx/MoEflq8sKMO3Fk/Ga/sv4pcf6ZeaKWTu1B6aXoievkFZTb8ZieHsoDCPf/HeEgDAyx+c12VsrXfk/m5fO0+GdwnpFRMAgKmuDBTnpWJziOYuWqqXRsuaaR603rija0yPjUCCMtIKb/Qf7J8vn4r7pxTgufVNuNClT2qm3PzxuZPy4chMxluf6JvXnoiMiJqFfr+LctOwpNKF1/dfjKpxihy8OpwmJxWkoyQvDTsj5uvrkx0ESAt8Y40b7zd34WaY6mGjYgKA1HbSbrPomiXERiBBCXUSAKSA4f9+tB5WIvyPt47oMrbcSlKrhfBgfSF2HO/AjdssKicHv4si0rr0e7OL0NnTj/ci7K4VoUOAloiwuMKB9093hnUP6hUY9tNY60b/kPeu2IRRFcOBZKYkYXGF5BIa0sklxEYgQYnkKy7MScW3l03Beyc7ou6vKmtsyPebPjjNg/4hL7axjIQsvFGkLS6qcCIv3Y5ff6xtPYbWap5+FlU6cWfAiw/DdPvSo1gskBnFuXBmJmNTkEvIqIrhYNbUF6Kjuw8fRdH9TAlsBBKUsXzFfzBvIibmp+G7G5o0DzopOa5PK8qBOyvlrg8eE5lwJ75A7DYLHppWiK3H2nG9t1/TsfXwzc+blI9kmyVslpDQ0R0ESKflFTVu7Djegdv9I6cRvTuLhWNplROpSVas00lLKKZGgIjuJ6IfEdGPiWhPLOeSaIy1ONhtFvzZ8qk42daDzTK6OkWDVDEs74NisRCWV7vwu5OjP3hmQQhheHtH/7jA2Kmaj80qQv+QF+9omG6oV6pmSpIV88vzsTPMKVWPrKRgGmvduD0whPdOjbjQ9O4xHI40uw1PzJ+Iyc4MXV5fsREgopeIqJ2IjgRdbySiE0TUTETPRHoNIcQuIcTTANYB+JnSuTB349/dR9oxra7zoDQ/TfOqUqWVpCtq3Lgz4MWuUxr7rg3gH94+ivrvbMahluuGjiuidFHUFGah0p2JNz7WLviup1tmcaUT57p6Q3b70jsmAABzyvKQk5aETUdGTqZGVgwH88zKSnxlQZkur63mJPBTAI2BF4jICuB5ACsBVANYS0TVRFRHROuCvpwB//ULAH6pYi5MEMMngQjPsVkt+PrCchy+dAPvRZDQVTK2kp3avZPykJVi0/xkYgQfX7iO7juDeOxHe/E7rQOwERjZnUZ+w4kIj84swqcXr6O5XRudeiG0LRYLZNFUX6poiNOAXrGIQJKsFiyrcmFrU9twcaXRFcNGodgICCHeAxAcqZgDoFkIcUYI0Q/gVQAPCyEOCyHWBH21AwARlQC4IYToDjUOET1FRPuJaH9Hh/l2iLFCRGMFADwyswie7BT85++06/mrNIUvyWrB0ioXtjW1ma7ZTEGGHUW5qZjsyMDX/ms/9p/TJ4gXjJy+tw9PLwQRNPMtS+0lNXmpuyjJT8MkRzp2hJCQ0FLCOhKNNW7cvDOID850+cY1tmLYKLSOCUwAcDHg5xbftUg8CeAn4R4UQrwghJgthJjtcDg0mOL4YKz8cT92mwW/P7cUe053abZDVNP+b0WNC9d6B/CRQYuoVngFkJ9ux8tfvReF2Sn4xssfoz2E9IAe4wLRvd/OrBTcU5qHdw9rE3zXs3IXABZXOPHBmS709g8GjatvYNjPfVMKkG634t0jrb5xpetsBDRGCPH3QoiIQWEWkJPPWNlBgXz+nmIkWQm/0KiqVI265ANTHUi2WbD5qLlcQgIAiJCbbsePvjQLN+8M4Jk3D+seLJa7O11Z58aJtm5NDL7eWTqLK5zoH/Ri7+nRAnhGuIMAKUC9rNqFjUeuYGDIG9OYgJ5obQQuASgO+LnId00VLCAnn1DNRsJRkJGMVXUe/PpAy127LqVjK3UTpNltuG9yAbY2tcUk20YpIqBArtKdhb9sqMD24+14W2fxLyHTT72y1gMAeFeDPgNeoW+mzD1luUizW++qZdG60XwkVtd5cK13AHtPd4WV7TY7WhuBfQCmEFEZEdkBPA7gbbUvyicB+cjxFQPAl+aWortvEG99on7RUntcX1rlQsu124Y12taKwPf6KwvKMK0oG8+tb9LEsIZDbhWrOzsFs0pzseGIOpeQETnzyTYrFkwuwI7jHaM2BHpqBwXzwFQHMpNtWHfocoB2kDFjG4WaFNFXAOwFUEFELUT0pBBiEMC3AGwC0ATgdSHEUbWT5JOAfOT6L2eV5mKqK0OTLl9qd4hLq6TMEDM1oQ/OmbdaCH+7phrt3X348a6zuo0r9yQAAKvqPGhqvRky/VLuuHoviIsrnLh0/fYo95VRgWFAcgktr3Zh09E29A1IyQpGGSCjUJMdtFYI4RFCJAkhioQQL/qubxBCTBVClAshntNiknwSkI+INj3I/yxfCuGB89dULQ7+sdXsEF1ZKaibkG0qCQkRwvDNnpiHxho3/vN3p3GjVx9NJCW705W1bgDABhUuIaNcI4sqpGSQQJeQEcVigayu9+DG7QHsbpbSqI2uGNabmAeGo4FPAvKJRk4gmM/MmAALAW+q1JjRYqe2tMqJgxevo7OnT9XrGEW4e/6TpVNwq38I/7X3nG7jAvJ+z4U5qZhenDOc9aIEo8TUCnNSUenOHNWA3siYAADcP8WBzBTbcL/mxDIBJjECjHyUZDK4slJw3xQH3vz4kio9IS12asuqXBACY3aZihe8oY4CAKoLs7Ck0omf7DmnixxGtKnAwayocePIpZu4rLDZzEilsv5L4qIKJ/adu4pun7Sz0ScBu82CFTVudHRLGxIODMcAdgfJR06KaCCPzpyAS9dvh1VwjAYt8sdrCrPgzkrBtiZzGAGp1WJovrGoHFdv9ePVfdo38lGau95QI3XQ2qKwOluPXgLhWFzhwKBX4H2fO8bImICf1fWe4e/ZCMQAdgfJR2ngrqHajYxkmyrZYamSVN0HhYiwpMqJXac60DdoAkG5CAvT7Il5uGdiLl56/6zmiq1KAsMAUO7IQLkjHZuPqcsSMmJBnFmai8wU27BLyKhisUAWlBcgOzUJAGcHMSZBaeAu1W7Fqjo33j3cqrjnr1Y+22VVTtzqH8IHZ+K/enisAqYn5k/Exau38TuNxfHU+OYbatz44MxVRUFrI9Mlk6wWPDDFgR0n2iGEMKxYLBC7zYLGGimgzkYgBrA7SD5qjutr6gtxq39IcScqrfK455cXICXJYoosIYHIi0NDtRsFGcn4xV5tqrKHx1WRr99Q7cKQV2D7Cfnv78gJRPZ/VcSiCgfau/twrPWmISqioVh7bwmKclPhyU41fGw9MYURYHeQfNTkcc8rz0dOWpLiFEKtNGVSkqy4b7ID25ra4756eCwJBbvNgrVzirH9RDsuXtWut/PIiU/+/51WlANnZrIiiY6RE4gxi/FCX6rozhMdqmRJ1DC9OAe7/3oJ8tLtxg+uI6YwAowSlH9Ik6wWNFS7sLWpXZE/XktNmaVVUrHQ8SshRWbjhmhc/WvnlIAAvPKRdgFif4xByUkgsJGPXNefkhRkNTgzpdqRHcfbY3YSSFRMYQTYHSQftf1QV9Z50NM3iN0K+gxomce9tFKqHt4e56mikjso8j0X5qRi4VQHfnNQXQpu8LiAcrdMQ40bvf1D2HNa3u9ZDDe4N24xXlzhwMcXruFab3/C+eVjiSmMALuD5DOSIqrs07KgvABZAQUy0Y+rbRGRMysF9UXZ8S8hESAgF4lHZhah9cadYY16tUTbVCYc8yblIzPZJtslJFebSgsWVTrhFcCZjlt8EtAQUxgBRj7+D6nSz4rdJnVW2n68XVaDF6Upi5FYWunCJ3FePeyNUjl1ebULmck2/FqjNo/DRlfhJ9lus2BRpRNbm9owJON0Eot+u9OKcpDv88cnmn5PLGEjkKBokb2xtMqF670DOHgx+r65/oChlh/SpVVOCBHfLiGB6PSSUpKsWF3vwbtHWjWT7QbUGd2Gahc6e/px8MI1GeP6fs8GrsZWXwwDAAY1rrcYz7ARSFBGUkSVf0jvn1oAm4VkVe2OxCK0WxxqCrPgyU6J61TRMKoRIXlkZhF6+4ew6aj6Dl9aaPgsqnAgyUqyejvH4iQAACt84nfBjWYY5ZjCCKgNDN/oHcBjP9yDjUeuxH2qodao8cpkpSRhTlmerMVXDzkBIsKSSid2nepUXMCmN0JGMHx2aS6K81Lxpqm1U/UAACAASURBVAYuIS3UPDNTkjC/vACbjkb/+RhxNxprBuaX5wPgk4CWmMIIqA0MX75xG1d7+/H0Lw7gyZ/t103WN57Qyje/tMqFU+09uNAlL7dd68DdsioXevuHNAuoao2cKlaLhfDZ6ROwu7kT7d3q+hBrVbnbUOPC+a5enIqy7aRR/QSCSbZZ8aPfn4XX/2iesQMnMKYwAmqp8mRh858+gL9bU41dpzrw2I/24Oqt/lhPS1e0kvodSdGM7jSgR0wAkArYUpOscS0oJ+eWV9cXQgio7qWs1WK8vErytW+O0kWlRwJAtDTWujGnLM/wcROVcWEEAMBmteAP7yvDz74yBxeu9uLLP/kobl0LWqDV4jCxIB3ljnRsizIo69VpcUhJsuK+KQXYFqe9h+UqW051ZWBSQboqTX9pXG2anzuzUjCjJCfquMCwO0jVqEw8MG6MgJ/5kwvw/bUzcKjlBr7zzrFYT0c3RsLC6j+mS6tc+OBMF3r6xs5m0VNYbFmVE5dv3EFTa/xVD8sVNSMirKyTBNzUnEq1DNA2VLtxqOVGVD0GlEpYM/HHuDMCgFQl+fTCcrzy0QXFeurxjpaL8ZJKJwaGBHZHoYA5cgLRfnVYXOkEETTJqtGasQTkQrGy1oMhr8AWFXLOWrpl/D0GoinMM6LRPGMM49IIAMBfNExFhSsTf/fWkah2uKZDw53aLJ+eezR5+kKnmAAg6cfcMzFPtQtFD5T0Va4pzEJxXio2HFZuBLQ09sM9BqKIUyhtWsTEH6YwAnpoByVZLfhfj9Si9cYdPL+jWbPXjRe0TOFLslqwcKoDO050jKl5o3f++KpaN0629aC5Pb5cQnLqBPwQEVbVevB+c6fijLURITdt3nGpx0DXmPOJZWCY0RZTGAG9tINmlebh4emF+Mn7Z9F2U12qXjhe/vA8nn3zMPoHo5de0AKt9d6XVDrR0d2HI5cjG2K9K0lX1nlABKw/FF8uoWgE5EKxss6DQa9QrI2kVe8GPw3VLgx6BXaciHzqM7KpDKMvpjACevIXyysw5BX4j22ndHn9F3efxSsfXcDTvziAARkaPGpRKywWzMKpDhCNLd3g1TEmAACurBTMLs2NO5eQiFJALphpRdlwZ6UobvPoVeCGijwfX4+BMeajRZEaEx+MeyNQkp+Gx2YV4VcHWlQX7oRiYn46AGnxfG59k+avHw61AnLB5GckY3pxDnaMYQT0jAn4WVXnwfEr3TjdEV1hkxFEKyAXDJGkh/PeSWXV0ELhuOHw9xjYeSJyjwE+CSQO494IAMDX7p+EgSEvfrbnnOavPeQVmFaUjSfvK8NP95zDuwq7dclFj4rOpZVOfNpyI6Kx1PoEEopGn37MhkPxcxqIVkAuFMurXbg9MKS8d4PG73U0PQb0zAJjjIWNAIBJjgw01rjx873nNc8U8goBi4Xw7MpK1E3Ixt++dcSQauURXX/tPqSLfdXDO0+ETxU1Qmfek52KWaW52HAkfuICSgLDfub6NP2VpCtLxkfhwGHnk4eMMXoMaN03gokdbAR8PL2wHDfvDOK1fRc1fV1/JanNasG/fK4e13sH8M8bj2s6Rshxff9quUBUe7LgzkqJ6BLSq2I4mFV1HjS13sTZzlu6jhMtcgTkgvFr+m87Lk/Tf2RcRcOGJdlmxaIKR8QeAxwTSBzYCPiYVpyDmSU5ePmD85rKEngDsjcq3Vl4Yv5EvLb/Io5dvqnZGKHQI4+biLC40oFdpzrDZjuN9LzVcOAQrPS7hALca913BvDVn+3D0TEymPRAbfPz5Qo0/QHp/dZjIW6ocaOzpx+fXAw9H44JJA4xNQJEVEJEvyWil4jomVjOBQC+eG8pznTewl4NlSqHvKN9xX+yZAqyU5Pwz5v0PQ1opSkTzJJKF3r6BrHv3NUw40r/6u0rLsxJxYySHKwPiAucbOvG1qZ2rP6P3bhmsECggDaa/nJdQgL67MaHewyEcQlpnYLMxA7FRsC3cLcT0ZGg641EdIKImqNY2OsAvCGE+EMAM5TORStW13uQnZqElz+8oNlrCgFYAz6k2WlJ+Nr9k7DzRAcOt+i3Y9VL22XB5HzYbZawqaJG9p5dXefBsdabOOdzCd3qG8lmefbNw/pPIAC5AnLBZKUkYe6kfGw+Jk8gz6swNTWa+cyL0GNAi6ZFTHyg5iTwUwCNgReIyArgeQArAVQDWEtE1URUR0Trgr6cAD4A8CQRbQewUcVcNCElyYrHZhVh05ErmqWLSoHh0de+NK8UmSk2XSuVtRSQCyTNbsPcSflh4wJGxQQAqdAKANb7XEK3fEH9h6cXYuPRK6NcRXojV0AuFA3VLpztvCUr9VWPmEDgfM519aI5RI8BPgkkDoqNgBDiPQDBPoE5AJqFEGeEEP0AXgXwsBDisBBiTdBXO4CvAPh7IcQSAKtDjUNETxHRfiLa39ExtoCZWtbOKcGgV+Ctg5c1eT0pJjD6k5KVkoQvz5+IjUev4FSbPvIHahuQR2JJhQNnOm+FDMoa6SuekJOKmQEuIX9m158um4qawiz84zvHcLvfGLlwJQJywSzz9c+V0+ZRiWZRtPj7+W4MkYXFKaKJg9ZLxAQAgek1Lb5r4dgI4E+I6EcAzoV6ghDiBSHEbCHEbIfDodlEwzHZmYFpRdl486D61n8AMBTGTfCVBWVITbLi/+06o8k4wegp8LWkUlocQrmEjF4cVtcX4ljrTZzp6EGvb8HPTk3C362pxpWbd/Dibn3e32DUZAf58WSnor4oW1ZcQGmRWjT4q7PXhzhRGen2Y/QlpoFhIcQRIcRjQoinhRB/Ge55egjIReKzMyagqfUmjl9Rn8ETTtslL92Oz8yYgLc+uaxLu0s9e8CW5KdhsjMjpEvIiIrhQFbVjWQJ+U8CaXYr7p2Uj4ZqF370uzOGtBNVKhsRzPIqFw5euI72KLWsBPTJDvKzul6qzg52CXE/gcRBayNwCUBxwM9Fvmuq0EtALhwPTiuEzUL4jQaNwEO5g/z8wbxS9A168asD2tYmAPpL/S6pdOLDs3c3mjEyJgBIu+fZpblYd6gVt/oGYbMQkm3Sn/WfLZ+Knr5B/GzvOd3noYU7CACWD2v6R9/JTc+3emWtJNgXHF/hfgKJg9ZGYB+AKURURkR2AI8DeFvtixp9EsjPSMbCqQ789pNLsot3ghnyhv+gVHmycM/EXPz8g/NjSjTLRe/FeHGFv9HMaGkBrXoby8G/Wz186QbSk23D73eVJwtLK534yftn0duvb88I6SSg/q4rXJkoyUuLutGMFm6oSLizU3BPad6oVFxAf8lwxjjUpIi+AmAvgAoiaiGiJ4UQgwC+BWATgCYArwshjqqdpNEnAQD47MwJaLvZhw9U1gwIIWCN8C7//txSnO/qxa5m+boxEcfVWEAumNkT/Y1mRvuvYxEw9O9Wdzd3It1uHfXYNxaX41rvAF75SPvTViBa+eb9gnLvN0fXzlMrN1QkVtd7cKKtOyiJQZ86FMZ41GQHrRVCeIQQSUKIIiHEi77rG4QQU4UQ5UKI57SYpNEnAQBYVuVCZrINb6p0CUVyBwHSApaTloQ3DrSoGicYvXuxJ1ktWFThxLam9lGnJa/BMQFA2q3OLs2FEEB6sm3UY7NK8zCnLA8v7jqj+lQXCS2zdJZXu9A/5MV7J8fOhhvr70sLVta6pR4OAS4hjgkkDqaQjYjFSSAlyYqGGjc2H7uiqiGMd4wiIrvNgoemFWLz0Su4eUf7AKaeC0RjjRtdt/qxP6B6OFYdp1b7agaCjQAA/OGCibh8405U7TGVoqV5mV2ai9y0pKiyhLSWkg6FMysFcybmYd2h1uFYAHcWSxxMYQRixcpaN7rvDKqSkfB6xZhdth6dWYS+Qe9dflc1GKHhs6jCAbvNgo0Bjd9jpSnj7ziWEcIILKtywZWVjJ9/cF638dVWDAdis1qwpNKFbU1tYzYi8uocE/Czpt6D5vYenGzr8Y3LKqKJgimMQCzcQQBw35QCpNut2Kiii5U3TIpoIPVF2ZjszMCvNXQJGVHUn55swwNTCrD56IjUQazUJV1ZKfjs9AmYVZp712M2qwVfmFOK9052DEtMaI1aAblglle7cPPOIPadDa3RNDyuDlLSoWis9cBCwPpDUhElF4slDqYwArFwBwGSS2hJlQubj8qX+PUzljsIkD5Ij84swv7z1zRbpIw6rq+ocePS9ds4ckmqqYiluuT3Pj8df7Z8asjHHp9TDJuF8PKH+pwG1ArIBfPA1AIk2yxjVg/rKRsRiCMzGXMn5WPdYcklJGL4e2a0xRRGIJasrJX83h+NsSMLR7SaMp+ZUQgiaFapbNRivKzKBauFsPGodFrSS71ULa6sFCypdOI3By9jUIdez/7mQVqRZrfh/ikF2DKGoJwwIDDsZ3W9B2c6buH4lW7uJ5BAmMIIxModBEgN1pNtFmw6qrARuFeMUhENhyc7FfdNLsBvD17SpJ/BSFMZfT+kuel23FuWN6wvo0dbS614dFYROnv6sEtBG8exUNNZLBzLq124dP02jrWGr1z36jBuOBpr3D6XUCv3E0ggTGEEYuUOAiS/98KpDmw8ckVRQVc07iA/a+o9uHC1F0e1aDijd45oAI21bpzuuIXm9m7DK4blsLjCidy0JPz6Y23TcQGf0dX4lpdWuUCEiFlCRqSI+snPSMb88gKsP9wa8Hs2ZGhGR0xhBGLNyjo3rty8g09brsv+v6GkpMOxvNoNq4U0kUCWmo2ofpmoaKiW9Hs2HW2L6x3icDrusTbcuK1tOq4ebpmCjGTMKsmN3OsXxr7Xq+s9ONt5K6B7Wxz+ohlZmMIIxNIdBEg7SKtFftcnQN5OLS/djvnl+dhwuFW1S8iro8RwMO7sFMwoyZFOSzo0uNeSR2YWoX/Qq3mvAT3cQQDQUOPCsdabaLnWG2Zc437PgJQIYLUQ1n0qvX/xaOwZeZjCCMTSHQQAOWl2zJmYh61NSoyAPNfIqjoPznX1RvQDR4Nei1I4VtS4cfjSDVy6dhtA/LoJ6ouyUe5Ix5sau4T02pEv952ytobZgBhRLBaIf6Pi//uMR7cfIw9TGIF4YHm1CyfbenC+S14KZzR1AoH4d1pqd6p69Z4NR2PN6MbvWmbKaAkR4ZGZRdh37houXg29u1aCVgJywZQVpGOyMyNsqqhXp3EjsabeM/x9fP6WGTmwEYgSf5cluS4hr1fecT0v3Y55k/Kx4XDo3q5Rj2vwUWBiQTqqPFnY7RPCi1MbAAB4sL4QAPCuiiLAYPRs7tJQ7cKHZ6+G7Iugt5R06Pm4h7/nk4D5YSMQJcV5aah0Z8pq/QdIH1KrzNVhZZ0bZzulfGzFGOwOAoBVtW4MDMV/A/KS/DTUTsjChsPK0n7DomObxyGvwI4ToTu5Gb0Q56bbh79nG2B+TGEEYh0Y9rO82oX9567i2q3+qP+PXHcQIO20iML7gaPB6KwRYKTxOxDfJwFAir18cvE6Ll2/rfq1hqtnVb9SaKYV5cCZmRzyFKq1XEW0PDJD6ho7qKMyK2MMpjACsQ4M+1le7YJXhO6tGw4ledyOzGRML85RFIgeHtdrXP64n8nODEx1ZQCIfzfBqlrJYL2rQZaQ3rURFgthWbULO0+0o29waNRjRsd+/Hz30Tr8++PTMa0otp9JRj2mMALxQm1hNlxZoXdk4fB6lQVJl1W58GnLDbRF2Ws2GK21bKJlpW9xjXMbgIkF6aj2ZGlTk2FAbURDtQu3+odCdnKLxXudbLPi4ekTWEAuAWAjIAOLhbCsyoX3TnXgzsDQ2P8BytxBwEggeluUvWaD0bvtYDi+eG8J1s4pxlRXpuFjy2V1vQcfX7iOyypdQkZEQeaXFyArxTaqsQtgnJQ0k7iwEZDJ8moXevuHsPd0dD0GlJb1T3FmoDgvVbFLyCiJ4WCcWSn47iP1SEmyjv3kGLPKF8N494i6APFwNzUdAyF2mwUNNW5sOdY2yiUkFG4yGMYPGwGZzCvPR7rdGnWWkNKdGpF06tjd3KmoSbrRxWJmpKwgHZXuTMXigH6MkmlaXe9B953BUS4h/j0zamEjIJNkmxULKxzY2tQ2pqCc//FoVERDsbzKhf5BryLVS6PlBMxKQ40b+89dRVdPn+rX0vvtXhDCJSRgfAIAk1iYwgjES4qon+XVLnR0940pKKe26fo9ZXnITLEpShU1UkDOzKyokTK+VGViGdRDIZRLyOuN/yA8E9+YwgjES4qoH7+g3FgLx3DqoMLVOMlqweIKJ7Yfb5fd2cxIATkzU+3JQlFuKjZFUOoci+EeChrNKRLBLiH+PTNqMYURiDf8gnJjpYpqsUNcVu1C161+fHJRnow1+4qjg4iwosaN3ac60dMnP/YCBDbw0W5e4Qh2CfGJj1ELGwGFLItCUE6tOwiQOpvZojh1BBOLimGzsqLGjf4hL3aGkGWIBiPls+02C1bUuLHlqOQS0ku4jhk/sBFQSEMUgnJaVJJmpyZhTlme7LhArOoEzMis0lzkp9sVu4SMbqm5qt6D7j7JJSQEom5axDCh4D8fhfgF5cZq/QeoXxyWVblwqr0H5zqjl7GWdohMNFgthOXVLuw4frcsQ1QMGwFj3vFAl1AspKSZxIKNgAqWVbmwL4Kg3HCKqEqn7bIq6dQhxyUkYiAxbGYaalzo6RvEniiLAAMR0FdALpjRLiEv/54ZVbARUMFYgnJaCYuV5PtkrGW4Kzh/XB7zywukIkAFhWOxaLrudwk1td5ktx+jipgaASKqJqLXieiHRPRYLOeihLoJkQXltAgM+2mocWP/+avojLKoycvZQbJISbJiUaUTW461yU7HHRGQM+4d97uE9Gxmw4wPFBsBInqJiNqJ6EjQ9UYiOkFEzUT0zBgvsxLA94UQXwfwB0rnEivGEpTTUlPGX9S0LUqXEAeG5bOixo3Onn58fOGarP9nZIqoH79LCIh/2W4mvlFzEvgpgMbAC0RkBfA8pMW9GsBa326/jojWBX05AfwcwONE9C8A8lXMJWYsiyAo5/VK/2rxIa32ZGFCTvRFTQLydrMMsLjCAbvVgk0yBeW8MTgJAJJLCOATH6MOxUZACPEegKtBl+cAaBZCnBFC9AN4FcDDQojDQog1QV/tvq9vAngGQEiBHCJ6ioj2E9H+jo4OpdPVjfkRBOW0dAfJLWri1EH5ZKYkYf7kfGw6JrO/s4EVw4H4XUJqEw+Y8Y3Wy8QEABcDfm7xXQsJEU0kohcA/BeAfwn1HCHEC0KI2UKI2Q6HQ9PJakEkQTmtd4gralxRFzVxEZEyVtS4cfHqbTS1Rt/fORbuIEByCf3gCzPxjcWTjR2YSShiulcUQpwTQjwlhPiiEGJ3uOfFm4BcMH5BuUOXRs/P7w5SqiIazOyJechPt0eVJcQVw8pYVuUCEWTJSxslIBeKB6Y6ML04x/BxmcRBayNwCUBxwM9FvmuqiDcBuWD8gnJbjo1eOEYCw9qMY/UFonccb0f/oDfic4XggKESHJnJmF2aK8sIGCkgxzBao7UR2AdgChGVEZEdwOMA3lb7ovF+EshJs+Oeibl3pYrqsUNsqHGhu28Qe05H7jHg5YphxayoceP4lW5c6OqN6vmxcgcxjBaoSRF9BcBeABVE1EJETwohBgF8C8AmAE0AXhdCHFU7yXg/CQDA8mr3XYJyWhWLBbJgslTUNFaWkAB4a6oQf+pltKcBfyyIYzCMGVGTHbRWCOERQiQJIYqEEC/6rm8QQkwVQpQLIZ7TYpLxfhIApC5gwGhBOT1OAilJViyqkIqaInY2Y3eQYorz0lDlyZLddpLfbsaMmCKJ0AwngZL8NFS4MsMYAW3HaqhxobOnDwciFDWxO0gdK2pcOHDhGjq6x67QHlER5XecMR+mMAJmOAkA0uK879yItIM/O0jrxWFplQvJNgvWH2oN+xwWkFPHiho3hIgsFe5npJ8Aw5gPUxgBM5wEAGBlrQdegeEUTv/ioHUxT0ayDYsrnFh/uDWszo0A1wmoodKdiZK8tKhcQv7fABfnMWaE/2w1pMqTibKCdGzwtf7Tyx0ESL1mO7r7sO9ccNG2BJ8E1CFVaLuw53Qnbt4ZiPjcYQE5NrqMCTGFETCLO4iIsLLWjb1nunD1Vr8u2UF+llY5kZJkwbpDl0M+7mUBOdWsqHFjYEhg54nIciWcIsqYGVMYAbO4gwBgVZ0HQ16BzUevaKoiGkya3YallS5sPHIFg0OhCsc4MKyWmSW5KMhIHtMlFAspaYbRClMYATNRU5iF0vw0qfWfVz93EACsqfegs6cfH5692yXEAnLqsfjaTu483h5SKtwPVwwzZoaXCY2RXEIe7DndhS5f20m98vUXVTiRZrdiXYgsIe49qw0raly41T8UsUKb3UGMmTGFETBLTMDPap9LyO9G0GtxSLVbsazKhY1HWjEQ5BJiATltmF9egMxkGzZG6DEQSwE5hlGLKYyAmWICAFA7IQtFuanY4ksV1UpFNBSr6z241jtwV1Mbwe0lNcFus2BZtQubjrbdZWj9sDuIMTOmMAJmg4iwuk5qBA7oExj2s3CqAxnJtruyhLxCcKBSI1bXeXDj9gB2N4d2CY1UDBs4KYbRCDYCOrGqzjP8vZ6Nn1KSrFju26kGy0vzoqQN908tQGaKLWyFdqzaSzKMFrAR0In6omxMyEkFoL+v2L9TfT9gp8ruIO1ItlnRUO3GpqNX0DcYPkuI32/GjJjCCJgtMAxIu8JVdZIksd5GwL9TDcwSEhAcqNSQNfUedN8ZxO5Td7uEWECOMTOmMAJmCwz7eXxOCWaX5qI0P03Xcfw71c3HRnaqXi+7g7RkweQCZKcmhXQJsYAcY2ZMYQTMSrkjA298fT5y0uy6j7W63o3uO4PY0yxlCbGAnLbYbRasqHFh87G2uwrHWECOMTP8Z5sgLJgs5bP7xetYQE57VtcXoqdvEO+dHK0lxAJyjJlhI5AgJNusWFrlxJYmKZ+djYD2zC/PR25aEtYfHu0SGlbz5vebMSFsBBKIxloPrvcO4MMzV9kdpANJVgsaa93YepdLiCuGGfNiCiNgxuygWLBwqgOpSVa8e6SVTwI6saa+ELf6h7DzRPvwNa4YZsyMKYyAWbODjCbVbsWSSic2HW3DoJdTRPXg3rI85Kfb8c6odFwJfrsZM2IKI8BET2OtG509ffjk4nVelHTA5nMJbW9qR2+/JAsyIhnObzhjPtgIJBiLK52w2/jXqidr6gtxe2AIO45LWUIcF2bMDK8WCUZGsg0PTHHEehoJzZyyPBRkJA+L9gm2AoyJYSOQgKysleQqjl6+GeOZJCZWiyQJsv14O271DQ7XCbA7iDEjbAQSkCWVTgDAVV9nM0Z71tQXom/Qi61NbewOYkwNG4EEJDfdjnmT8vH0wvJYTyVhmV2aC2dmMtYfamUBOcbU2GI9AUYfXnlqbqynkNBYLIQVNW68caAFn5tdDIBTRBlzYthJgIgmEdGLRPRGwLV0IvoZEf0/IvqiUXNhGC1YVu3C7YGh4T4OejYPYhi9iMoIENFLRNROREeCrjcS0QkiaiaiZyK9hhDijBDiyaDLjwB4QwjxNQAPyZo5w8SYuZPykG63YmtTm+8KWwHGfER7EvgpgMbAC0RkBfA8gJUAqgGsJaJqIqojonVBX84wr1sE4KLv+/AtmxgmDkm2WXH/FAdart0GwO4gxpxEZQSEEO8BuBp0eQ6AZt8Ovx/AqwAeFkIcFkKsCfpqv+tFJVogGYKwcyGip4hoPxHt7+joCPUUhokZS6tG9jecIsqYETUxgQkY2cUD0oI+IdyTiSifiH4EYAYRPeu7/CaAR4nohwDeCfX/hBAvCCFmCyFmOxxcBMXEF0sqncMnADYBjBkxLDtICNEF4Omga7cAfGWs/0tEDwJ4cPLkyTrNjmGUkZ+RjJkluThw/hq7gxhTouYkcAlAccDPRb5rDDOu8LuEuH8DY0bUGIF9AKYQURkR2QE8DuBtbaY1GpaSZuKZx+8pwdfuL0OFOzPWU2EY2USbIvoKgL0AKoiohYieFEIMAvgWgE0AmgC8LoQ4qt9UGSY+yUu3429WV7N6K2NKoooJCCHWhrm+AcAGTWcUAo4JMAzD6IMpti7sDmIYhtEHUxgB7jHMMAyjD6YwAnwSYBiG0QdTGAGGYRhGH0xhBNgdxDAMow+mMALsDmIYhtEHUxgBhmEYRh/I3yTbDBBRB4DzKl6iAECnRtMxC3zP4wO+5/GB0nsuFUKEVOA0lRFQCxHtF0LMjvU8jITveXzA9zw+0OOe2R3EMAwzjmEjwDAMM44Zb0bghVhPIAbwPY8P+J7HB5rf87iKCTAMwzCjGW8nAYZhGCYANgIMwzDjmHFhBIiokYhOEFEzET0T6/loBRG9RETtRHQk4FoeEW0holO+f3N914mI/sP3Hhwiopmxm7lyiKiYiHYQ0TEiOkpE3/ZdT9j7JqIUIvqIiD713fN3fNfLiOhD37295uvwByJK9v3c7Ht8YiznrwYishLRQSJa5/s5oe+ZiM4R0WEi+oSI9vuu6fq3nfBGgIisAJ4HsBJANYC1RFQd21lpxk8BNAZdewbANiHEFADbfD8D0v1P8X09BeCHBs1RawYB/IUQohrAXADf9P0+E/m++wAsEUJMAzAdQCMRzQXwvwH8qxBiMoBrAJ70Pf9JANd81//V9zyz8m1InQv9jId7XiyEmB5QD6Dv37YQIqG/AMwDsCng52cBPBvreWl4fxMBHAn4+QQAj+97D4ATvu//E8DaUM8z8xeAtwAsHy/3DSANwMcA7oVUOWrzXR/+O4fU8nWe73ub73kU67kruNci36K3BMA6ADQO7vkcgIKga7r+bSf8SQDABAAXA35u8V1LVFxCiFbf91cAuHzfJ9z74DvyzwDwIRL8vn1ukU8AtAPYAuA0gOtC6vUNjL6v4Xv2PX4DQL6xM9aEfwPwo7gYRAAAAghJREFUVwC8vp/zkfj3LABsJqIDRPSU75quf9tR9RhmzIkQQhBRQuYAE1EGgF8D+FMhxE0iGn4sEe9bCDEEYDoR5QD4DYDKGE9JV4hoDYB2IcQBIloU6/kYyH1CiEtE5ASwhYiOBz6ox9/2eDgJXAJQHPBzke9aotJGRB4A8P3b7rueMO8DESVBMgAvCyHe9F1O+PsGACHEdQA7ILlCcojIv5ELvK/he/Y9ng2gy+CpqmUBgIeI6ByAVyG5hP4diX3PEEJc8v3bDsnYz4HOf9vjwQjsAzDFl1VgB/A4gLdjPCc9eRvAE77vn4DkM/df/wNfRsFcADcCjpimgaQt/4sAmoQQ3wt4KGHvm4gcvhMAiCgVUgykCZIxeMz3tOB79r8XjwHYLnxOY7MghHhWCFEkhJgI6TO7XQjxRSTwPRNROhFl+r8H0ADgCPT+2451IMSgYMsqACch+VH/Jtbz0fC+XgHQCmAAkj/wSUh+0G0ATgHYCiDP91yClCV1GsBhALNjPX+F93wfJL/pIQCf+L5WJfJ9A6gHcNB3z0cA/J3v+iQAHwFoBvArAMm+6ym+n5t9j0+K9T2ovP9FANYl+j377u1T39dR/1ql9982y0YwDMOMY8aDO4hhGIYJAxsBhmGYcQwbAYZhmHEMGwGGYZhxDBsBhmGYcQwbAYZhmHEMGwGGYZhxzP8Hp9gMEo7gihoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "semilogy(mu);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 595
+    },
+    "colab_type": "code",
+    "id": "KLdw1eSvVXE3",
+    "outputId": "cc8fc33a-ccb2-47a8-8e3b-cf4fdc4d9eb1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAJCCAYAAADKjmNEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3df4xld33f/9dnZna8XpZlGS+2g9fE0DFCVgTEsnZJmqoEiuSFNOYPlC+wlt0IhPRVsWmbqqWVKkPVqkpblcRJFYkmKaR2mqA0Cm66/lIKfJv+E29sEkL40eyA+GGD2drjtVmv1+vZ++kfc8b51HXYXfvOnLkfPx7S0d575q7nfXzuzDznnHPvllprAABYNzf2AAAA24k4AgBoiCMAgIY4AgBoiCMAgIY4AgBobEoclVKuL6X8z1LKSinlg5vxOQAANkOZ9vsclVLmk/x5krckuT/JHyV5V631y1P9RAAAm2AzjhwdSLJSa/16rfVMkt9KcsMmfB4AgKlb2IT/5hVJvt3cvz/JwR/0F0op3qYbALap+SRnxx5iczxUa33ZM1eOdkF2KeV9pZR7Syn3jjUDAHBuZ5MslS5fw/XNZ1u5GVv6QJIrm/v7h3X/h1rrR2ut19Var9uEGQCAKVqtk14D6f+yGVv5R0muLqW8spSymOSdSe7ahM8DAGyh1ToZe4QtMfVrjmqta6WU9yf5VNZPU/56rfVL0/48AACbYeov5X9OQ7ggGwDYevc92+U9L4yThwAA50kcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0zhlHpZRfL6UcL6X8WbNuqZTy6VLKseHPlw7rSynl9lLKSinlT0sp127m8AAA03Y+R44+luT6Z6z7YJLP1FqvTvKZ4X6SHEpy9bC8L8mvTGdMAICtcc44qrX+QZLVZ6y+IcnHh9sfT/L2Zv1v1HV/mGRvKeWHpjUsALD1lsoL6yqc57q1l9VavzvcfjDJZcPtK5J8u3nc/cO6/0sp5X2llHtLKfc+xxkAmEG9/qA9ML/Y5bYdWtiZD120Z+wxttTz3ou11pqkPoe/99Fa63W11uue7wwAzI7VOukyIo6ePZPluYXutu3utdO5/czJ3L5z79ijbJnnuge/t3G6bPjz+LD+gSRXNo/bP6wDgKf1HEhLZa67bVuZrOVDTz6W214gR5Ce6967K8nNw+2bk3yyWX/T8Kq1NyR5tDn9BgBP6zWQViZrSfo7fbhaJ/nwk4/llsXdY4+y6cr6WbEf8IBS/mOSNybZl+R7SW5L8ntJPpHkFUm+meRnaq2rpZSS5Jez/uq2U0l+ttZ6zmuKSikXfFoOALa7pTKX1ToZe4ypO7SwM3evnR57jGm479ku7zlnHG0FcQRAr3oNpAPzizl69szYYzxfzxpHfR3zA4BtpscwStZPHy7PLYw9xqYQRwDABVutk26vG+tviwCALbFxVKy3QOrzeBgAsCV6PG3YV+oBADxP4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOoLFUfEnAZjswvzj2CJvijouXsjy3MPYYU3fPiy7Nly/9kbHH2FJ+EkBjtU4EEmyyo2fPdBkRH3rysRzesau7bTv8xGq+//jxPHDJq8ceZcv4KQDPsFonY48A3Vutk+4iYmWyljufOpWD84tdbdvKZC2Hn1jNF55YzWTP/rHH2RKl1jr2DCmljD8EAFtq4yhtb7+QLM8tZKnMZbVOsjJZG3ucqVkqc7nj4qUkyVtPPTTyNFNzX631umeudOQIgFH0FkUbViZrT5+i7+k0/WqdPB1FtyzuHnmazdXPXgNg5vR6nd/KZC0rk7WnjyL15K2nHsqhhZ3dXlifiCMARtZrIG2cVutx29566qHcuri7q2urWv3tMQBmTq+n2DYCqceIuPGJ1RzesavL+OtviwBgm+k1kD785GM5tLCzu0Dqa2sAYJvq9RTbnU+d6u7aqn62BAC2uV6vrzp69kxXr87rYysAYEb0Gkgb7+nUw7bN/hYAwIzp+QL0HuJvtqcHALadWY8/cQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAACNc8ZRKeXKUsrnSilfLqV8qZTygWH9Uinl06WUY8OfLx3Wl1LK7aWUlVLKn5ZSrt3sjQAAmJbzOXK0luTnaq3XJHlDkr9dSrkmyQeTfKbWenWSzwz3k+RQkquH5X1JfmXqUwMAbJJzxlGt9bu11s8Pt7+f5CtJrkhyQ5KPDw/7eJK3D7dvSPIbdd0fJtlbSvmhqU8OALAJLuiao1LKVUl+NMk9SS6rtX53+NCDSS4bbl+R5NvNX7t/WPfM/9b7Sin3llLuvcCZAQA2zXnHUSlld5L/lOTv1Fofaz9Wa61J6oV84lrrR2ut19Var7uQvwcAsJnOK45KKTuyHkZ31lp/d1j9vY3TZcOfx4f1DyS5svnr+4d1AADb3vm8Wq0k+bUkX6m1/pvmQ3cluXm4fXOSTzbrbxpetfaGJI82p98AALa1sn5G7Ac8oJSfSPI/knwxyWRY/Y+zft3RJ5K8Isk3k/xMrXV1iKlfTnJ9klNJfrbW+gOvKyqlXNApOQCAKbjv2S7vOWccbQVxBACM4FnjyDtkAwA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAcAULM8tjD3CplieW8jhHbvGHmNLiSMAmIKVyVqWSn8/Vlcma7l77fQLKpD624sAMJLVOukykFbrJHevnc6hhZ1jj7Il+tuDADCi1ToZe4RNsVonuefsmRyYXxx7lE0njgCA87JaJ1mZrHV7fdUGcQQAnLfVOun29OGGfrcMANgUvZ463CCOAIAL1vPRoz63CgDYdL0eQRJHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0DhnHJVSdpZSjpZSvlBK+VIp5cPD+leWUu4ppayUUn67lLI4rL9ouL8yfPyqzd0EAIDpOZ8jR08meVOt9XVJXp/k+lLKG5L8fJKP1FqXkzyS5D3D49+T5JFh/UeGxwEAzIRzxlFdd3K4u2NYapI3JfmdYf3Hk7x9uH3DcD/Dx99cSilTmxgAYBOd1zVHpZT5UsqfJDme5NNJvpbkRK11bXjI/UmuGG5fkeTbSTJ8/NEkl0xzaABm11Lp83LXQws7xx5hUxzesStHdu0be4wtdV7P0Frr2Vrr65PsT3IgyWue7ycupbyvlHJvKeXe5/vfAmC29BhID9dJDswvdrdtxybrx0Fu37l35Em2zgXtwVrriSSfS/JjSfaWUhaGD+1P8sBw+4EkVybJ8PGXJHn4Wf5bH621Xldrve45zg7ADFqtk7FH2BRHz57Jap10F0dHz57JradPZHluIYd37Bp7nC1xPq9We1kpZe9w++Ikb0nylaxH0juGh92c5JPD7buG+xk+/tlaa53m0ADMth4jIklWhqMsy3ML53jkbFmZrOXGJ1ZzeMeuHJhfHHucTVfO1S2llNdm/QLr+azH1Cdqrf+0lPKqJL+VZCnJHye5sdb6ZCllZ5L/kORHk6wmeWet9evn+BziCYBuLJW5LJW5p2OpJ3dcvJRbT5/o5Qjgfc92BuuccbQVxBEAvdk4MtZJRPwfbt+5N7eePjH2GNPwrHHU3zFNANgGVuuk29OHt54+kVsWd489xqbpb48BwDbSayD90pmT3b59QX97CwC2mV4D6e61011eoN3fngKAbajHa4+S9Zf69/bqPHEEADwvK5O1ro6M9bMlAMBoejoyJo4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4A2FJLpc8fPQfmF8ceYVMcmF/MLYu7xx5jS/X5DGXT+eYGm2upzHX5dbZU5nJs9+Vjj7Ep/sXlr89tF+0Ze4yp+3f7XpMHr3lHlucWxh5ly5Ra69gzpJQy/hBcsKUyl9U6GXuMqVueW8hqnXS5bcyWjTjq8bn48Itfnku+/52xx5i6L1/6I/n897+TG59YHXuUqZrs2Z+/uXx9/svnf3XsUabtvlrrdc9c2d+vJWyZ1Trp8jfblclat7+1M1s2Ir3H5+Il3/9O7nnRpWOPMXXXHP+zvP2iPTmya9/Yo0zV3GP357ovfSLvft1NY4+yJfr7imNL9fqNe2WylqTf04fMlh6PHCXJwceP546Ll8YeY+p2n/hGLilz3cXfh598LCt/9lv5J695+9ijbDrf+Xneev3G3fNv7bBd3PjEam5Z3N3d19nBx4/nyNrp7o4gHT17Jp86diR3XvXGsUfZVH09G2ETCCTYXHc+dSoH5xe7+zr7pTMnc+dTp7o7Onb07JkceeBovnDZa7vbZxv63CqYsl6PjsF2sFonuefsmSzPLXT1w3a1TnL32unc+dSp7l7FdudTp/K7J76Rb73kFV2+is2r1QDYFjZeCNHjq0UPLezMUpnLnU+dGnuUqbrtoj05OL+YW0+fePpazRnj1WoAbF/tdX49HUFKkrvXTme1Trp7L7UPP/lY7jl7Jod37OrqCFJfzz4AZlqPR4023L12OpeUua4iIlkPpNU66eq6sT62AoBu9PxK0bvXTufqzq6tStYvPk/STSDN/hYA0KWeA6m3o0fJ+kXaDw9HkGZdf886ALrRayAdHV6d15ujZ8/k2GQthxZ2jj3K89LfMw6ArvQaSBv/VFFvViZruefsmZm++Ly/vQJAd3oNpJ63a5aPjvW3RwDoUq+vYut1u5L1o0izGEjiCADYNLN4+nC2pgUAZs6snT6cnUkBgJk1S6cPxREAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0zjuOSinzpZQ/LqX8/nD/laWUe0opK6WU3y6lLA7rLxrurwwfv2pzRgcAmL4LOXL0gSRfae7/fJKP1FqXkzyS5D3D+vckeWRY/5HhcQAAM+G84qiUsj/J25L86nC/JHlTkt8ZHvLxJG8fbt8w3M/w8TcPjwcA2PbO98jRLyT5B0kmw/1Lkpyota4N9+9PcsVw+4ok306S4eOPDo+nIwfmF8ceYVPccfFSlucWxh6DC9Dr/jq0sLPLr7MD84v5zBUHxh5jU/yVH//7efjFLx97jKl79+tuyt/6W///2GNsqXPGUSnlp5Icr7XeN81PXEp5Xynl3lLKvdP877I1ViZrXX7j/tCTj+Xwjl3d/sDt0cpkLUulv9eW3L12Okl/8Xf07Jn8wUNfzZcv/ZGxR5m6o1/8zfzDH/7rObn3qrFHmaoPrPx/efxPPpZ3veuusUfZOrXWH7gk+RdZPzL0jSQPJjmV5M4kDyVZGB7zY0k+Ndz+VJIfG24vDI8r5/gc1TJ7y1KZq8tzC6PPMe1leW6hHt6xq8tt63lZKnOjz7AZ27Q8t9Dlc/GOi5fqyb1XjT7HtJeTe6+qH7vqJ+sjL33V6LNMczmya1999+tuqtdf/wujzzLl5d5n65Jz/rpVa/1Htdb9tdarkrwzyWdrrYeTfC7JO4aH3Zzkk8Ptu4b7GT7+2ToUEH1ZrZOs1kl3v7WvTNZyz9kzWSpz3f3W3rPVOjn3g2bMap1kZbJ+9UJvX2c3PrGaPzhzMve86NKxR5mq3Se+kRse/Wa+ePFSnnzJK8YeZ2reeuqhXP3V38vkf305P3Hd/zv2OJvu+Xy1/cMkf6+UspL1a4p+bVj/a0kuGdb/vSQffH4jsp31+AMpWQ+kjfDr7YcSs2fj1GFvz8W3nnooSXLbRXu62raXPvL1HHz8eL520Z6u4u/DTz6WE3/ysZya35FfXL5+7HE2VdkOB3VKKeMPwfOyVOa6DKWNo0cbsQRj6vXr7MiufbnzqVO5e+10V9t3z4suzYtfdGn+22P359bTJ8YeZ2qWylwuPfiB/OevfSoHH/rqrO+z+2qt1z1zZT+pzqh6PL2W/MVpjR63jdnT69fZW089lEMLO3Owsxd5HHz8eP7bY/fnb+zZn0MLO8ceZ2pW6yRf/cOP5MZXvinHdl/e5XOyvy1iNDP+28NfaiOQXH/EdtBrIN34xGoOzC92FRFJcuvpE/m51ZXc/tJXdfc95J6jv5xbXvU3csfFS909J51WgwuwcYoNxtbrKbbDO3ZltU6efiuDXizPLeS/v/RVueLhPx97lKn718uH8te+e18OPn587FGei2c9rSaO4AL1+kMJtosD84u5pMx1F0hJcnLvVdl94htjjzF1n7niQF7x6Ldy9ckHxx7lQrnmCKah19MasF0cPXsmxyZr3Z1iS9Zf6n9s9+VjjzF1b37gaF6yuLubbfMdHp4DgQSba+P9xnp8J/6rTz6YOy5eGnuMqbt0dSWrddLF2xf47g7PkVNrsLlW6yRHz57p7kLmZP0C9FsWd3f3S9bBx4/njqdO5ciufWOP8ry45giAba/Ha/16fR+1pTKXg/OLOTC/mA8/+djY45yLa44AmE09nspu30etp23beLXh3Wunc3jHrrHHeU76O1YJQJd6Orqyocdt2nD07Jkk668+3Lg9K/pJVQCYQb3+I97JXwTSrG3bbE0LAJ3qOZBm7dTh7EwKAJ3r9TTbrP0blbMzKQAws2YpkGZjSgBg5s3KqcPtPyEA0I1ZOHUojgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjnhODi3sHHuETXFk174szy2MPQYXoNf9dXjHrhyYXxx7jKk7ML+YL1z22rHH2BQ3v/bGHNm1b+wxpu5jV/1k3vKWfzn2GFtqW8TR/NgDcEGWylwOLezs8ofSVbsvz50XL3W5bb06OL+YpbItvpVN1eEdu/Khi/Z091w8OL+Yf/ZD12ayZ//Yo0xdufa9+fev/qnuAuk3X/22vPvdq3nbte8de5StU2sdfUlSl8pcTWKZoeX2nXu73G8PXPLqemTXvi63rdfl8I5dXe6v23fu7fK5uDy3UN927XvrbRftGX2WaS/vetdd9d2vu6m7bXvbte+tn/zkj9Tfv/LHR59lysu9z9olY4fRRhwlAmkWl96+AWwskz3765Fd+0afw3L+y6GFnV1+Dzm8Y1e3z8V3v+6memB+cfQ5pr1cf/0v1Ldd+97utu33r/zx+l//62I9tvvy0WeZ4rL948gym8sti7tHn2EzliO79nX7Q6nX5cD8YpeBdGB+sd5x8dLoc2zG8k9e8/buIiJJPXjg/fXag7d293w8tvvyeuTIZT3tM3Fk2bzl0MLO0WfYjOWWxd0CacaW5bmF7n4gJetH1m/fuXf0OTZjufOqN9bDO3aNPse0l19cvr6+5g1/d/Q5pr0cmF+sv/mbh+vy3MLos0xhEUeWzV381m7ZLstSmevyuZj0e6T2C5e9tsvT9Mdedk09eOD9o88x7WV5bqH+q3/1+R72mTiybP7S62/ty3MLPXwTeMEtPT4Xkz6P1C6VuXpy71XdfZ0tlbn68ItfXt/9uptGn2Xay20X7anvf/9X62TP/tFneR6LOLJszdLrb+1LZa7LQ/+W2Vw6uubj6WV5bqEe2bWvy0A6smtf/dfLh0afZdrLZM/++tM//av1gUtePfosz3F51jgqQ5yMqpQy/hBM1VKZy2qdjD3G1C2VuSzPLeTo2TNjjwJZnlvIymRt7DGmanluIYd37MpqneSXzpwce5ypWSpzuXvXvpzce1Xe/MDRsceZqgcueXX+n1e+Of/+m/89V/+vL489zoW6r9Z63TNXiiO4QEtlLktlrrsfSsymHn8RWZ5byMHh3cHvfOrUyNNM17Hdl+cli7tz6erK2KNM1bGXXZNPvuSH865HvpYrHv7zsce5EOIIpmXjHZl7+6EE28VSmcvB+cU8XCfdHak9tvvyrNZJDj5+fOxRpuqBS16dL168lJ/8/ndy0aPfGnuc8/WscdTfe+7DFhBFsLlW6yT3nD2TS4ZT2T25+uSDSZJbFnd39U/fXPHwn+cnv/+dfHXn3tzzokvHHud56WevwBZbrZOuvrHBdrNaJ7l77XSunlvo7mvt4OPHc2hh59OnD3tx0aPfyumTD2Zp177csrh77HGes76ebbDFHEGCzXf32unujh4lyVtPPZQD84s50FkgHXz8eG5/9Fv54ItfPrPb5pojAGZCj6/OS5LDO3bl2GStu2urDswv5lN79uevnPjGdv5F0gXZAMy2XgNp4whLb4G0VOby0ItfnrnH7h97lL+MC7IBmG0rk7Xurj9K1qNoZbLW3enD1TrJ3GP358iufWOPckH6e4YB0LVeXwyxWidZrZPuAilZv77qtov2jD3GeXNaDQC2mR7f3DNJDi3szN1rp8ceo+W0GgDMgl6Pjs3KKw/7+z8PAB3o8chRMhvXjW3v6QCA7mz3I2PbdzIAoFvb+ciYOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaCyMPcDgoSSPD38yG/bF/po19tnssc9mi/01e3742VaWWutWD/KsSin31lqvG3sOzo/9NXvss9ljn80W+6sfTqsBADTEEQBAYzvF0UfHHoALYn/NHvts9thns8X+6sS2ueYIAGA72E5HjgAARjd6HJVSri+l/M9Sykop5YNjz8O6Usqvl1KOl1L+rFm3VEr5dCnl2PDnS4f1pZRy+7AP/7SUcu14k78wlVKuLKV8rpTy5VLKl0opHxjW22fbVCllZynlaCnlC8M++/Cw/pWllHuGffPbpZTFYf1Fw/2V4eNXjTn/C1kpZb6U8sellN8f7ttnnRk1jkop80n+bZJDSa5J8q5SyjVjzsTTPpbk+mes+2CSz9Rar07ymeF+sr7/rh6W9yX5lS2akb+wluTnaq3XJHlDkr89fC3ZZ9vXk0neVGt9XZLXJ7m+lPKGJD+f5CO11uUkjyR5z/D49yR5ZFj/keFxjOMDSb7S3LfPOjP2kaMDSVZqrV+vtZ5J8ltJbhh5JpLUWv8gyeozVt+Q5OPD7Y8neXuz/jfquj9MsreU8kNbMylJUmv9bq3188Pt72f9G/cVsc+2reH//cnh7o5hqUnelOR3hvXP3Gcb+/J3kry5lFK2aFwGpZT9Sd6W5FeH+yX2WXfGjqMrkny7uX//sB7kBP0AAAIpSURBVI7t6bJa63eH2w8muWy4bT9uI8Oh+x9Nck/ss21tOD3zJ0mOJ/l0kq8lOVFrXRse0u6Xp/fZ8PFHk1yytROT5BeS/IMkk+H+JbHPujN2HDGj6vrLHL3UcZsppexO8p+S/J1a62Ptx+yz7afWerbW+vok+7N+JP01I4/ED1BK+akkx2ut9409C5tr7Dh6IMmVzf39wzq2p+9tnHoZ/jw+rLcft4FSyo6sh9GdtdbfHVbbZzOg1noiyeeS/FjWT3Fu/LuX7X55ep8NH39Jkoe3eNQXur+a5KdLKd/I+mUgb0ryi7HPujN2HP1RkquHK/0Xk7wzyV0jz8Rf7q4kNw+3b07yyWb9TcMroN6Q5NHmVA5bYLiO4deSfKXW+m+aD9ln21Qp5WWllL3D7YuTvCXr14p9Lsk7hoc9c59t7Mt3JPls9UZ1W6rW+o9qrftrrVdl/efVZ2uth2OfdWf0N4Espbw16+dw55P8eq31n486EEmSUsp/TPLGrP8r099LcluS30vyiSSvSPLNJD9Ta10dfjD/ctZf3XYqyc/WWu8dY+4XqlLKTyT5H0m+mL+4FuIfZ/26I/tsGyqlvDbrF+vOZ/0X1U/UWv9pKeVVWT8qsZTkj5PcWGt9spSyM8l/yPr1ZKtJ3llr/fo401NKeWOSv19r/Sn7rD+jxxEAwHYy9mk1AIBtRRwBADTEEQBAQxwBADTEEQBAQxwBADTEEQBAQxwBADT+N3rVH1uCgb6fAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 720x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "figure(figsize=(10,10))\n",
+    "imshow(np.log10(cov+1e-11),cmap='gist_stern');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hN5jA8ogp7Bb"
+   },
+   "source": [
+    "## Where the wild things are: Automatic Differentiation\n",
+    "\n",
+    "Now that we know how to compute various quantities, we can move on to the amazing part, computing gradients automatically by autodiff. As an example, we\n",
+    "will demonstrate how to analytically **compute Fisher matrices, without finite differences.** But gradients are usefull for a wide range of other applications.\n",
+    "\n",
+    "\n",
+    "We begin by defining a Gaussian likelihood function for the data vector we have \n",
+    "obtained at the previous step. And we make this likelihood function depend on an array of parameters, `Omega_c`, `sigma_8`.\n",
+    " \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "QUBA8ajicFk4"
+   },
+   "outputs": [],
+   "source": [
+    "# Let's define a parameter vector for Omega_cdm, sigma8, which we initialize \n",
+    "# at the fiducial cosmology used to produce the data vector.\n",
+    "data = mu;\n",
+    "params = np.array([cosmo.Omega_c, cosmo.sigma8])\n",
+    "\n",
+    "# Note the `jit` decorator for just in time compilation, this makes your code\n",
+    "# run fast on GPU :-)\n",
+    "@jax.jit\n",
+    "def likelihood(p):\n",
+    "  # Create a new cosmology at these parameters\n",
+    "  cosmo = jc.Planck15(Omega_c=p[0], sigma8=p[1])\n",
+    "\n",
+    "  # Compute mean and covariance of angular Cls\n",
+    "  m, C = jc.angular_cl.gaussian_cl_covariance_and_mean(cosmo, ell, probes)\n",
+    "\n",
+    "  # Return likelihood value assuming constant covariance, so we stop the gradient\n",
+    "  # at the level of the precision matrix, and we will not include the logdet term\n",
+    "  # in the likelihood\n",
+    "  P = jax.lax.stop_gradient(np.linalg.inv(C))\n",
+    "  r = data - m\n",
+    "  return -0.5 * (r.T @ P @ r)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 51
+    },
+    "colab_type": "code",
+    "id": "4Us1pbt1dt-h",
+    "outputId": "42bfcaff-0ed7-457f-95ce-108d1d8462eb"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-2.5765703e-09\n",
+      "10 loops, best of 3: 40.5 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Computing the likelihood at our fiducial params, we should get 0 since we don't\n",
+    "# have the normalization term\n",
+    "print(likelihood(params))\n",
+    "%timeit likelihood(params).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "EmJfTrVSySAW"
+   },
+   "source": [
+    "This is an illustration of evaluating the full likelihood. Note that because we \n",
+    "used the `@jax.jit` decorator on the likelihood, this code is being compiled to \n",
+    "and XLA expression that runs automatically on the GPU if it's available. \n",
+    "\n",
+    "\n",
+    "But now that we have a likelihood function of the parameters, we can manipulate\n",
+    "it with JAX, and in particular take the second derivative of this likelihood \n",
+    "with respect to the input cosmological parameters. This Hessian, is just minus \n",
+    "the Fisher matrix when everything is nice and Gaussian around the fiducial comology.\n",
+    "\n",
+    "\n",
+    "So this mean, by JAX automaticatic differentiation, we can analytically derive\n",
+    "the Fisher matrix in just one line:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 139
+    },
+    "colab_type": "code",
+    "id": "V9vX2W1UyRhm",
+    "outputId": "e5985d95-374b-4150-8b28-e16218ab9d45"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compile a function that computes the Hessian of the likelihood\n",
+    "hessian_loglik = jax.jit(jax.hessian(likelihood))\n",
+    "\n",
+    "# Evalauate the Hessian at fiductial cosmology to retrieve Fisher matrix\n",
+    "F = - hessian_loglik(params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "_Vvm8-IpB4rf"
+   },
+   "source": [
+    "What we are doing on the line above is taking the Hessian of the likelihood function, and evaluating at the fiducial cosmology. We surround the whole thing \n",
+    "with a `jit` instruction so that the function gets compiled and evaluated in one\n",
+    "block in the GPU.\n",
+    "\n",
+    "Compiling the function is not instantaneous, but once compiled, it becomes  fast but the evaluation is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "NgrRoxsSB3UZ",
+    "outputId": "ec070fd3-1f46-449c-e5c5-bca82ccae07d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 270 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit hessian_loglik(params).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ZqXezv82EnxE"
+   },
+   "source": [
+    "And best of all: **No derivatives were harmed by finite differences in the computation of this Fisher!**\n",
+    "\n",
+    "We can now try to plot it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 299
+    },
+    "colab_type": "code",
+    "id": "pmTdQeeXk8qB",
+    "outputId": "3ac0f9a9-3dc5-4dd4-b58b-fa6a6d8e1291"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(14.5, 0.5, 'sigma8')"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deZyN9f//8ceLMcY+tj7WWTJaZBsmDLKnTNlKmJBsE9FG6wclaf9Jq0/fLEkiVEp9CFkqjBj7EmPKGINKicJIeP3+OBefaTLM0RzXOTOv++12bnPOda5zzfOM5TnX9b7O+xJVxRhjjMmpAm4HMMYYE1isOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWnxSEiN4rIDhFJEZFHz/F8mIgsFZH1IrJJROKc5WWd5UdE5PUsr+nmrLtVRJ73ZX5jjDF/J776HIeIFASSgeuBdGANEK+q2zKt8xawXlX/IyI1gHmqGiEixYBooCZQU1WHOOuXBdYD9VX1gIi8A0xV1cXny1KuXDmNiIjI/TdpjDF52Nq1a39W1fJZlwf58Hs2AFJU9XsAEXkf6Ahsy7SOAiWd+6WAfQCqehRYLiJRWbZ5ObBTVQ84j78AbgXOWxwREREkJSX9g7dijDH5j4jsPtdyXxZHZWBPpsfpQMMs64wCForIPUAxoM0FtpkCXCkiEc72OgHBuZDVGGNMDrk9OB4PTFHVKkAc8K6IZJtJVX8FBgEzga+BVODUudYVkQQRSRKRpAMHDpxrFWOMMRfBl8WxF6ia6XEVZ1lm/YBZAKqaCIQA5c63UVX9VFUbqmossAPPOMq51ntLVWNUNaZ8+b8dojPGGHORfFkca4DqIhIpIsFAd2BulnXSgNYAInI1nuI47+6BiFzmfC0N3A1MzOXcxhhjzsNnYxyqelJEhgALgILAZFXdKiKjgSRVnQsMAyaIyAN4BsrvVOc0LxFJxTNwHiwinYC2zhlZr4hIHefbjFbVc+5xGGOM8Q2fnY7rT2JiYtTOqjLGGO+IyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXfFocInKjiOwQkRQRefQcz4eJyFIRWS8im0Qkzlle1ll+RERez/KaeBHZ7Kz/uYiU8+V7MMYY81c+Kw4RKQi8AbQDagDxIlIjy2ojgFmqGg10B8Y7y48DI4EHs2wzCHgFaKmqtYFNwBBfvQdjjDF/F+TDbTcAUlT1ewAReR/oCGzLtI4CJZ37pYB9AKp6FFguIlFZtinOrZiI/OK8NsVn78BctMOHD7N7927S0tLYvXs36enpHDlyhIyMDI4fP87x48f/dv/EiRMUKVKEYsWKnfdWpkwZKlasSKVKlahUqRJly5ZFRNx+y8bkG74sjsrAnkyP04GGWdYZBSwUkXuAYkCb821QVf8UkUHAZuAosBMYfK51RSQBSAAICwu7iPjmQlSV5ORkEhMTWbt2Lbt27TpbFKdOnSI8PJzw8HDCwsKoWrUqFStWpEiRIoSEhJz9mvl+oUKFOH78OEePHs32tnfvXjZv3sy+ffvYv38/+/bt48iRI1SqVInw8HAiIiLOft+oqChq1qxJmTJl3P5RGZOn+LI4ciIemKKqY0UkFnhXRGqq6ulzrSwihYBBQDTwPfAa8BgwJuu6qvoW8BZATEyM+ih/vvLbb7+xevVqVq1aRWJiIqtWraJEiRLExsZy7bXX0qZNG8LCwggPD6d06dKXbC/g+PHj7N27l9TUVHbv3s3u3bv56quvmDhxIlu3bqV48eLUrFmTmjVrUqtWLWrWrEmNGjUoWrToJclnTF7jy+LYC1TN9LiKsyyzfsCNAKqaKCIhQDngp2y2WddZ9zsAEZkF/G3Q3eSeH3/8kVmzZjFjxgw2btxIdHQ0sbGx9OvXj4kTJ1KxYkW3IxISEkK1atWoVq3a355TVfbs2cOWLVvYvHkzixcv5uWXXyY5OZnKlSufLZNGjRoRGxtL6dKlXXgHxgQWXxbHGqC6iETiKYzuwO1Z1kkDWgNTRORqIAQ4cJ5t7gVqiEh5VT0AXA98m+vJ87nDhw/z0UcfMWPGDFavXk379u0ZMWIEbdq0ITg42O14XhERwsLCCAsLIy4u7uzykydPkpKSwpYtW9iwYQNjx45l9erVhIeH06RJE5o0aULTpk2JjIy08RNjshBV3x3FcU6vfRkoCExW1adFZDSQpKpznbOsJgDF8QyUP6yqC53XpuIZ/A4GDgFtVXWbiAwE7gP+BHYDd6rqL+fLERMTo0lJST55j3nJypUrGTt2LF988QWtWrUiPj6em2++Od8c0vnzzz/ZuHEjK1asOHs7ffr02SJp0qQJ0dHRFCpUyO2oxlwSIrJWVWP+ttyXxeEvrDjOb+3atYwcOZKtW7fy2GOP0b17d0JDQ92O5TpVJTU19S9FkpaWRsuWLYmLi6Ndu3ZUqVLF7ZjG+IwVhxXH32zevJnHH3+c1atXM3z4cPr160fhwoXdjuXXfvrpJxYsWMD8+fNZuHAhFStWpF27drRr144mTZoE3KE8Y87HisOK46xffvmFe++9l8WLF/PII48wcOBAihQp4nasgHPq1CnWrFnD/PnzmT9/PsnJybRs2fJskVStWvXCGzHGj2VXHDZXVT6zfPlyoqOjqVChAikpKTzwwANWGhepYMGCNGrUiCeffJLVq1eTnJzMLbfcwrJly4iOjqZevXo899xz7Nq1y+2oxuQq2+PIJ06dOsVzzz3Ha6+9xqRJk7jpppvcjpSnnTp1iq+++oqZM2fy0UcfERERQbdu3ejatavtiZiAYYeq8nFx/PDDD/Tq1Ys//viD6dOn24DuJXby5EmWLFnCrFmzmDNnDldeeSXdunXjtttuo1KlSm7HMyZbdqgqn0pJSaFBgwY0bNiQJUuWWGm4ICgoiLZt2zJx4kT279/PiBEjWLduHddccw3Nmzdn/Pjx/Pzzz27HNCbHrDjysF27dtG6dWtGjBjBmDFjCApye4YZExwcTFxcHO+88w779+9n6NChLF++nKioKLp3784XX3zB6dPnnHHHGL9hxZFH/fjjj7Ru3ZqHH36YhIQEt+OYcwgJCaFjx45Mnz6dXbt2cd111/Hggw8SFRXF008/zd69WWfoMcY/WHHkQceOHaN9+/bccccdDB58zsmDjZ8pXbo0gwcPZv369cyaNYu0tDRq1qxJ+/btmTt3LidPnnQ7ojFn2eB4HtSzZ09EhKlTp9o8SwHsyJEjzJ49mwkTJpCamkqfPn3o27fvOSdzNMYXbHA8n/jiiy9YuXIlb731lpVGgCtevDh9+vRh5cqVLFq0iIyMDBo1asRNN93EkiVLyA+/9Bn/ZMWRh5w4cYJ77rmHl19+2T7Ul8dcc801vPTSS6SlpdG5c2eGDBlCdHQ0U6dO5cSJE27HM/mMFUce8sorrxAZGUn79u3djmJ8pEiRIvTv358tW7bw3HPPMW3aNCIjI3n22Wc5ePCg2/FMPmHFkUfs3buX559/nldeecUOUeUDBQoU4MYbb2ThwoXMnz+fnTt3EhUVxeDBg0lOTnY7nsnjrDjyiGeeeYb+/ftTvXp1t6OYS6x27dpMnjyZbdu2UaZMGZo2bUrHjh358ssvbRzE+IQVRx5w8uRJZs+ebZ/XyOcqVKjAU089RWpqKnFxcQwYMIDmzZvbQLrJdVYcecCSJUuIiIjg8ssvdzuK8QNFixblrrvuYtu2bSQkJDBw4EBatGjB0qVL3Y5m8ggrjjxg1qxZdOvWze0Yxs8EBQXRs2dPtm3bRv/+/UlISKBFixYsW7bM7WgmwFlxBLgTJ04wZ84cbrvtNrejGD8VFBREr169+Pbbb+nTpw/9+/enZcuWfPnll25HMwHKiiPAffnll1xxxRWEhYW5HcX4uaCgIHr37s327dvp3bs3ffv2pVWrVnz11VduRzMBxoojwH377bfUr1/f7RgmgAQFBXHnnXeyfft2evXqRZ8+fWjTpg3r1q1zO5oJEFYcAS41NZWIiAi3Y5gAVKhQIfr06cP27du59dZbiYuLo1evXqSlpbkdzfg5K44AZ8Vh/qlChQoxaNAgdu7cSUREBNHR0TzyyCMcOnTI7WjGT1lxBDgrDpNbSpQowVNPPcWmTZv4+eefufLKKxk/frxN6W7+xoojwFlxmNxWuXJlJk2axMKFC/nggw+oW7cuixYtcjuW8SM+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nWr+EiGzIdPtZRF725XvwZydPnuTQoUOULVvW7SgmD6pTpw6LFy9mzJgxDBo0iA4dOtg8WAbwYXGISEHgDaAdUAOIF5EaWVYbAcxS1WigOzDeWX4cGAk8mHllVf1dVeueuQG7gY989R78XVBQEMHBwWRkZLgdxeRRIkKnTp3YunUrzZo1o3HjxgwfPtz+zuVzvtzjaACkqOr3qnoCeB/omGUdBUo690sB+wBU9aiqLsdTIOckIlcAlwFf53bwQFKqVCkOHz7sdgyTxxUuXJgHH3yQTZs2kZKSQq1atezwVT7my+KoDOzJ9DjdWZbZKKCniKQD84B7vNh+d2CmZjN7m4gkiEiSiCQdOHDAi80GltDQUCsOc8lUqlSJmTNn8uqrr5KQkECPHj348ccf3Y5lLjG3B8fjgSmqWgWIA94VkZxm6g7MyO5JVX1LVWNUNaZ8+fK5ENU/2R6HcUNcXBxbtmyhcuXK1KpViwkTJnD69Gm3Y5lLxJfFsReomulxFWdZZv2AWQCqmgiEAOUutGERqQMEqera3IkauEqVKmXn2xtXFCtWjBdeeIFFixYxadIkmjVrxtatW92OZS4BXxbHGqC6iESKSDCePYS5WdZJA1oDiMjVeIojJ8eV4jnP3kZ+ctlll7F//363Y5h8rE6dOqxYsYIePXrQokULGzzPB3xWHKp6EhgCLAC+xXP21FYRGS0iHZzVhgEDRGQjniK488yYhYikAi8Bd4pIepYzsrpixQFATEwMq1evdjuGyecKFizIoEGDzg6e165dm5UrV7ody/iI5Icrg8XExGhSUpLbMXxi1apVDBo0iPXr17sdxZizPv74YwYOHEj//v15/PHHCQ4OdjuSuQgislZVY7Iud3tw3PxD0dHRJCcnc+TIEbejGHNWp06d2LBhAxs3biQ2NpZt27a5HcnkIiuOAFe4cGHq1KnDmjVr3I5izF9UqFCBuXPnMnDgQJo3b86rr75qZ17lEVYceUBsbCyJiYluxzDmb0SEAQMGkJiYyIwZM7jhhhtIT093O5b5h6w48oDGjRuzfPlyt2MYk62oqCi+/vprWrRoQb169Zgxw85tCWQ2OJ4H/Pbbb4SFhZGSkkK5chf8GIwxrlq7di09e/akbt26vPnmm5QqVcrtSCYbNjieh5UsWZKbbrrJfoszAaF+/fqsW7eOMmXKEBMTw6ZNm9yOZLxkxZFH9O7dm3feecftGMbkSJEiRXjjjTd48sknad26NVOnTnU7kvGCFUce0bp1a3744Qeb8sEElNtvv51ly5bx9NNPM3DgQI4fz3ZCbONHrDjyiIIFC9KrVy/b6zAB55prrmHNmjX8/PPPXHfddaSmprodyVyAFUce0rt3b6ZNm2bXiDYBp2TJksyePZv4+HgaNmzI559/7nYkcx5WHHnIVVddRUREBJ988onbUYzxmogwdOhQPvjgA/r168eoUaM4deqU27HMOVhx5DHDhw9n1KhR9gldE7Cuu+461q5dy9KlS7n55pv57bff3I5ksrDiyGPi4uIoVqwYs2fPdjuKMRetQoUKLF68mMjISJo2bcqePXsu/CJzyVhx5DEiwujRo2033wS8oKAg3njjDXr37k1sbCzr1q1zO5JxWHHkQddffz3lypVj+vTpbkcx5h8REYYNG8Yrr7zCDTfcwH//+1+3IxmsOPKkM3sdTz75JH/++afbcYz5x2699VY+/fRT+vfvz/jx492Ok+9ZceRRLVu2JCwsjHfffdftKMbkikaNGrFixQpeffVVhg0bZieAuOi8xSEil4vIZBEZIyLFRWSCiGwRkdkiEnFpIpqLNWbMGJ544gl+//13t6MYkysuv/xyVq5cSVJSErfddhvHjh1zO1K+dKE9jinAGuAIsArYDrQDPgcm+zSZ+ccaN27M9ddfz8iRI92OYkyuKVOmDAsXLqRIkSK0bt2aQ4cOuR0p37lQcZRQ1f+o6nNASVUdq6p7VHUSUPoS5DP/0AsvvMD7779vZ6SYPKVw4cK8++67NGzYkDZt2nDw4EG3I+UrFyqO0yJyhYhcCxQVkRgAEYkCCvo8nfnHypUrx3PPPUdCQoJNRWLyFBFh3LhxtGrVipYtW3LgwAG3I+UbFyqOh4FPgalAJ+AxEUkBVgJ2/CNA9O7dm9DQUMaOHet2FGNylYjw/PPP0759e1q0aMEPP/zgdqR8Ieh8T6rqYuDKTIuWi0g54FdVtU+XBQgRYeLEiVx77bW0b9+eGjVquB3JmFwjIowZM4bChQvTokULFi9eTOXKld2OlaedtzgyE5GaQA0gxHmMqtrVVwJEREQETz31FH369GHFihUEBeX4j96YgDBy5EiCg4Np3rw5S5YsISwszO1IeVaOPschIk8Arzm3lsALQAcf5jI+kJCQQIkSJRgzZozbUYzxiUceeYTBgwfTvHlzdu3a5XacPCunHwDsArQGflDVPkAd4IJXmBeRG0Vkh4ikiMij53g+TESWish6EdkkInHO8rLO8iMi8nqW1wSLyFsikiwi20Xk1hy+h3yvQIECTJs2jYkTJ9r1Dkye9cADD/Dggw/SokULmxzRR3J6vCJDVU+LyEkRKQn8BFQ93wtEpCDwBnA9kA6sEZG5qrot02ojgFmq+h8RqQHMAyKA43gG32s6t8yGAz+p6hUiUgAok8P3YPDMOjpjxgy6dOnC6tWrCQ8PdzuSMblu8ODB/PHHH9xwww0sX76cMmXsv4nclNM9jiQRCQUmAGuBdUDiBV7TAEhR1e9V9QTwPtAxyzoKlHTulwL2AajqUVVdjqdAsuoLPOusd1pVf87hezCO6667jocffpguXbrwxx9/uB3HGJ8YOnQocXFxdOjQgYyMDLfj5Ck5Kg5VvVtVD6nqm3j2IHo7h6zOpzKQeT8x3VmW2Sigp4ik49nbuOd8G3TKC+ApEVnnTH3yr5y8B/NXQ4cOJSwsjPvvv9/tKMb4zAsvvEBERATx8fH2OaZclONJDkWktoh0AOoBUSJySy58/3hgiqpWAeKAd53DT9kJAqoAK1W1Hp69nv+XTd4EEUkSkST7YNDfiQhvv/02ixcvtokQTZ5VoEABJk+ezLFjxxg8eDCq6nakPCGnZ1VNxjM31a1Ae+d28wVetpe/joNUcZZl1g+YBaCqiXhO9S13nm3+AhwDPnIez8ZTZH+jqm+paoyqxpQvX/4CUfOnkiVL8uGHHzJ06FA2b97sdhxjfCI4OJgPP/yQpKQkRo8e7XacPCGng+ONVNXbT42tAaqLSCSewugO3J5lnTQ8Z2tNEZGr8RRHtrsHqqoi8inQAljivHZbduubC6tVqxbjxo2jc+fOrFy5kssuu8ztSMbkuhIlSjBv3jyaNGlCxYoVSUhIcDtSQMtpcSSKSI0sZ0Sdl6qeFJEhwAI881pNVtWtIjIaSFLVucAwYIKIPIBnoPxOdfYlRSQVz8B5sIh0Ato63/8RPIe0XsZTMhcaazEX0LNnT3bs2MFNN93E0qVLKV68uNuRjMl1//rXv/j8889p1qwZVapUIS4uzu1IAUtycsxPRJoDc4EfgD8AwbMDUNu38XJHTEyMJiUluR3Dr6kqAwYMID09nU8//ZRChQq5HckYn0hMTKRTp06sWrWKyMhIt+P4NRFZq6oxWZfndHB8EtALuJH/jW+0z714xm0iwptvvkmhQoXo16+fDSKaPCs2Npbhw4fTpUsXjh8/1xn/5kJyWhwHVHWuqu5S1d1nbj5NZi65oKAgZs6cyc6dO3nsscfcjmOMz9xzzz1Ur16de++91+0oASmnxbFeRKaLSLyI3HLm5tNkxhVFixbls88+4+OPP+aVV15xO44xPnFmxuivv/6at99+2+04ASeng+NF8IxttM20TPnfabEmDylbtiwLFiygadOmVKhQgW7durkdyZhcV7x4cT788EOaN29OdHQ0devWdTtSwMhRceTgU+ImjwkPD2fevHm0adOGkiVL0q5dO7cjGZPratSowWuvvUaXLl1ISkoiNDT0wi8yOT6r6tVzLD6M57TaT3I9VS6zs6ou3qpVq+jQoQMTJ06kQwebSd/kTffddx9paWl89NFHiIjbcfzGPz2rKgSoC+x0brXxfBK8n/N5CpNHNWrUiHnz5jFgwAA+/PBDt+MY4xMvvvgiqampTJ1q16bLiZyOcdQGmpy5XKyI/Af4GmgK2FwVeVxMTAwLFiygXbt2nDhxgvj4eLcjGZOrgoODefvtt2nbti1t2rSxS89eQE73OEoDmT9OXAwo4xSJzcudD9StW5dFixYxbNgw3nnnHbfjGJPr6taty913381dd91ln2O6gJwWxwvABhF5W0SmAOuBF0WkGPCFr8IZ/1KzZk2WLFnC8OHDmThxottxjMl1//73v9mzZw/Tp093O4pfy9HgOICIVMRzcSaANaq6z2epcpkNjueunTt30rp1ax599FHuvvtut+MYk6tWr15Nx44d2bZtG6VLl3Y7jqsuanBcRK5yvtYDKuK5MNMeoIKzzORD1atX58svv+TFF1/kueees916k6c0aNCAW265hUcffdTtKH7rvHscIvKWqiaIyNJMi8++QFVb+TJcbrE9Dt/Yu3cvN998M9deey1vvPGGTYxo8ozDhw9To0YNZs+eTePGjd2O45qL2uNQ1TOT1v8H6KiqLYGleD7D8WCupzQBpXLlynz11Vekp6fTvn17fvvtN7cjGZMrSpUqxTPPPMMjjzxie9TnkNPB8RGq+puINAVaARPxlInJ50qUKMHcuXOJjIykadOm7Nmz58IvMiYA9OzZkwMHDrBo0SK3o/idnBbHKefrTcAEVf0vEOybSCbQBAUFMX78eHr16kVsbCzr1693O5Ix/1jBggUZNWoUjz/+uO11ZJHT4tgrIv8HdAPmiUhhL15r8gER4aGHHuLll1+mbdu2zJs3z+1IxvxjXbt25ciRI/b3OYuc/uffFc8lYG9Q1UNAGeAhn6UyAatLly7MnTuXfv368Z//2NFME9gKFCjAk08+aXsdWeSoOFT1mKp+pKo7ncf7VXWhb6OZQBUbG8vy5ct5+eWXGTJkCCdOnHA7kjEXrXPnzpw+fZqPP/7Y7Sh+ww43GZ+oVq0a33zzDXv27KF58+Y2aG4C1pm9jieeeML2OhxWHMZnQkNDmTNnDp06daJBgwZ88YXNTmMCU/v27Tlx4gSJiYluR/ELVhzGpwoUKMAjjzzC9OnTueOOO3j66ac5ffq027GM8YqI0Lt3b5vg02HFYS6Jli1bsmbNGubNm0fHjh359ddf3Y5kjFd69erF7NmzycjIcDuK66w4zCVTuXJlli1bRlRUFDExMfZ5DxNQqlSpQv369Zk7d67bUVxnxWEuqUKFCjFu3DieffZZ2rZty6RJk2zA0QQMO1zlYcVhXNG1a1e++uorxo0bR7du3Th48KDbkYy5oM6dO5OYmMj+/fvdjuIqnxaHiNwoIjtEJEVE/jZHsYiEichSEVkvIptEJM5ZXtZZfkREXs/ymmXONjc4t8t8+R6M71x99dUkJSVRpUoVateuzYIFC9yOZMx5FStWjE6dOjFr1iy3o7jKZ8UhIgWBN4B2QA0gXkRqZFltBDBLVaOB7sB4Z/lxYCTZz8DbQ1XrOrefcj+9uVRCQkJ46aWXmDp1KgMGDGDIkCEcO3bM7VjGZKt169YsX77c7Riu8uUeRwMgRVW/V9UTwPtAxyzrKFDSuV8K2AegqkdVdTmeAjH5QKtWrdi0aROHDh2iXr16rFmzxu1IxpxTbGxsvv88hy+LozKeqwWeke4sy2wU0FNE0oF5wD053PbbzmGqkSIi51pBRBJEJElEkg4cOOBldOOG0NBQpk2bxujRo7n55psZPXo0J0+edDuWMX9x+eWXc+LEiXw9G4Lbg+PxwBRVrQLEAe+KyIUy9VDVWsB1zq3XuVZS1bdUNUZVY8qXL5+roY1vde3alXXr1rFixQqaNGlCcnKy25GMOUtE8v1ehy+LYy9QNdPjKs6yzPoBswBUNREIAcqdb6Oqutf5+jswHc8hMZPHVK5cmc8//5w77riDxo0bM27cONv7MH7DisN31gDVRSRSRILxDH5n/eRMGtAaQESuxlMc2R5XEpEgESnn3C8E3Axs8UF24wdEhMGDB7Ny5Uo+++wzGjZsiF073vgDKw4fUdWTwBA81/H4Fs/ZU1tFZLSIdHBWGwYMEJGNwAzgTnU+DSYiqcBLwJ0iku6ckVUYWCAim4ANePZgJvjqPRj/cMUVV/DFF19w//33c/PNN3Pffffx+++/ux3L5GPVq1cnNTXV7Riukfzwqd2YmBi131Tzhl9++YWHH36YhQsX8tprr9GpUye3I5l86OjRo5QrVy7Pz1slImtVNSbrcrcHx43xStmyZZk0aRLTpk3jscceo2PHjqSlpbkdy+QzRYsW5eTJk/n2ImVWHCYgNW/enA0bNhATE0O9evVs8NxcUiJCqVKlOHz4sNtRXGHFYQJW4cKFGTly5NnB8wYNGrBy5Uq3Y5l8olSpUhw6dMjtGK6w4jAB78zg+bBhw+jWrRvx8fF2+Mr4nO1xGBPgRIQePXqwfft2rrzySqKjo3n88cc5cuSI29FMHpWRkUFISIjbMVxhxWHylGLFijFq1Cg2bNjAd999x1VXXcWUKVM4deqU27RRwb4AABInSURBVNFMHqKq7N69m4iICLejuMKKw+RJVatW5b333uODDz5gwoQJ1KtXj4ULF7ody+QRP/30E0WLFqV48eJuR3GFFYfJ0xo1asTy5ct54oknGDx4MDfccAMbN250O5YJcKmpqfl2bwOsOEw+ICLccsstbNu2jfbt29O2bVt69eplkyeai2bFYUw+UahQIYYMGcLOnTu54ooraNKkCb1792bnzp1uRzMBJjk5mcjISLdjuMaKw+Q7JUuWZOTIkaSkpFCtWjViY2O58847SUlJcTuaCRCffPIJN954o9sxXGPFYfKtUqVK8fjjj5OSkkJkZCSNGjWiT58+fPfdd25HM34sJSWFPXv20Lx5c7ejuMaKw+R7oaGhPPHEE6SkpBAeHk7Dhg3p27cv33//vdvRjB+aPXs2t956K0FBQW5HcY0VhzGO0NBQRo0axc6dO6latSoNGjSgX79+7Nixw+1oxo/MnDmTbt26uR3DVVYcxmRRunRpnnzySZKTk6latSrNmjWjffv2LF26lPxwGQKTva1bt/LTTz/RtGlTt6O4yorDmGyUKVOGUaNGkZqaSocOHbj77rupV68e7777br6dTjs/U1UeeughHnjgAQoWLOh2HFdZcRhzAUWKFGHAgAFs3bqVZ555hqlTpxIZGcmzzz7LwYMH3Y5nLpFPP/2UXbt2cd9997kdxXVWHMbkUIECBWjXrh2LFi1i/vz5JCcnExUVxeDBg+2zIHlcRkYG999/P6+99hrBwcFux3GdFYcxF6F27dq8/fbbbN26ldKlS9O4cWM6duzIvHnzbELFPOj555+nfv36tGnTxu0ofsGuOW5MLjh27BjvvfceEyZMYP/+/fTt25e+ffsSHh7udjTzD61fv57rr7+edevWERYW5nacS8quOW6MDxUtWpQBAwawevVqPvvsMw4ePEi9evW44YYb+OCDD2wwPUClp6fToUMH/u///i/flcb5WHEYk8vq1KnDa6+9Rnp6OnfccQevv/46VatW5aGHHmL79u1uxzM5dPDgQW666Sbuvfdebr31Vrfj+BUrDmN8pEiRIvTo0YNly5bx9ddfU6BAAVq0aEGzZs2YMmVKvr3saCA4dOgQbdu25frrr+fBBx90O47fseIw5hK44ooreP7559mzZw8PPPAAc+bMoWrVqnTs2JHp06fz+++/ux3ROPbu3Uvbtm1p2rQpL774IiLidiS/Y8VhzCVUqFAhOnfuzCeffEJaWhq33HIL06ZNo0qVKnTp0oVZs2Zx9OhRt2PmW/PmzaN+/fp06NCBcePGWWlkw6fFISI3isgOEUkRkUfP8XyYiCwVkfUisklE4pzlZZ3lR0Tk9Wy2PVdEtvgyvzG+FBoaSu/evZk3bx7ff/897dq1Y+LEiVSqVInu3bszZ84cjh8/7nbMfOHPP//k4Ycf5q677mLWrFmMGDHCSuM8fFYcIlIQeANoB9QA4kWkRpbVRgCzVDUa6A6Md5YfB0YC5zy4KCK3AEd8kdsYN5QtW5Z+/fqxcOFCUlJSaNGiBa+++ioVKlQgPj6eadOmceDAAbdj5kmpqak0a9aMrVu3sn79epo1a+Z2JL/nyz2OBkCKqn6vqieA94GOWdZRoKRzvxSwD0BVj6rqcjwF8hciUhwYCozxVXBj3FS+fHkGDhzI0qVL2b59Oy1btuTDDz8kKiqKBg0a8MQTT7Bq1Sr7oOE/dOjQIUaOHEn9+vXp0qULn376KeXKlXM7VkDwZXFUBvZkepzuLMtsFNBTRNKBecA9OdjuU8BY4FguZDTGr1WoUIGEhATmzJnDgQMHeP7558nIyGDAgAFUqFCBHj162N6Il37//XfGjBlDVFQUe/fuJSkpiWHDhlGggA355pTbP6l4YIqqVgHigHdFJNtMIlIXqKaqcy60YRFJEJEkEUmyf1QmLwgODqZly5a88MILbN68mXXr1tG8efO/7I38+9//Zt68efz6669ux/U7x44d48UXXyQqKopvv/2WlStXMnny5Hx97fCL5ctLWO0FqmZ6XMVZllk/4EYAVU0UkRCgHPBTNtuMBWJEJBVP9stEZJmqtsi6oqq+BbwFnilHLv5tGOOfqlatSkJCAgkJCZw4cYIVK1awdOlSxo4dy+rVqwkPD6dJkyY0adKEpk2bEhkZme8GfE+ePMmSJUuYMWMGn3zyCa1atWLJkiVcc801bkcLaD6bq0pEgoBkoDWewlgD3K6qWzOtMx+YqapTRORqYDFQWZ1QInInEKOqQ86x/QjgM1WteaEsNleVyW/+/PNPNm7cyIoVK87eTp8+fbZImjRpQq1atShSpIjbUXOdqrJq1SqmT5/O7NmzCQsLIz4+nq5du1K5ctaj5eZ8spuryqeTHDqn174MFAQmq+rTIjIaSFLVuc5ZVhOA4ngGyh9W1YXOa1PxDJwHA4eAtqq6LdO2I7DiMCZHVJXdu3efLZGVK1eyY8cOwsLCqFWrFjVr1qRmzZrUqlWLatWqBdT1tFWVHTt2kJiYSGJiIosWLSIkJITbb7+d7t27U716dbcjBixXisNfWHEY83d//vknycnJbNmyhS1btrB582a2bNnCvn37uPLKK88WylVXXUV4eDjh4eGEhoa6HZtff/2VtWvXni2Kb775hhIlShAbG0tsbCwtWrSgVq1a+e6wnC9YcVhxGJMjR48eZdu2bWcLZceOHezevZvdu3cjIoSHhxMWFkalSpWoVKkSFStWpFKlSpQvX55ixYr95Va0aNEcna106tQpMjIyOH78OEePHmXv3r2kpaWd/b5n7qelpXH69Gnq1q1LbGwsjRo1IjY2looVK16Cn0z+Y8VhxWHMP6KqHDp0iNTUVPbs2cP+/fvZt28f+/btY//+/Rw4cICjR4/+5ZaRkUFISMhfiiRzSRw/fpyMjAxOnTpFkSJFCAkJoUiRIlSuXPnsXk5YWNhf7oeGhtrexCWSXXEEzoFMY4yrRITSpUtTunRpoqOjc/Sa06dPk5GRcbZIjh07RlBQECEhIWdLIiQkhEKFClkZBBArDmOMzxQoUODs3obJO9z+AKAxxpgAY8VhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxis+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nec3nIrJRRLaKyJsiUtCX78EYY8xf+aw4nP/Q3wDaATWAeBGpkWW1EcAsVY0GugPjneXHgZHAg+fYdFdVrQPUBMoDt/kgvjHGmGz4co+jAZCiqt+r6gngfaBjlnUUKOncLwXsA1DVo6q6HE+B/PUFqr85d4OAYGcbxhhjLhFfFkdlYE+mx+nOssxGAT1FJB2YB9yTkw2LyALgJ+B34INs1kkQkSQRSTpw4ICX0Y0xxmTH7cHxeGCKqlYB4oB3ReSCmVT1BqAiUBholc06b6lqjKrGlC9fPjczG2NMvubL4tgLVM30uIqzLLN+wCwAVU0EQoByOdm4qh4HPuHvh7+MMcb4kC+LYw1QXUQiRSQYz+D33CzrpAGtAUTkajzFke1xJREpLiIVnftBwE3Adh9kN8YYk40gX21YVU+KyBBgAVAQmKyqW0VkNJCkqnOBYcAEEXkAzyD3naqqACKSimfgPFhEOgFtgV+AuSJSGE/pLQXe9NV7MMYY83fi/D+dp8XExGhSUpLbMYwxJqCIyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4JV+McYjIAWC32zmyUQ742e0QXrC8vhdomS2vb7mZN1xV//ZBuHxRHP5MRJLONfjkryyv7wVaZsvrW/6Y1w5VGWOM8YoVhzHGGK9YcbjvLbcDeMny+l6gZba8vuV3eW2MwxhjjFdsj8MYY4xXrDiMMcZ4xYojl+XgOutDRWSbc431xSISnum5UyKywbnNzbRcRORpEUkWkW9F5F4/z/t1puX7RORjP8/bWkTWOcuXi0iUn+dt5eTdIiLvODNF+0PeMBFZ6Pwd3SYiEc7ySBH5xtnmTGe2bH/OO8TZnopIji7z4HLe95xtbhGRySJSKDczn5Oq2i2XbnhmAf4OuBzPZW03AjWyrNMSKOrcHwTMzPTckWy22weYChRwHl/mz3mzvP5D4A5/zgskA1c79+/Gc3Exv8yL55e9PcAVzuPRQD8/ybsMuN65XzzTerOA7s79N4FBfp43GogAUoFyuZHVx3njAHFuM3Lr53u+m+1x5K4LXmddVZeq6jHn4So8F7i6kEHAaFU97WzjJz/PC4CIlMRzhcbc2uPwVV7FM4U/QClgnx/nLQucUNVk5/Ei4Fa384pIDSBIVRc56x1R1WMiInj+Dpy5xPM7QCd/zevcX6+qqbmU8VLknacOYDVe/Bu9WFYcuSsn11nPrB8wP9PjEPFcJ32VeK5BckY1oJvz3HwRqe7nec/oBCxW1d/+eVTAd3n7A/NEJB3oBTznx3l/BoJE5Mwnibvw1yttupX3CuCQiHwkIutF5EURKYin6A6p6skcbtPtvL7k07zOIapewOe5mPmcfHYhJ3N+ItITiAGaZ1ocrqp7ReRyYImIbFbV7/BcW/24qsaIyC3AZOA6P857Rjww8VLmPMPLvA8Acar6jYg8BLyEp0z8Mq+IdAfGieeCZguBU5cyazZ5g/D8nYzGc2XPmcCdeC7v7Dov8k5yI19WF5l3PPCVqn7t63y2x5G7cnKddUSkDTAc6KCqf5xZrqp7na/f4zmeGe08lQ585NyfA9T287w4g4oNgP/mUlaf5BWR8kAdVf3GWW0m0Nhf8zqPE1X1OlVtAHyFZ4zG7bzpwAbnMMxJPIcn6+G5amdopgH8c27Tj/L6ks/yisgTQHlgqI+y/5WvB1Hy0w3PbwXfA5H8b/DrmizrROMZIKueZXlpoLBzvxywE2fgDM+hk77O/RbAGn/O6ywbCLzj7z9fZ5s/87/B5n7Ah/6a13l8mfO1MLAYaOUHeQs665d3Hr8NDHbuz+avg+N3+3PeTOukkruD4776+fYHVgJFcivrBd/LpfpG+eWG5wyHZOcPf7izbDSe3x4AvgB+BDY4t7nO8sbAZucvx2YynSkDhOL5zX0zkIjnN2S/zes8vwy4MUB+vp0zPbcMuNzP874IfAvsAO73h5+v89z1wCYn7xQg2Fl+OZ5B2xQ8JVLYz/Pei+c3/JN4TpSY6Od5TzrbO/Oax3P7313Wm005Yowxxis2xmGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMach4hUEZFPRGSniHwnIq/k5uyuxgQiKw5jsuFM0PcR8LGqVsczX1Bx4GlXgxnjMisOY7LXCs8cYW8DqOopPPNa9RWRu0XkYxFZJCKpzjUchjoT0K0SkTIAIlJNRD4XkbXiuU7JVZmWrxKRzSIyRkSOOMuLO9dhWOc81zGbbIhIhIhsF5Ep4rlWy3si0kZEVjh7SA18/hMy+ZIVhzHZuwZYm3mBemb6TcMzfURN4BbgWjx7IcdUNRrPp/vvcF7yFnCPqtYHHsQzER3AK8ArqloLz6eUzzgOdFbVeniuzTDW2fPJThQwFrjKud0ONHW+178v4j0bc0E2O64xF2+pqv4O/C4ih4FPneWbgdoiUhzP1CGzM/3fX9j5Gsv/rksxHfh/zn0BnhGRZsBpPNNu/wv4IZsMu1R1M4CIbMUzjb2KyGY8FyMyJtdZcRiTvW14rndxlnNxqjA88wP9kemp05ken8bzb6sAnmtR1PXie/bAM8tpfVX9U0RSgZDzrH+hDMbkOjtUZUz2FgNFReQOAOfCOWPxTDB37DyvA84e1tolIrc5rxcRqeM8vYr/Xbmve6aXlQJ+ckqjJRCeG2/EmNxkxWFMNtQzA2hn4DYR2YlnVtPjeDd20APoJyIbga3871Kh9wNDRWQTnnGKw87y94AY51DTHcD2f/xGjMllNjuuMS4QkaJAhjMe0R2IV9Vsz6Ayxp/YMVBj3FEfeN05Y+oQ0NflPMbkmO1xGOPnRKQsnvGWrFqr6i+XOo8xVhzGGGO8YoPjxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO88v8Bjugk/8WdHIIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light",
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# We can now plot contours obtained with this \n",
+    "plot_contours(F, params, fill=False);\n",
+    "xlabel('Omega_m')\n",
+    "ylabel('sigma8')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "dEXC2lIlE5IN"
+   },
+   "source": [
+    "And just to reinforce this point and demonstrate further audodiff magic, let's try to derive the same matrix differently, using the usual formula for constant\n",
+    "covariance:\n",
+    "\n",
+    "$$ F_{\\alpha, \\beta} = \\sum_{i,j} \\frac{d \\mu_i}{d \\theta_\\alpha} C^{-1}_{i,j} \\frac{d \\mu_j}{d \\theta_\\beta} $$\n",
+    "\n",
+    "What we need in this expression, is the covariance matrix, which we already have\n",
+    "and the Jacobian of the mean with respect to parameters. Normally you would need to use finite differencing, but luckily we can get that easily with JAX:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "WKn4COsdlKfs"
+   },
+   "outputs": [],
+   "source": [
+    "# We define a parameter dependent function that computes the mean\n",
+    "def mean_fn(p):\n",
+    "  cosmo = jc.Planck15(Omega_c=p[0], sigma8=p[1])\n",
+    "  # Compute signal vector\n",
+    "  m = jc.angular_cl.angular_cl(cosmo, ell, probes)\n",
+    "  return m.flatten() # We want it in 1d to operate against the covariance matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Be381gp6Gjqx"
+   },
+   "outputs": [],
+   "source": [
+    "# We compute it's jacobian with JAX, and we JIT it for efficiency\n",
+    "jac_mean = jax.jit(jax.jacfwd(mean_fn))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 139
+    },
+    "colab_type": "code",
+    "id": "t3kVMfEaGyuJ",
+    "outputId": "339ec1c1-4f47-43e9-f692-9c9070f5f0a2"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We can now evaluate the jacobian at the fiducial cosmology\n",
+    "dmu = jac_mean(params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "H6uzzV-jHnNe",
+    "outputId": "ed61a0df-5f6f-485b-ebbc-33ddaaa15c20"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(500, 2)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmu.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "X9ZDB3RtHFnG",
+    "outputId": "07f53328-fb3a-4ead-bdaf-d6528136a8aa"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 31.6 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For fun, we can alsi time it\n",
+    "%timeit jac_mean(params).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "ej3RdeaeHWy6"
+   },
+   "source": [
+    "Getting these gradients is the same order of time than evaluating the forward function!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "F3UMqqdLHQX7"
+   },
+   "outputs": [],
+   "source": [
+    "# Now we can compose the Fisher matrix:\n",
+    "F_2 = np.einsum('ia, ij, jb', dmu, np.linalg.inv(cov), dmu)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 282
+    },
+    "colab_type": "code",
+    "id": "zUv4GmcVH1z8",
+    "outputId": "4b7fb3e2-3271-4492-f781-45c205c2e57c"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3xUVfrH8c8zCUloSQRCJ4aqxNAjvQmoCK7ACgKKiqKujbW7rq67/Oyru7oquq6ggigosBZcQSxL6C10Qg09oSR0khBCMuf3x72wM0MSMpjJTXner9e8mHtu4TuUPHPvufccMcaglFJKFZXL6QBKKaXKFi0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKLwEtHCLSX0S2ikiyiDyTz/poEZknImtEZL2IDLDba9rtGSIy3mef4fa2SSLy10DmV0opdSEJ1HMcIhIEbAOuBVKAlcBIY8wmj20+BNYYY/4pIrHAbGNMjIhUBdoBcUCcMeZhe/uawBqggzEmXUQmA58aY34pLEutWrVMTExM8X9IpZQqx1atWnXYGBPl2x4cwN+zI5BsjNkJICJfAIOATR7bGCDcfh8B7AcwxmQCi0Skmc8xmwDbjTHp9vLPwM1AoYUjJiaGxMTEX/FRlFKq4hGRPfm1B7JwNAD2eSynAJ18thkH/CgiY4GqQL+LHDMZuEJEYuzjDQZCiiGrUkqpInK6c3wkMMkY0xAYAEwRkQIzGWOOAQ8AXwILgd1AXn7bish9IpIoIonp6en5baKUUuoSBLJwpAKNPJYb2m2exgDTAYwxS4EwoFZhBzXGfGeM6WSM6QJsxepHyW+7D40x8caY+KioCy7RKaWUukSBLBwrgeYi0lhEQoARwCyfbfYCfQFEpCVW4Sj09EBEatu/XgY8CEws5txKKaUKEbA+DmNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOspHG/s2LxHZjdVxHiIig4Hr7Duy3haRNvZv84IxJt8zDqWUUoERsNtxS5P4+Hijd1UppZR/RGSVMSbet93pznGllFJljBYOpZRSftHCoZRSyi9aOJRSSvlFC4dSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyixYOpZRSfgkO5MFFpD/wNhAETDTGvOazPhqYDETa2zxjjJktIjWBmcDVwCRjzMMe+4wEngUMsB8YZYw5HMjPoX6900ePcvrIEc4cP07OyZOcOXGC3FOnOHvqFLmnTpEZHExa48aEhYVRtWpVr1d1Y6gSEUFYZCTi0u86SjktYIVDRIKA94BrgRRgpYjMMsZs8tjsT8B0Y8w/RSQWmA3EANnA80Cc/Tp3zGCsQhRrjDksIq8DDwPjAvU51MUZYzh06BApmzdz9rvvOLN9O7J3L2FpaUScOEGd7GwuM4bKhRzjF2BYAesWAd0AN5ABnAoK4mhYGJnVq3OmZk3cdeoQFB1N1dhYanboQL2OHQmpVq2YP6VS6pxAnnF0BJKNMTsBROQLYBDgWTgMEG6/j8A6g8AYkwksEpFmPscU+1VVRI7Y+yYH7BOofGVmZpKYmMjSpUtZunQpy5YtIy0tjcuB3Zd4zLBC1lW1f3UB1YHqeXnUz8yEzEw4eBCSkry2dwMHXC7SqlXjyxtvpEHXrsTFxREXF0fNmjUvMaFS6pxAFo4GwD6P5RSgk88244AfRWQs1s+HfoUd0BhzVkQeADYAmcB24KH8thWR+4D7AKKjoy8hvjrn1P79bHjtNc4mJBC1YwfvnT7N+8ZcsF0qkId1zdFfhZ2NVC1kXX5cQD23m3onT9J16lSypk49v65evXrExcUxODycVuHh1OzVi8tvuIGqtWtfQmqlKqaA9nEUwUisPoy/i0gXYIqIxBlj3PltLCKVgAeAdsBO4F3gj8BLvtsaYz4EPgSIj4+/8KecKlT28eOsffVVzNSptE1JoavHum7A+/nsk4t1ytgon3VngVMinBEhx+UiJyiIs0FBnA0OJjc4mEPVqzOkfXuys7PJzMw8/8rIyCBv/37OuN2E+vkZdgBZPm0HDhzgwIED3An0APjkE9zA9tBQDjRujKtHD6JvvZVGPXtqf4pSBQhk4UjF+2dIQ7vN0xigP4AxZqmIhAG1gLQCjtnW3nYHgIhMB54pxswVWl5ODuv+8Q8yJ06k9fbtdC5guy75tFWpUoWmTZuyIjOTnVWqYBo1IqRZM6rHxREVH09UXBw1QkIK/f0HXCRfbnY2mWlpHE9O5sSWLWRs387ZPXswKSmEHDpE9aNHqZWVRR23GxfWaWlB4jzeu4DmZ87QfMsW2LIFJkzgkMvFznr1OBMfT9SgQbQYPpxKVapcJKFSFUMgC8dKoLmINMYqGCOAW3222Qv0BSaJSEusS93phRwzFYgVkShjTDpWx/vmYk9ewZzNymLp/ffTZOpU2uflXXT7xkDHmBiu6NGDzp0706VLF1q1akVwcGBPYIPDwoiIjiYiOhr69ClwuzMnT3Jw5Uoik5N57fhxNmzYwMaNG9m8eTM5OTkEA1de5Peq43ZTJzUVUlPh22/JuvtukiIiOB4XR6Vnn6XjtddSqVKlYv18SpUVYvK5Vl1sBxcZAPwD67L3x8aYl0XkBSDRGDPLvpNqAlANq6P8aWPMj/a+u7E6v0OA48B1xphNInI/8AjW1Y89wGhjzJHCcsTHx5vExMSAfMayLC8nh6UPP0yjTz7h8tzcQrdNCQoiuV07Kl9/PU1uvZWo2NgSSll8zp49S3JyMpsTE6kxYQJhycnUPXyY6LNni/xA00mgJlAlPJxrr72WAQMG0L9/f+rXrx/A5Eo5Q0RWGWPiL2gPZOEoLbRweHO73cyYMYN6Y8bQMzOzwO3SRdgUF0eNhx4i7t57y+01/xN79rB9yhQy5s4lYuNGWhw/XmCH/FfAzfm0t2nThj9GR3PltdcSO2aMXtZS5YIWDi0cACQnJzNy5EgSExO5C/jYZ302kNikCZXvuYc2jz1GcFhhN8qWT2ezstg+cybpX39NyMqVND5wgLpu636Ne4CP8tknCDiM9STrCWBTgwbkXncdcc89x2VNm5ZYdqWKkxYOLRx88cUX3HfffZw6dQqwfthtBppjXfdbGhtL80mTqHf11Q6mLH2M203KokXsmTqVaYcPM2PBAtLTvbviugML89n3LLA2KoozgwbR6vnnrf4ZpcoILRwVuHBkZWXxyCOPMHHixAvWjRThgWbNiJk4kUY9ezqQruxxu92sWrWKOXPmMGfOHJYvX87LxvDHi+x3Blhbpw65N99M6+eeo7r2i6hSTgtHBS0cybNmsWr0aG49dgzfh2MGDRrE66+/TosWLRzJVl4cOXKE9W+8QaXp07li926iivB/6jSwrn593MOG0ebZZ/UBRFUqaeGogIVj0+TJNBg9mgjgz8CLdntoaChvvfUW999/PyLiYMLyx52by5bPPyft449ptGwZTXNyLrrPPSEhZAwZwt13302/fv1wldObEFTZo4WjghWOzZ99Rr077iDS/vvNw3pg5kCLFkyfPp02bdo4mq8iMG4327/+mv1vvUXMihXEnD17wTbZQG3glL0cExPDmDFjGD16NA0bNizJuEpdQAtHBSocO+fMIXLgQGr4/N3ObtmSnitWUE1Hji1xxu1m65dfcvDtt2m6ahWN7OdmvgZ+m8/2LpeLl9q2pc/119P+T3/S23uVIwoqHHpOXM4c3ryZoJtuuqBoJHTrxg0bN2rRcIi4XFw5ciS9ly2j4ZkzJH38MQkdOvBNAaP1Greb4atX0+nVVzlavToJXbuy57//LeHUSuVPzzjKkbycHJJq1aL1qVNe7QkdO9Jr6dJy+wBfWeZ2u1m4cCETJ05k5syZZGdnA9AHa44SX6svu4zsUaO4+rXX9CxEBZyecVQAi+6444KisbB5cy0apZjL5aJXr15MmTKF/fv3M378eNq0acO9BWzf/tgxur77Lunh4SQMHMiJPXtKNK9SoGcc5cbhzZsJvuqq853hYH07jdu7V2fDK2OMMWz+7DMOv/IK7bZsoXoh254CVrdtS5O339bncFSx0zOOcm7z4MFeReMUUO/HH7VolEEiQuztt9Nz82bkwAEWjh7NhgL+HqsDvdaupX6vXixt2JAN//pXyYZVFZIWjnJg40cf0WPbNq+2VQMGUC/+gi8KqoypVrcuPT75hFanTrH9q69YcNVVF0xOBdbwMV1SU7nq/vsZ3K4d06dPJ/ciIx4rdam0cJRxxu2GRx7xatsREkLXL790KJEKlOZDhtBz40ZOb93KvH79OJRPv9Us4Nu1axk+fDjNmjXj7bff5vTp0yUfVpVrWjjKuO1ff02cz9DoJ158US9RlWM1W7Tgmp9+IvLYMRbdcw9bPUYwftNjuz179vDoo4/SpEkTq4D43Dih1KXSwlHG7X/rLa/lVTVq0P7ppx1Ko0pSaHg43SdMoEVmJqtff51vLr883xF6Dx48yHuPPsqxyEjm33wzp48eLfGsqnzRwlGGGWN4Yv9+7gJ+AHKB07/N7zlkVZ6Jy0X7p55i8O7dJCUlce+99xIaGuq1zfNAfbebXl99xYmoKOYPHUr28ePOBFZlnt6OW4atWbOG9u3bn1+uV6kSm3btIrJBAwdTqdIgLS2Nv/3tb7z33ns0zMpiE1YHuqcDLhfbhgyh08SJhEVGOhFTlXJ6O2459KVPB3h8//5aNBQAtWvX5vXXX2fXrl08f+ONnMlnm3puN73+/W+O1azJ/GHDOHPyZInnVGWTFo4y7IcffvBaHj58uENJVGlVu3ZtRn33HZkbNpDQoUO+t/LWc7vpNXMmaTVrsmTsWNx6G6+6CC0cZZQxhl27dnm19e3b16E0qrSLioujd2JioQWkUW4uXcePZ0tEBGvffrvEM6qyQwtHGXX8+HFOelxaCAsLo06dOg4mUmXBuQKSsW4dCe3bk98THrFZWbR99FGW163LzjlzSjyjKv20cJRRKYmJDAOuBqKAmMsv19n8VJHVbt2a3qtWcWrdOua3asWFU0zB1YcOUX/AAKb36cNRvYVXedDCUUZl/vwz04EVQBrwif7HVpegduvW9Fq/ntQff2Spz40VLqAS8NK8eTRr1ox3332Xs/nMYqgqHi0cZVT21q1eyzlRUQ4lUeVBzLXX0iUlhQ0ffOA1oOJEYANw7Ngxfv/739OmTRvmzp3rWE5VOgS0cIhIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jIeI/tq4vIWo/XYRH5RyA/Q6mVlua16NbCoYpBq9/9jrgTJ1j22GNsqlSJ533Wb968mf79+zN8+HAO+NycoSqOgBUOEQkC3gNuAGKBkSIS67PZn4Dpxph2wAjgfbs9G+th1yc9NzbGnDLGtD33AvYAXwXqM5Rq1X1macjK7z4ZpfwnLhed33yTJidO8Pirr+Y73fC66dMJbtqUBSNH6u27FVAgzzg6AsnGmJ3GmBzgC2CQzzYGCLffRwD7AYwxmcaYRVgFJF8i0gKoDfkOz1PuuWrU8F7WAexUMQurXJlnnnmGbdu2cffdd3vdfPEBEGUMPb/4gqTLLmPbzJnOBVUlLpCFowGwz2M5xW7zNA4YJSIpwGxgrB/HHwF8aQoYM0VE7hORRBFJTE9P9+OwZUOQT+EI9hkhV6niUq9ePT766CNWrFhB+/btuQPo7bG+VUYGTYYNI6FTJzJ9LqGq8snpzvGRwCRjTENgADBFRIqaaQQwraCVxpgPjTHxxpj4qHJ4/T/E5zOF6KUqFWDx8fEsX76c20eMwPf8NhjovWIFRxs0YOULLzgRT5WgQBaOVKCRx3JDu83TGGA6gDFmKRAG1LrYgUWkDRBsjFlVPFHLntDatb2Xz+Q3GpFSxSs4OJh+06ZxavlyltWrd8H6Rrm5XP2Xv7AkOppDa9c6kFCVhEAWjpVAcxFpLCIhWGcIs3y22Qv0BRCRlliFoyjXlUZSyNlGRVClYUOv5TpZWdZsgEqVgPodO9J5/36WPfMM+4N8x92Frvv2Edq+PUt8ZqdU5UPACocxJhd4GJgLbMa6eypJRF4QkZvszZ4A7hWRdViFYPS5PgsR2Y01odloEUnxuSPrFip44bi8Xz+v8YZqu92kLlniWB5VMXV+9VWq791LQrt25PmsizSGru+8w+KYGI7rrbvlis7HUYati4igjcd4VUsefpiu777rYCJVkW36/HO47z5i8+lvO+Bysf/VV+mgs1OWKTofRzl0rGVLr+WzCxY4lEQpiL3tNlocPUpCPvN/1HO7+fAPf+DRRx/l9On8hlZUZYkWjjKs8jXXeC1HJSc7lEQpS3BoKL2/+469X33F1rCw8+3/AT4E3n77bTp06MDq1asdy6h+PS0cZViT227zWm6elcVpHexQlQLNhwwh5tAhEjp14iBwj8e6zZs306lTJ1555RVy9anzMkkLRxkWFRfHvMqV+RcwGogDEpYtczaUUrbQ8HB6L1vGztmzqRwT47UuNzeX5557jj49e5K6cqUzAdUl08JRxk297TbuByYD24BPp0xxOJFS3rrecAPr1q3j7rvvvmDdDUuXEtapE4mvvOJAMnWptHCUcaNGjfJa/uabbzh+/LhDaZTKX3h4OB999BFff/01tWpZz/jeBPwRqGkM7Z97joQ+fXTAxDJCC0cZ16NHD2I8LgNkZ2czffp05wIpVYjBgwezceNGbr/mGiZ7tLuA3vPmsap+fY5u3+5UPFVEWjjKOJfLxR133OHVNnny5AK2Vsp5derUYdKPP7L2uusueGjw6vR0slq2ZNOnnzqSTRWNFo5ywLdwrFqyhB16u6MqxVzBwfSeO5d1r79Ousdw7QAN8/JoeuedLBg1SofRKaW0cJQDTZs2pUf37nTGmifhILDv4YcdTqXUxbV/6ilyly/3mq4WIBTo+fnnLG7RgqzDh50JpwqkhaOc+L+WLVkK/A6IBNotXarjA6kyod7VV3PFgQPMb9PmgnXdd+xgb3Q0B/SW3VJFC0c5ET9uHEc9TvkjgLW33+5cIKX8EFKtGr3WrmXJ2LFk+Ky78vRp6NyZrXrTR6mhhaOcqF6/Puuvu86rrcPixRzZutWhREr5r+s773Dw22/ZERLi1V7P7ab+8OGsfPFFh5IpT1o4ypH4SZO8OhqrAxv0rEOVMc1uuonau3axvG5dr/aqwKvjxvGvf/3LmWDqPC0c5Ui1unVJGjjQq63jypWkb9zoUCKlLk31+vWJ37PHq9/jceBrt5v777+fP/zhD7j1jivHaOEoZzp+8gmHXP/7a60CbPK5XVepsiAoJIRea9cyf8gQ3gbe9lj3+uuvM2LECB2i3SFaOMqZKrVqsWXIEK+2TmvWsE/n6lBlVK+vviLmm2+oXLmyV/uMGTPo27cv6elFmW1aFadCC4eINBGRj0XkJRGpJiITRGSjiMwQkZiSiaj81WniRK95oMOAg0OH6sNUqswaNGgQ8+fPp06dOl7tS5cu5dMrr2T/8uUOJauYLnbGMQlYCWQAy4AtwA3AD8DHAU2mLllYZCQ7fC5PXZ2ezrKnnnIokVK/3tVXX82yZcto6THz5evAE0ePktu9OymLFjkXroIpdM5xEVljjGlnv99rjInOb11pV17nHC+MOzeXDTVres1JftDlovKuXURERxeyp1Kl2/Hjx7n5t7+lz7x5POfRnhoURO7cuVzet69j2cqbS51z3C0iLUTkaqCKiMTbB2sGBBW+q3KSKziYqlOmkOPRVtftZt311zuWSaniEBkZyZzvv6dPgwZe7Q3y8gi57jp2zpnjULKK42KF42ngO+BTYDDwRxFJBpYAzwc4m/qVmt10E0u6dvVqy9qyhZ++/96hREoVj5DKlbk6OZnFPmfP9dxuqt14IztmzXIoWcVQ6KWqfHcQqQUcM8b4johcalXES1XnnD56lAP16lEzJ4fHsTqmGjVqxMaNGwkPD3c6nlK/Sl5ODktiY+mxY4dX+2ERjn75JS2GDXMoWflwqZeqPA8QJyK3AAOA20REHw4oAyrXqEHGRx/RWuT83Qz79u1j7Nix+PulQanSJigkhG5btrDgiiu82msZQ63hw9n8+ecOJSvfilQ4ROQvwLv26xqsmxluCmAuVYxajxrFLU884dX26aefMnHiRIcSKVV8XMHBdN+4kflxcV7tNYyh/qhRbJs506Fk5VdRzziGAn2Bg8aYu4A2WAOwFkpE+ovIVhFJFpFn8lkfLSLzRGSNiKwXkQF2e027PUNExvvsEyIiH4rINhHZIiI3F/EzVGgvvPCC122MAA8//DCrVq1yKJFSxccVHEzPdetIaOd9o2cEED58OCmLFzsTrJwqauE4bYxxA7kiEg6kAY0K20FEgoD3sJ77iAVGikisz2Z/Aqbbt/WOAN6327OxOt+fzOfQzwFpxpgW9nHnF/EzVGiVK1dm5syZVK1a9XxbTk4OU/v355jP9WGlyiJxueiVmEhCp05e7XXdbnL69OHItm0OJSt/ilo4EkUkEpgArAJWA0svsk9HINkYs9MYkwN8AQzy2cYA53poI4D9AMaYTGPMIqwC4utu4FV7O7cxRqcHK6LY2FgmTJgAQGWspzv/fvgwyV264M7NdTKaUsVCXC56LVnC/LZtvdqb5OSwv0MHMo8edShZ+VKkwmGMedAYc9wY8wFwLXCnfcmqMA2AfR7LKXabp3HAKBFJAWYDYws7oF28AF4UkdX20Cd1CttHeRs5ciTPjh7NUuBOu+3q9HQW9O/vZCylio24XPRYuZIljbwvinyWkcHw228nV78k/Wr+3FXVWkRuAtoDzUTkt8Xw+48EJhljGmLdrTVFRArLFAw0BJYYY9pjnfX8rYC894lIoogk6iBo3v7y7ru4fOZ47vnLL6x67TWHEilVvFzBwXTYuJHVkZHkYn1Jeh34fvZsfve73+kdhb9SUe+q+hjrEYCbgd/Yrxsvslsq3v0gDe02T2OA6QDGmKVY4/HVKuSYR4As4Ct7eQZWIbuAMeZDY0y8MSY+KirqIlErlpBq1aj5888c9pj0yQXEPPssu3/6yblgShWj0PBwmq5fz/1Nm/KpR/vHH3/M88/r88u/RlHPODrbP4TvNMbcZb/uvsg+K4HmItJYREKwOr99H+fci3W3FiLSEqtwFHh6YKyvCd8Bve2mvsCmIn4G5aF+p07sfe01PMfLrWkMrgEDSFu/3rFcShWniEaNeHHhQmJiYrzaX375ZZ1J8FcoauFYms8dUYUyxuQCDwNzgc1Yd08licgL9iUvgCeAe0VkHTANGG0XB0RkN/AmMFpEUjx+/z8A40RkPXC7fQx1Cdo//TQL+vXzaovOzeVI586c2r/foVRKFa969eoxd+5catXyvpgxduxYVi5c6FCqsq1IQ46ISC+ss4WDwBlAsE4AWgc2XvGoyEOOXIxxu1ncvDndd+70al9Vowat9uwhxKcvRKmyavny5fTp04esrCzA+sY5NiiIaklJ1PR58lxZfu2QIx9hfbvvz//6N35TfPGUU8TlotOGDaz0+TbW4ehRVsbF6W26qtzo1KkTkydPJhyYiXVXzeV5eezq1o28nJyL7K08FbVwpBtjZhljdhlj9px7BTSZKjGVqlSh5YYNJHk8HAjQbc8eFnTu7FAqpYrf0KFDmdqtG57DTcQfOcLC665zLFNZVNTCsUZEporISBH57blXQJOpElWtbl3qrFzJrkqVvNp7r1pFwm/05FKVH9f9+CPrq1f3aus5fz4rX3jBoURlT1ELR2Wsvo3rKPrtuKqMqdWyJcE//8whl/c/izb/+Q9T3nnHoVRKFa9KVapQOyGBdJ/b0ZuOG6djWhVRUZ8cvyuf18Vux1VlUKOePTn22Wecm3D2FNZgY3c88ggffPCBg8mUKj5127cn9e9/x3NSoRrGcPK668jJyHAsV1kRXJSNRCS/r5sngERjzLfFG0k57cqRI1mdkkLM009zE7Dcbn/ggQfIycnh97//vZPxlCoWbR97jISffqK3x1SzsVlZJAwYQO8FCxxMVvoV9VJVGNAW2G6/WmM9CT5GRP4RoGzKQe2feopln3/OCp8+j0ceeYQ33njDoVRKFa9e//kPy+vW9WrrvnChTgB1EUUtHK2Ba4wx7xpj3gX6AVcCQ7D6PVQ5NODWW/nmm28IDQ31an/66ad59f/+z6FUShUfcbm4YvFiDnr06wUDrnvu0UtWhShq4bgM8HwSrCpQw553/Eyxp1KlxoABA/juu++oXLny+bYqQPdx40jo2RPjdhe8s1JlQGSTJux99lmvtiuys1midxMWqKiF43VgrYh8IiKTgDXAGyJSFfg5UOFU6XDttdcye/ZsqlatShjWEAI9gN4LFzK/a1ctHqrM6/jiiyxq3NirrUtCAjs9+j/U/xRpyBEAEamHNTkTwEpjTJkZzEiHHCkeixcv5lDv3vzW52nyBbGxdF21iuCwMIeSKfXrHduxg7MtWlDb44vQ6ssuo93hw4iryDNQlCuXNOSIiFxp/9oeqIc1MdM+oK7dpiqQbt260eKDDzjh095z0ybWREeTcfCgI7mUKg6XNW1K8oMPnl8+BUw+dozPpkxxLlQpVegZh4h8aIy5T0TmeTSf38EY0yeQ4YqLnnEUr82ffUbdO+7gMp9/O5srV+ayRYuo216/U6iyybjdrI6KYvfRozyCNYFQ3bp12blzp1c/X0VxSWccxpj77Lf/BAYZY64B5mE9w/FksadUZULLUaM4/O9/kxoU5N1++jTujh3Z9u9/O5RMqV9HXC4uW7CAUWFh52edO3jwIP/85z8dzVXaFPXC3Z+MMSdFpDvQB5iIVUxUBdV8yBCCVqxgs8+3sPp5edQdOpRVr77qUDKlfp0mV111wUOur732GpmZmQ4lKn2KWjjOPZk/EJhgjPkeCAlMJFVW1G3fnkY7d7Kidm2v9nCgzbPPsuCOO5wJptSv9NRTT1HNYy6a9BMzqHIAABs5SURBVPR0xo8f72Ci0qWohSNVRP4FDAdmi0ioH/uqcqxa3bp02LeP+a1aebUHAz2nTCGhSxed00OVObVq1eKRRx7xanv9r3/l5JEjDiUqXYr6w/8WrClgrzfGHAdqAE8FLJUqU4JCQui5di3zBw/G94mO3suW8UVcHMePH3ckm1KX6vHHHyc8PBywZrD74dgxVt9yi7OhSomijo6bZYz5yhiz3V4+YIz5MbDRVFkiLhe9vv6aFU8/TZZHewrw6NatxMfHs3btWqfiKeW3GjVq8NKdd7IYmANcDbT77385sUfnsNPLTapYdf7rX9n18ceki5ADDAXSgR07dtClSxcmTZrkbECl/HDHk0/S0mPejghgzUMPOReolNDCoYrdVXfdRc7ixfyladPzQ7IDZGdnc9ddd3HfffeRnZ3tWD6liioiOpp1fft6tTX4+ecKP8yOFg4VEA26dGFcUhIPPPDABesmTJjAg23asE/nPFBlwFVvvYXn7R3Nz5xhy7RpjuUpDbRwqIAJDQ3l/fff59NPP/V66rYR8Pq2bVTr3ZuVOjy7KuWi4uJY7XPLeVoFn5NGC4cKuNtvv51ly5bRrFkzQoAZQC3gMmO4etw4Enr0IFcvXalSLO+227yW49avr9DzdWjhUCWidevWJCYm8lbbtnTyWdd70SK21KrF7p9+ciSbUhfT7s9/5rhHJ3lNY1jz8ssOJnKWFg5VYiIiInhg1SoSBgw4PxTBOXGZmURddx3zb7utwnc8qtInLDKS9bGxXm1m8mSH0jgvoIVDRPqLyFYRSRaRZ/JZHy0i80RkjYisF5EBdntNuz1DRMb77JNgH3Ot/arte1xVeonLRe/vv2fDW2+R5jPHQVWg19SprKxbl0P6zIcqZWo89pjXcpsDBziblVXA1uVbwAqHiAQB7wE3ALHASBGJ9dnsT8B0Y0w7YATwvt2eDTxPwSPw3maMaWu/0oo/vQq0to8+iqxfz/K6dS9Y1zE9neD27Vn6lA5OoEqPq+66iwMeX3YqA9tnznQukIMCecbREUg2xuw0xuQAXwCDfLYxWGPigfVszX4AY0ymMWYRVgFR5VTUVVfRMTWVhaNHc8pnXU1j6PK3v7GwWTNO7N3rSD6lPInLxe569bza0mfNciiNswJZOBpgzRZ4Tord5mkcMEpEUoDZwNgiHvsT+zLV8yIePVYeROQ+EUkUkcT09HQ/o6uSIi4XPT75hGPz5rEuPPyC9T127OBkkyasfecdB9Ip5S2nXTuv5UorVzqUxFlOd46PBCYZYxoCA4ApInKxTLcZY1oBPezX7fltZIz50BgTb4yJj4qKKtbQqvhF9+5NXHo6Cf37k+OzrlFeHuMfeYQHH3xQB0tUjqoxcKDXcnRqagFblm+BLBypWM96ndPQbvM0BpgOYIxZCoRh3eJfIGNMqv3rKWAq1iUxVQ4EhYTQe84cdn3xBdtDQ8+3zwI+Av75z3/SsmVLpk+fTmFTHisVKM1HjCAH2IN17f2NvDwOVMDiEcjCsRJoLiKNRSQEq/Pb94LgXqAvgIi0xCocBV5XEpFgEallv68E3AhsDEB25aArhg+n0cGDJHTowEHgXo91Bw8eZPjw4QwcOJBdu3Y5FVFVUGGRkfymfXtisC6XvAMsr4CXqwJWOIwxucDDWPN4bMa6eypJRF4QkZvszZ4A7hWRdcA0YLSxv0qKyG7gTWC0iKTYd2SFAnNFZD2wFusMZkKgPoNyTlhkJL0TE0n+7jvCmzW7YP2cOXO4JjaWeTfeWGFviVTOiG7f3mv54MGDDiVxTnAgD26MmY3V6e3Z9meP95uAbgXsG1PAYTsUVz5V+nW/8UY29OvHK6+8wmuvvcbZs2fPr3s5O5trvv+ebTVrkvPuu8Tdc4+DSVVFERkZ6bVcEfvdnO4cV+qiwsLCeOGFF1i3bh09evQAoB9wbvSgFtnZxN57Lwvi4nSSHRVwERERXssnTpxwKIlztHCoMqNly5YkJCTw0cSJvBYU5LXOBfRMSuJMkyYsvOsunedcBYwWDi0cqoxxuVzcPWYMl69fz+ImTS5YX9vtpsekSWwND2fd+PH5HEGpX8f3UtUJvVSlVNlQKzaWbjt2sOaNN9hdqdIF61uePk2bsWNZ2qiRThililXj1FQ2YN0SegJ45JdfHE5U8rRwqDKt3ZNPUjctjYSePTmdz/ouKSlE9epFQseO2v+hioXs20cc1kNq4YDb57JpRaCFQ5V5YZGR9J4/nyOLFrGkUaML1wO9V64kr3Fj5t52Gzk5vs+mK1V0Z7dv91rO9hm/qiLQwqHKjYbdutF1717Wv/8+m6pUuWB9DWOYPHWqPn2ufhXXvn1eyxIT40gOJ2nhUOVO6wce4MoTJ1h0zz1ew2AnYg0TsXPnToYPH0779u359ttvtYAov1RN857JIezKKx1K4hwtHKpccgUH033CBCIOHSKhXz9OYU3u4lki1q5dy+DBg+nQoQP/fe89nXlQFUmNU96TAFzmM2JuRaCFQ5VrVWrVovdPP5G9bRtXPfggQfl0ZKasWUPnhx9mS7VqLH/uOS0gqkDHd+2iocfoBQB1Ola8cVa1cKgKIap5c9577z2SkpIYNmyY17qngSpYt/B2euUVtlSrxornn9cCoi6w4cUX8bz5e1elSkRERzuWxylaOFSFcsUVVzB9+nTWr1/P0KFDqQ086LNNy9On6fjSS2yuXp0Vf/6zFhB1XmWfGf/2dO7sUBJnaeFQFVKrVq2YMWMG83/4gXUNfCemtMRmZdHxxRfZXL06S8aO1VF4K7gjW7fS9sgRr7aGTzzhUBpnaeFQFdqV119Pl5QUtk2fzrL69fPdJjYri67jx5MWHk7CjTfqg4QVVNKLL3oNJ749NJRmgwY5lsdJWjiUAloMG0bn1FS2fvklywp4oKtBXh69v/8eV0wM89u106FMKpCcjAwazJjh1ZbaLd8ZISoELRxKebjillvovH8/W7/4osACUh3otXYtb/TuzbBhw1i6dGnJhlQlbsnw4TT1GXHg8qefdiiN87RwKJWPK4YPp/P+/eycPZsFsbH49m4cBz42hpkzZ9K1a1e6dOnCjBkzyNXh3Mud1NRUJv3yC4c82ha2aEHj6693LJPTtHAoVYgmN9xAz6QkTm/Zwry+fTlkP4n+LyDTY7tly5Zxyy23EBMTw5RbbyVl0SJH8qri99RTTzH5zBmuAP4BpIvQ8ptvnI7lKC0cShVBzSuu4Jqffyby2DEWjhnDzwUMM3E4NZUB06ZRv0cPEmvVYunjj5OTkVHCaVVxmT17NtOmTQOsIdQfA77529+o1bKlo7mcpoVDKT+EhofTY+JEfty0iZ9++okbbrjBa/1goCbWf6z4I0fo8tZbnAwPJyE+nh3/+Y8TkdUlWr9+PSNGjPBqa9u2LXc/8ohDiUoPLRxKXQIRoV+/fsyePZukpCTuvfdeqlSpwj35bFvLGHqvWkXT3/yG9eHhLLr3XrIOHy7xzKro9uzYwcCBAznlMS6ViPDee+/lO2xNRaOFQ6lfKTY2lg8//JAD+/dT6fbbSapatcBtW586RfeJEzkbFcXCFi1IfPllfbCwlNm/fDk5LVsSl5Li1f7mm2/StWtXh1KVLlo4lCom4RER9Pr0U67KyGDrl18yv1Urjovku20E0GP7duL/9CdOVqvGgpYtWTBrFnl5eSUbWnnZNnMmZ7t3p/nZs3wD3Gi3P/TQQzyil6jOk4owF0F8fLxJTEx0OoaqgE4fPcrq556j6rRptD1xosDt0oD6QK06dRg6dCjDhw+nW7duuFz63a4kGLebhaNG0XHaNMI82nOA/+vbl//74QeCg4ML2r3cEpFVxpj4C9q1cChVMnbNncueP/+Zq1auJMrn/937wEM+2zdo0IBhw4ZxR9eutBkyBFcF/MFVEk7s3cumbt3o4nNpCmBpgwbEb99OpcqVHUjmvIIKR0C/zohIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jI+AKOPUtENgYyv1LFqfH119N7+XIiMzJIfOklFjZvfv5S1pf5bJ+amsqH//gHLW65hSMhISxq2pQlY8dy1GfOa3XpNk6cyPGmTfMtGgtbtCB+27YKWzQKE7AzDhEJArYB1wIpwEpgpDFmk8c2HwJrjDH/FJFYYLYxJkZEqgLtgDggzhjzsM+xfwsMBVobY+IulkXPOFRplZORwdq//533tm/n61mzvO7iARgGTPfZJw/YVK0aRzp2pPadd3Llrbfq2Yifts2cydHf/57OBw5csO4UsP7BB+n23nslH6yUceKMoyOQbIzZaYzJwZru2XcoSQOE2+8jgP0AxphMY8wiINv3oCJSDXgceClQwZUqKSHVqtHxL39h8mefkZaWxjfffMPIkSOpat+ZNTyffYKAVhkZ9P7vf4m98049G/HDztmzWRIdbQ1qmU/R2FK5Mkd+/FGLxkUEsnA0APZ5LKfYbZ7GAaNEJAWYDYwtwnFfBP4OFwwfpFSZFhYWxqBBg5g6dSppaWnMnDGDmjExFNylbokyhu47d9J1/HhqtGhBclgYC1u25Ks33mDHjh1UhH7MwhhjWLFiBf+Ji+PygQPpum9fvtvNb9WKmP37ibn22hJOWPY4fcvGSGCSMaYhMACYIiIFZhKRtkBTY8zXFzuwiNwnIokikpienl58iZUqAVWqVOHmoUPpvWsXVTIzWffOOyR07szWsLCL7tvszBl6bNnCk08/TbNmzahXrx4333wzb775JsuXLyfHZ5TX8mrTpk08//zzNG/enE6dOrEmKYn8Ht3bWLUqq//6V3qtX09YZGSJ5yyLAtnH0QUYZ4y53l7+I4Ax5lWPbZKA/saYffbyTqCzMSbNXh4NxJ/r4xCRB4Dnse6SCwZqA0uMMb0Ly6J9HKo8OZCYSPL48QT//DOxqalE5LcN1u29+XkxOJgbq1blePPmBLdtS81evYgZMIDKNWoEMHXgGbebPb/8wtdLljD5669Zt26d1/orgc0ey1sqV+bkk09y9bhxiN72nK8Svx1XRIKxOsf7AqlYneO3GmOSPLaZA3xpjJkkIi2BX4AGxg7lWzh8jh8D/Ec7x1VFdjYri6QJEzg+bRp116+nxenTuICZWB3r+VkA9PBpywP2VqrEoagosps1I7RDB+r060d0nz4EF+EsxwmZaWlsnzaN43PmUHndOpocOkSUMTwAfFDAPmuAaqGhpI8dS6dXX9WbCi7Ckec47Ntr/4HVn/exMeZlEXkBSDTGzLLvpJoAVMPqKH/aGPOjve9urI7zEKzpD67zuSMrBi0cSnk5sXcv26dMYU1yMtP27GH58uVkeQxpEoI1ymtRS0E2sDcsjGMREZxs0IB1I0dy+eWXEx0dTYMGDahTpw6VKlUKwCexuHNzObxpE2krV3IqKYkz27bh2rWLqF27aH76NPn92F8A9PJpCwkJYeDAgfyub1/63XsvQSEhActcnugDgFo4VAV09uxZ1q1bx+LFi1m8eDFZ8+bxn0scYDEJ6/54TyJCVFQU/zp7lkYinA0NJTcsDHdYGO4qVaBKFahaFalenaDwcFzVq0NuLnkZGbhPnyYzKIg1sbFkZ2eTnZ3N6dOnycjIICUlhXcXLqRxTk6Ri5ynaCDV5aJv376MHDmSIUOGEKn9F37TwqGFQymM203qkiXsnT6dnNWrqbxjB3UPH+byIsxcOBsYWMC6ZKDpJeTZALQuYN0mwN9ZLzKA7ZGRbL3nHno/8QR169a9hFTqnIIKh17gU6oCEZeLht2707B7d6/2jIMH2TNnDkcXLCBv/Xqq795Nw+PHqeN2n99mTyHHzX929osr7GxiLxcvHLsrVSKlUSPcHTtSZ/Bgmg4aRLuwMNpdYh5VNFo4lFJUq1uXq+66C+66y6v9yNatHFi0iJMbN1I9N5eHjGH37t2kpKRw4MAB0tLSiACqXOLvW1jhOFeoTgAHw8I4ER7O6Tp1MA0bUqVDB5rceisxLVsSc4m/t7p0eqlKKXXJzp49y6GUFE4kJJC1bx+5J06Qd/IkeadOYU6dgsxMyMjAdfo0ruxsgs6cwbhc5IWEYEJDya5WjYS+fQkLCyMsLIzKlSsTFhZGvXr1aFK9Og0aNyYiOtrpj1lh6aUqpVSxq1SpEg0bN6Zh48aXfIzrijGPKhn61ItSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyS0ALh4j0F5GtIpIsIs/ksz5aROaJyBoRWS8iA+z2mnZ7hoiM99nnBxFZJyJJIvKBiAQF8jMopZTyFrDCYf9Afw+4AYgFRopIrM9mfwKmG2PaASOA9+32bOB54Ml8Dn2LMaYNEAdEAcMCEF8ppVQBAnnG0RFINsbsNMbkAF8Ag3y2MUC4/T4C2A9gjMk0xizCKiDeOxhz0n4bDITYx1BKKVVCAlk4GgD7PJZT7DZP44BRIpICzAbGFuXAIjIXSANOATML2OY+EUkUkcT09HQ/oyullCqI053jI4FJxpiGwABgiohcNJMx5nqgHhAK9Clgmw+NMfHGmPioqKjizKyUUhVaIAtHKtDIY7mh3eZpDDAdwBizFAgDahXl4MaYbOBbLrz8pZRSKoACWThWAs1FpLGIhGB1fs/y2WYv0BdARFpiFY4CryuJSDURqWe/DwYGAlsCkF0ppVQBggN1YGNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOrlHG2MMgIjsxuo4DxGRwcB1wBFgloiEYhW9ecAHgfoMSimlLiT2z+lyLT4+3iQmJjodQymlyhQRWWWMifdtd7pzXCmlVBmjhUMppZRftHAopZTyS4Xo4xCRdGCP0zkKUAs47HQIP2jewCtrmTVvYDmZ93JjzAUPwlWIwlGaiUhifp1PpZXmDbyyllnzBlZpzKuXqpRSSvlFC4dSSim/aOFw3odOB/CT5g28spZZ8wZWqcurfRxKKaX8omccSiml/KKFQymllF+0cBSzIsyz/riIbLLnWP9FRC73WJcnImvt1yyPdhGRl0Vkm4hsFpHfl/K8Cz3a94vIN6U8b18RWW23LxKRZqU8bx8770YRmWyPFF0a8kaLyI/2v9FNIhJjtzcWkeX2Mb+0R8suzXkfto9nRKRI0zw4nPdz+5gbReRjEalUnJnzZYzRVzG9sEYB3gE0wZrWdh0Q67PNNUAV+/0DwJce6zIKOO5dwKeAy16uXZrz+uz/b+CO0pwX2Aa0tN8/iDW5WKnMi/Vlbx/Qwl5+ARhTSvImANfa76t5bDcdGGG//wB4oJTnbQfEALuBWsWRNcB5BwBiv6YV159vYS894yheF51n3RgzzxiTZS8uw5rg6mIeAF4wxrjtY6SV8rwAiEg41gyNxXXGEai8BmsIf4AIYH8pzlsTyDHGbLOXfwJudjqviMQCwcaYn+ztMowxWSIiWP8Gzk3xPBkYXFrz2u/XGGN2F1PGksg729iAFfjxf/RSaeEoXkWZZ93TGGCOx3KYWPOkLxNrDpJzmgLD7XVzRKR5Kc97zmDgF2PMyV8fFQhc3nuA2SKSAtwOvFaK8x4GgkXk3JPEQ/GeadOpvC2A4yLylYisEZE3RCQIq9AdN8bkFvGYTucNpIDmtS9R3Q78UIyZ8xWwiZxU4URkFBAP9PJovtwYkyoiTYD/isgGY8wOrLnVs40x8SLyW+BjoEcpznvOSGBiSeY8x8+8jwEDjDHLReQp4E2sYlIq84rICOAtsSY0+xHIK8msBeQNxvo32Q5rZs8vgdFY0zs7zo+8HzmRz9cl5n0fWGCMWRjofHrGUbyKMs86ItIPeA64yRhz5ly7MSbV/nUn1vXMdvaqFOAr+/3XQOtSnhe7U7Ej8H0xZQ1IXhGJAtoYY5bbm30JdC2tee3lpcaYHsaYjsACrD4ap/OmAGvtyzC5WJcn22PN2hnp0YGf7zFLUd5AClheEfkLEAU8HqDs3gLdiVKRXljfCnYCjflf59dVPtu0w+oga+7TfhkQar+vBWzH7jjDunRyt/2+N7CyNOe12+4HJpf2P1/7mIf5X2fzGODfpTWvvVzb/jUU+AXoUwryBtnbR9nLnwAP2e9n4N05/mBpzuuxzW6Kt3M8UH++9wBLgMrFlfWin6WkfqOK8sK6w2Gb/Zf/nN32Ata3B4CfgUPAWvs1y27vCmyw/3FswONOGSAS65v7BmAp1jfkUpvXXp8A9C8jf75DPNYlAE1Ked43gM3AVuDR0vDna6+7Flhv550EhNjtTbA6bZOxikhoKc/7e6xv+LlYN0pMLOV5c+3jndvnz8X9/873pUOOKKWU8ov2cSillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VCqECLSUES+FZHtIrJDRN4uztFdlSqLtHAoVQB7gL6vgG+MMc2xxguqBrzsaDClHKaFQ6mC9cEaI+wTAGNMHta4VneLyIMi8o2I/CQiu+05HB63B6BbJiI1AESkqYj8ICKrxJqn5EqP9mUiskFEXhKRDLu9mj0Pw2p73aACsiEiMSKyRUQmiTVXy+ci0k9EFttnSB0D/iekKiQtHEoV7CpglWeDsUb63Ys1fEQc8FvgaqyzkCxjTDusp/vvsHf5EBhrjOkAPIk1EB3A28DbxphWWE8pn5MNDDHGtMeam+Hv9plPQZoBfweutF+3At3t3+vZS/jMSl2Ujo6r1KWbZ4w5BZwSkRPAd3b7BqC1iFTDGjpkhsfP/lD71y78b16KqcDf7PcCvCIiPQE31rDbdYCDBWTYZYzZACAiSVjD2BsR2YA1GZFSxU4Lh1IF24Q138V59uRU0VjjA53xWOX2WHZj/d9yYc1F0daP3/M2rFFOOxhjzorIbiCskO0vlkGpYqeXqpQq2C9AFRG5A8CeOOfvWAPMZRWyH3D+stYuERlm7y8i0sZevYz/zdw3wmO3CCDNLhrXAJcXxwdRqjhp4VCqAMYaAXQIMExEtmONapqNf30HtwFjRGQdkMT/pgp9FHhcRNZj9VOcsNs/B+LtS013AFt+9QdRqpjp6LhKOUBEqgCn7f6IEcBIY0yBd1ApVZroNVClnNEBGG/fMXUcuNvhPEoVmZ5xKFXKiUhNrP4WX32NMUdKOo9SWjiUUkr5RTvHlVJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX/4fiMNLKoYl9uIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light",
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# We can now plot contours obtained with this \n",
+    "plot_contours(F, params, fill=False,color='black',lw=4);\n",
+    "plot_contours(F_2, params, fill=False, color='red', lw=4, linestyle='dashed');\n",
+    "xlabel('Omega_m')\n",
+    "ylabel('sigma8');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "51gfhl9cIzMC"
+   },
+   "source": [
+    "The red dashed is our second derivation of the Fisher matrix using the jacobian, the black contour underneath is our first derivation simply taking the Hessian of the likelihood.\n",
+    "\n",
+    "They agree perfectly, and they should, because they are both analytically computed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "JrpDmbNfJUJ4"
+   },
+   "source": [
+    "## Conclusions and going further\n",
+    "\n",
+    "We have covered some of the most important points of `jax-cosmo`, feel free to \n",
+    "go through the [design document](https://github.com/DifferentiableUniverseInitiative/jax_cosmo/blob/master/design.md) for background and further explanations of how things work. You can also follow this [JAX document](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) to go deeper into JAX.\n",
+    "\n",
+    "\n",
+    "`jax-cosmo` is still very young and lacks many features, but hopefuly this notebook demonstrates the power of automatic differentiation, and given that the entire code is in simple Python, feel free to contribute missing features that would be necessary for your work ;-) "
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "include_colab_link": true,
+   "name": "jax-cosmo-intro.ipynb",
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "flowpm2",
+   "language": "python",
+   "name": "flowpm2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/docs/notebooks/jax-cosmo-intro.ipynb
+++ b/docs/notebooks/jax-cosmo-intro.ipynb
@@ -71,41 +71,10 @@
     "id": "yZWz-yxPcG6q",
     "outputId": "b315e257-1cb3-4654-c8ff-2b319ab27b13"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[?25l\r",
-      "\u001b[K     |█▌                              | 10kB 28.3MB/s eta 0:00:01\r",
-      "\u001b[K     |███                             | 20kB 3.0MB/s eta 0:00:01\r",
-      "\u001b[K     |████▍                           | 30kB 4.0MB/s eta 0:00:01\r",
-      "\u001b[K     |█████▉                          | 40kB 4.3MB/s eta 0:00:01\r",
-      "\u001b[K     |███████▎                        | 51kB 3.5MB/s eta 0:00:01\r",
-      "\u001b[K     |████████▊                       | 61kB 3.9MB/s eta 0:00:01\r",
-      "\u001b[K     |██████████▏                     | 71kB 4.3MB/s eta 0:00:01\r",
-      "\u001b[K     |███████████▋                    | 81kB 4.5MB/s eta 0:00:01\r",
-      "\u001b[K     |█████████████                   | 92kB 4.9MB/s eta 0:00:01\r",
-      "\u001b[K     |██████████████▌                 | 102kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |████████████████                | 112kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |█████████████████▌              | 122kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |███████████████████             | 133kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |████████████████████▍           | 143kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |█████████████████████▉          | 153kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |███████████████████████▎        | 163kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |████████████████████████▊       | 174kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |██████████████████████████▏     | 184kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |███████████████████████████▋    | 194kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |█████████████████████████████   | 204kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |██████████████████████████████▌ | 215kB 4.8MB/s eta 0:00:01\r",
-      "\u001b[K     |████████████████████████████████| 225kB 4.8MB/s \n",
-      "\u001b[?25h  Building wheel for jax-cosmo (setup.py) ... \u001b[?25l\u001b[?25hdone\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Installing jax-cosmo\n",
-    "!pip install --quiet jax-cosmo"
+    "#!pip install --quiet jax-cosmo"
    ]
   },
   {
@@ -122,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -162,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "cellView": "form",
     "colab": {},
@@ -225,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -239,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -253,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -270,7 +239,7 @@
        "0.6774"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -346,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -355,7 +324,7 @@
    "outputs": [],
    "source": [
     "# Not sure what are the units of the comoving distance? just ask:\n",
-    "jc.background.radial_comoving_distance?"
+    "#jc.background.radial_comoving_distance?"
    ]
   },
   {
@@ -377,7 +346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -393,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -430,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -447,7 +416,7 @@
        "DeviceArray(0.99999976, dtype=float32)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -499,7 +468,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as np\n",
+    "\n",
+    "#@jit\n",
+    "def mag_bias(z):\n",
+    "    #print(\"mag_bias\")\n",
+    "    return np.sqrt(1. + z)*10.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function __main__.mag_bias(z)>"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mag_bias"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -508,8 +511,40 @@
    "outputs": [],
    "source": [
     "# And now we define 2 probes \n",
-    "probes = [ jc.probes.WeakLensing(nzs, sigma_e=0.26), \n",
-    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.)) ]"
+    "probes_nomag = [ \n",
+    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.))  ]\n",
+    "\n",
+    "probes_mag = [ \n",
+    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=mag_bias)  ]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb = jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=mag_bias)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray(20., dtype=float32)"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mb.config[\"mag_bias\"](3.0)"
    ]
   },
   {
@@ -524,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 50,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -536,15 +571,25 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
+     "ename": "TypeError",
+     "evalue": "Argument '<function mag_bias at 0x7f8ca82aa1e0>' of type <class 'function'> is not a valid JAX type",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-50-3a8f13f67b17>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# And compute the data vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcls_nomag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobes_nomag\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mcls_mag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobes_mag\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mangular_cl\u001b[0;34m(cosmo, ell, probes, transfer_fn, nonlinear_fn)\u001b[0m\n\u001b[1;32m    102\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0msimps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mintegrand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz2a\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzmax\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mconst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc\u001b[0m \u001b[0;34m**\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    103\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 104\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mcl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    105\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36mbatched_fun\u001b[0;34m(*args)\u001b[0m\n\u001b[1;32m    856\u001b[0m     \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_mapped_axis_size\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0min_tree\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_axes_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"vmap\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    857\u001b[0m     out_flat = batching.batch(flat_fun, args_flat, in_axes_flat,\n\u001b[0;32m--> 858\u001b[0;31m                               lambda: flatten_axes(out_tree(), out_axes))\n\u001b[0m\u001b[1;32m    859\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mtree_unflatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mout_tree\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_flat\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    860\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/interpreters/batching.py\u001b[0m in \u001b[0;36mbatch\u001b[0;34m(fun, in_vals, in_dims, out_dim_dests)\u001b[0m\n\u001b[1;32m     32\u001b[0m   \u001b[0;31m# executes a batched version of `fun` following out_dim_dests\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m   \u001b[0mbatched_fun\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbatch_fun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfun\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_dims\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_dim_dests\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m   \u001b[0;32mreturn\u001b[0m \u001b[0mbatched_fun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall_wrapped\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0min_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m@\u001b[0m\u001b[0mlu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtransformation_with_aux\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/linear_util.py\u001b[0m in \u001b[0;36mcall_wrapped\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    148\u001b[0m     \u001b[0mgen\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    149\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 150\u001b[0;31m     \u001b[0mans\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    151\u001b[0m     \u001b[0;32mdel\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    152\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0mstack\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mcl\u001b[0;34m(ell)\u001b[0m\n\u001b[1;32m    100\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mT\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 102\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msimps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mintegrand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz2a\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzmax\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mconst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc\u001b[0m \u001b[0;34m**\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    103\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    104\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mcl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/scipy/integrate.py\u001b[0m in \u001b[0;36msimps\u001b[0;34m(f, a, b, N)\u001b[0m\n\u001b[1;32m    196\u001b[0m     \u001b[0mdx\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mb\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mN\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    197\u001b[0m     \u001b[0mx\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlinspace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mb\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mN\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 198\u001b[0;31m     \u001b[0my\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    199\u001b[0m     \u001b[0mS\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdx\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m3\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m4\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    200\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mS\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mintegrand\u001b[0;34m(a)\u001b[0m\n\u001b[1;32m     84\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     85\u001b[0m             \u001b[0;31m# Compute the kernels for all probes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 86\u001b[0;31m             \u001b[0mkernels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvstack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma2z\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mprobes\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     87\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[0;31m# Define an ordering for the blocks of the signal vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     84\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     85\u001b[0m             \u001b[0;31m# Compute the kernels for all probes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 86\u001b[0;31m             \u001b[0mkernels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvstack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma2z\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mprobes\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     87\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[0;31m# Define an ordering for the blocks of the signal vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/probes.py\u001b[0m in \u001b[0;36mkernel\u001b[0;34m(self, cosmo, z, ell)\u001b[0m\n\u001b[1;32m    290\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    291\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmag_bias\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 292\u001b[0;31m             \u001b[0mkernel\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mmag_kernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpzs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmag_bias\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    293\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    294\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mkernel\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36mf_jitted\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    151\u001b[0m       \u001b[0mdyn_args\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    152\u001b[0m     \u001b[0margs_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_tree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtree_flatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdyn_args\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 153\u001b[0;31m     \u001b[0;32mfor\u001b[0m \u001b[0marg\u001b[0m \u001b[0;32min\u001b[0m \u001b[0margs_flat\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0m_check_arg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    154\u001b[0m     \u001b[0mflat_fun\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_tree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mflatten_fun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_tree\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    155\u001b[0m     out = xla.xla_call(flat_fun, *args_flat, device=device, backend=backend,\n",
+      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36m_check_arg\u001b[0;34m(arg)\u001b[0m\n\u001b[1;32m   1681\u001b[0m   \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTracer\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0m_valid_jaxtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1682\u001b[0m     raise TypeError(\"Argument '{}' of type {} is not a valid JAX type\"\n\u001b[0;32m-> 1683\u001b[0;31m                     .format(arg, type(arg)))\n\u001b[0m\u001b[1;32m   1684\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1685\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0m_valid_jaxtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: Argument '<function mag_bias at 0x7f8ca82aa1e0>' of type <class 'function'> is not a valid JAX type"
      ]
     }
    ],
@@ -553,12 +598,13 @@
     "ell = np.logspace(1,3)\n",
     "\n",
     "# And compute the data vector\n",
-    "cls = jc.angular_cl.angular_cl(cosmo, ell, probes)"
+    "cls_nomag = jc.angular_cl.angular_cl(cosmo, ell, probes_nomag)\n",
+    "cls_mag = jc.angular_cl.angular_cl(cosmo, ell, probes_mag)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -568,21 +614,10 @@
     "id": "VSKlZxxARxYO",
     "outputId": "3d39a4d7-165e-428d-d2a8-d482353d2064"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(10, 50)"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Let's check the shape of these Cls\n",
-    "cls.shape"
+    "cls_mag[1]-cls_nomag[1]"
    ]
   },
   {
@@ -597,7 +632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -607,27 +642,22 @@
     "id": "-Xc458aidYL8",
     "outputId": "960b3f8d-8bb4-4018-f45d-869de305ca19"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEeCAYAAACdYvI/AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3zV9b3H8dcni5AAgZCwCXsKAhJmgrjFgQwVcTFEERneVju0t95qb1vb26tWBUVUQMGBTAWtVK2KhBmWbMPehBlmgITv/SOxjVxGTjjJ75yT9/PxyKM953fGO338mje/3+/7+37NOYeIiEhhhXkdQEREgouKQ0REfKLiEBERn6g4RETEJyoOERHxiYpDRER8ouIQERGfqDhERMQnKg4Rj5nZFjO7wescIoWl4hApwMy+MbNDZlbG6yxFZWblzexPZrbBzI6a2WYzG2lmiV5nk9Cg4hDJZ2Z1gS6AA+7wNMwlmFnEBZ6vCHwHNAVucc6VJ+93igTqlFxCCWUqDpF/6wcsAMYD/QtuyD+d9Asz+97MssxskplF52+7ysyW5f/rfnL+tj8UeK8zs4YFHo8vuP2c73nKzDbmf9YaM+t1ToZfm9n3wPELlMdLwEHgLudcBoBzbodz7lHnXHpR/4cRKUjFIfJv/YD38n9uNrOq52zvA3QD6gFXAgPMLAqYTl7ZxAMfAL0ouo3kHSHEAc8BE82seoHt9wK3ARWdczkF32hmtYEHgf90zp29jAwiF6XiEAHMLJW8UzkfOeeWkPcH/L5zXvaKc26Xc+4gMBNoDXQEIvK3nXHOTQMWFTWHc25y/necdc5NAjKA9udk2O6cO3met98A7HPOzS/q94sUhopDJE9/4B/Ouf35j9/nnNNVwJ4C//0EUA6oAex0P12fYHtRQ5hZPzNbbmaHzeww0AJIKORnVwW2XeLzh5rZvKLmE4G8fymJlGpmVpa801DhZvZjOZQBKppZK+fciou8fTdQ08ysQHnUJu+I5UcngJgCj6sBO86Tow7wJnA9MN85l2tmywEr8LKLLaCzLT9L2EVOVd0M6IhELouOOESgJ5ALNCfv9FNroBl5o5P6XeK98/PfO9zMIsysBz89tQSwHLjPzMLNrBvQ9QKfFUteMewDMLOB5B1xFNas/P/8s5lVyP+Mxmb2spkl5F+gz+Q8pSXiCxWHSN4pqXHOuW3OuT0//gAjgfsvNPQVwDl3GugNDAIOAw+Q9wf8VIGX/QfQPX/7/cCMC3zWGuAF8spoL9ASSCvsL+GcOwJcBzQGMvJPdU0HjuefgmtB3oX9twr7mSLnY1o6VsS/zGwhMNo5N87rLAWZWX/yrsu8rlFXcjl0xCFymcysq5lVyz9V1Z+8obqfe52rIDMzoC551zh+7m0aCXa6OC5y+ZoAH5F3jWITeTff7fY20k/lX7h/zuscEhp0qkpERHyiU1UiIuITFYeIiPikVFzjSEhIcHXr1vU6hohI0FiyZMl+59x5p+IvFcVRt25d0tM1MaiISGGZ2dYLbdOpKhER8YmKQ0REfKLiEBERn6g4RETEJyoOERHxSUgXh5l1N7MxWVlZXkcREQkZIV0czrmZzrnBcXFxRXr/dxn7WLDpANsPnuB0jiYTFRGBUnIfR1H918er2bz/OABmUKV8GWpWLEuNimWpVSmG+gmx1E+MpV5CLPGxUeRNQCoiEtpUHBcxdkA7dh46ya7DJ9mZ/7Pr8ElW7cxi9uo9nMn99wSRcWUjqZcQS4PEcjSrXp5m1SvQrHoF4mOjPPwNRET8T8VxEfUS8o4mzicn9yw7Dp1k8/7jbNx3jM37j7N5/3HmZOxj6tJ/r8xZtUKZf5VIq1oVuSqpIlUqRJfUryAi4ncqjiKKCA+jbkIsdRNiubZplZ9s23/sFGt3H8n/Ocra3UeYm7GfnLN5Ryg1K5alde2KtEmqSOvaFWlZK44yEeFe/BoiIj5TcRSDhHJl6NIokS6N/j0/WPaZXFbvOsKybYdYvv0wy7Yd5tOVeWv9lIkIo22dSnSsX5lODSrTqlZFoiJCetyCiASxUrGQU3JysgvESQ4zj2azbNthFm46yIJNB1i75wjOQXRkXpGkNEzgmsZVaFa9vC68i0iJMrMlzrnk825TcQSOwydOs3BzXonM33iAdXuOAnnXSbo2TuSaJlVIbZRAhehIj5OKSKhTcQRJcZwr80g23/ywj2/X72NOxj6OZucQHmYk16lEtxbVuPmKatSoWNbrmCISglQcQVocBeXknmXptsN8sz6TL9fu5Ye9xwBoVSuOm1tUo9sV1aifWM7jlCISKlQcIVAc59q47xizV+9h9qo9rNiRN6VKk6rluaN1De5oVYPa8TEeJxSRYKbiCMHiKGjn4ZP8Y/UePv1+N+lbDwGQXKcSPdrU5LaW1XUTooj4TMUR4sVR0PaDJ/hkxS5mLNtJRuYxIsKMro0TuTu5Ftc1raphviJSKCqOUlQcP3LOsXb3UT5evpMZy3ey98gpEspFcedVtejTrjYNdD1ERC5CxVEKi6Og3LOOOT/s48PF2/hqbSY5Zx3t68ZzT7va3NqyOmWjdNe6iPyUiqOUF0dBmUezmbZ0J5MWb2fz/uPElY2kb7vaPNCxji6oi8i/lNriMLPuQPeGDRs+kpGR4XWcgOKcY8Gmg0xYsIXZq/dy1jmub1qF/p3rktowQXeqi5RypbY4fqQjjovbnXWS9xZs44NF2zhw/DT1E2MZ2Lkud7WtrdNYIqWUikPFUSincnL59PvdvDNvCyt2ZFEpJpIHO9Wlf6c6VC5Xxut4IlKCVBwqDp8451i85RBj5mzky7WZlIkI4+7kWjycWp+6F1ifRERCy8WKQ9Oqy/9jZrSvF0/7evFsyDzKm3M289HiHby3cBu3tKjGsGsbckWNoq3jLiLBT0ccUiiZR7IZP28LE+Zv5eipHG5oVoUR1zWiVe2KXkcTkWKgU1UqDr/JOnmGd+Zt4e25m8k6eYaujRN5/PpGtK1TyetoIuJHKg4Vh98dzT7DhAVbeeu7zRw8fpqUhpV54sYmKhCREKHiUHEUmxOnc3hvwTbemLOR/cdOc33TKjx5UxOa16jgdTQRuQwqDhVHsTt+Kofx87bwxrcbOZKdw+1XVufnNzbWnFgiQUrFoeIoMVknz/DmnE2MTdtM9plc7ryqFj+/sbFWKhQJMioOFUeJ23/sFK99vZGJC7diwEOp9XjsmgZaL10kSKg4VBye2XHoBC/84wemL9tJpZhIHr++Efd3qKN1QUQC3MWKQ//vlWJVq1IML93TmlkjUmlWvQLPzVzDTS99y2crd1Ma/tEiEopUHFIiWtSM472HOzBuQDuiIsIY+t5S7ho9n5X566WLSPBQcUiJMTOubVqFzx7vwvO9W7L1wHHuGDWXX01ZQebRbK/jiUghqTikxEWEh3Fv+yT++YtreKRLfaYv28l1//stb3y7kVM5uV7HE5FLUHGIZypER/KbW5sx+2dX06FePM//fR03vzSHr9bu9TqaiFyEikM8Vz+xHG8PaMf4ge0IDzMGvZPOw+8sZvvBE15HE5HzUHFIwLimSRU+/9nV/ObWpszbeIAbXvyWV77KIPuMTl+JBBIVhwSUyPAwBl/dgK+e7MoNzary4hc/0O1vc/j2h31eRxORfCoOCUjV48oy6v6rePeh9oSZ0X/sIoZMWMLurJNeRxMp9VQcEtCubpzI33/WhV/e3ISv12dy44tzGJ+2mdyzunlQxCsqDgl4ZSLCGXZtQ774eVfaJFXk2Zlr6P36PNbsOuJ1NJFSScUhQSOpcgzvPtSel/u2ZuehE3QfOZfnP1vLidM5XkcTKVVUHBJUzIwerWvy5RNdubttLd6Ys4mbXprDHF08FykxKg4JShVjovjznVcyaXBHoiLC6Dd2Eb+YvIKsE2e8jiYS8oKuOMwsycxmmNlYM3vK6zzirQ71K/PZ410Ydm0Dpi/byQ0vfcvnq/Z4HUskpJVoceT/sc80s1XnPN/NzNab2YZClEFLYIpz7iGgTbGFlaARHRnOL29uysfDUkgsV4YhE5cw7L2l7Dt6yutoIiGpRBdyMrOrgWPAu865FvnPhQM/ADcCO4DFwL1AOPD8OR/xEJALTAEcMME5N+5S36uFnEqPM7lnGTNnEy9/mUHZqHCeu+MKerSugZl5HU0kqATUCoBmVheYVaA4OgHPOuduzn/8NIBz7tzS+PH9vwAWOefmmNkU59xdF3jdYGAwQFJSUtutW7f6+1eRALYh8xi/mrKCpdsOc1PzqvyxV0sSy5fxOpZI0Aj0FQBrAtsLPN6R/9yFfA48bmajgS0XepFzboxzLtk5l5yYmOiXoBI8GlYpx+QhnfnNrU355od93PTSt8xcscvrWCIhIcLrAL5yzq0CznuUIVJQeJgx+OoGXNe0Ck9O/p4RHyzj81V7+H2PK6hcTkcfIkUVCEccO4HaBR7Xyn9OxC8aVinP1CGd+FW3JnyxZi83vTSHz1ft9jqWSNAKhOJYDDQys3pmFgX0BT7xxwebWXczG5OVpXWtS7uI8DCGXtOQmSNSqV4xmiETl/LkRys4kq37PkR8VdLDcT8A5gNNzGyHmQ1yzuUAw4HZwFrgI+fcan98n3NupnNucFxcnD8+TkJAk2rlmT40hceva8j0ZTu45W/fsWDTAa9jiQSVEh9V5QUNx5XzWbrtEE9MWs7Wgyd4pEt9nrixMdGR4V7HEgkIgT6qSsQTVyVV4rP/6MJ97ZMYM2cTPUamacZdkUJQcUipFhMVwR97tWTcwHYcPHGanqPSeOu7TZzVeh8iF6TiEAGubVKF2T+7mq5NEvnDp2vpP24RmUeyvY4lEpBCujg0qkp8ER8bxZgH2/LHXi1YvOUgN/9tDl+s2et1LJGAE9LFoVFV4isz4/4OdZg1IpXqcWV55N10fjtjJSdP53odTSRghHRxiBRVwyrlmT6sM4Ovrs/EBdvoPnIu6/bowrkIqDhELqhMRDi/ubUZEwa1J+vkGXqMTGPigq2UhiHsIhej4hC5hC6NEvn7f3ShQ/3K/HbGKoa+t5Ssk7rjXEqvkC4OXRwXf0koV4bxA9rx9C1N+WLNXm59+TuWbjvkdSwRT4R0cejiuPhTWJjxaNcGTB7SCTO4e/R8Xv9mo+75kFInpItDpDi0SarEp493odsV1fjL5+sYOH4xB4+f9jqWSIlRcYgUQVzZSEbe14b/7tmC+RsPcNsr37Fk60GvY4mUCBWHSBGZGQ92rMO0oZ2JDA/jnjcW8NZ3mzTqSkKeikPkMrWoGcfMEalc36wKf/h0LYMnLCHrhEZdSehScYj4QVzZSEY/0JZnbm/O1+syue3V71i5Q6P5JDSFdHFoOK6UJDNjUGo9Jg/phHNw5+vz+HDRNq9jifhdSBeHhuOKF9okVWLmiFQ61I/nqWkr+dWUFWSf0VxXEjpCujhEvBIfG8X4ge0ZcV1DPkrfwV2j57H94AmvY4n4hYpDpJiEhxlP3tSEt/ols/XACW5/dS5fr8/0OpbIZVNxiBSzG5pXZdaIVGpULMtD4xfz8pcZuttcgpqKQ6QE1Kkcy7THOtOrTU1e+vIHHp24hKPZGrIrwUnFIVJCykaF88Ldrfhd9+b8c10mPUelsXHfMa9jifhMxSFSgsyMgSn1mDioA4dOnKHnyDS+1PK0EmRCujh0H4cEqk4NKjNzRCp1EmJ4+N10XfeQoBLSxaH7OCSQ1axYlilDOtO7wHWPY6dyvI4lckkhXRwigS46MpwX+rTiv27Pu+7R+7U0th3Q/R4S2FQcIh4zMx5Krcc7A9uz98gp7hg1l3kb93sdS+SCVBwiASK1UQIfD0shoVwZHnx7ERPmb9EU7RKQVBwiAaRuQizTh3ama+NEnvl4Nf85YxWnc856HUvkJ1QcIgGmfHQkb/ZL5rFrGvD+wm088PZCLU0rAUXFIRKAwsOMX3dryst9W7N8+2F6jJpLxt6jXscSAVQcIgGtR+uaTBrckZOnz9L7tXmaJFECQkgXh24AlFDQJqkSnwxPoVZ8DIPGL2bs3M26aC6eCuni0A2AEipqVCzLlCGduL5ZVX4/aw3/OWMVZ3J10Vy8EdLFIRJKYstE8MYDbf910bz/2EUcPqGL5lLyVBwiQSQs/6L5C3e3In3LIXq/No8t+497HUtKGRWHSBC6s20tJj7cgUMnTtPztTQWbT7odSQpRVQcIkGqfb14pg9NIT4mivvfWsC0pTu8jiSlhIpDJIjl3WmeQnKdeJ74aAUv/GO9pmeXYqfiEAlycTGRvPNQe/ok1+LVf27g8Q+XkX0m1+tYEsIivA4gIpcvKiKMv9x5JfUSyvGXz9ex6/BJ3uyXTOVyZbyOJiFIRxwiIcLMeOyaBrx+/1Ws3nWEXq/NY0Om1jQX/1NxiISYW1pW58PBHTlxOofer6Uxf+MBryNJiFFxiISgNkmVmD40hSoVouk3diFTl2jElfhPSBeH5qqS0qx2fAxTH+tMu7rxPDl5BS9+8YPmuBK/8Kk4zCzVzIaZWf0Cz9Xzfyz/0FxVUtrFlY1k/MC8EVevfJXBzyct51SORlzJ5fF1VFUi0B5ob2YHgPeBXwF9/B1MRPzjxxFXdSrH8tfZ69mVlc2YB9tSMSbK62gSpC55xGFmz5jZMADn3HTgIWAUsAroAqwt1oQictnMjGHXNuSVe9uwfNthzXEll6Uwp6r6AG//+MA5l+ucW5T/3mjn3O+KK5yI+NcdrWrw3iN5c1z1fn0eS7ZqjivxXWGK44xzLvs8z78LPODnPCJSzNrVjWfa0BQqREdw75sLmfX9Lq8jSZApTHGcNrPq5z7pnDsNnPF/JBEpbvUSYpk2NIUra8Yx/P1lvPbNBo24kkIrTHG8AHxsZnUKPmlmVQDtaSJBKj42iokPd6B7qxr8z+freXraSq0qKIVyyVFVzrnJZhYDLDGzBcBy8grnbuDZ4o0nIsUpOjKcl+9pTVJ8WUZ9vZGdh08y6v6rqBAd6XU0CWCFuo/DOfcOUA+YBEQC2cB9zrn3ijGbiJSAsDDjlzc35X/uvJL5Gw9w9+vz2Xn4pNexJIBZaTivmZyc7NLT072OIRLw5mbs57GJSygbFc7b/dvRspZuni2tzGyJcy75fNtCesoREfFNaqMEpg7tTGR4GH3emM+Xa/Z6HUkCkIpDRH6icdXyTB/WmUZVyzF4Qjrj0zZ7HUkCjIpDRP6fKuWj+XBwR65vVpVnZ67h2U9Wk6slaSWfikNEzismKoLRD7Tl4dR6jJ+3hUcnpHP8VI7XsSQAqDhE5ILCw4zf3t6c/+7Zgn+uy6TPG/PZk3W+iSSkNFFxiMglPdixDm8PaMeW/cfpOSqNNbuOeB1JPKTiEJFCubZJFSYP6YwZ3D16Hl+vy/Q6kngkpItDKwCK+FfzGhWYMSyFeomxDHpnsUZclVIhXRxaAVDE/6pWiOajRztxXdO8EVe/+3gVOZrjqlQJ6eIQkeIRExXBGw/mjbh6Z/5WHnk3nWMacVVqqDhEpEh+HHH1h54tmJOxn7ten6c5rkoJFYeIXJYHOtZh3IB27Dx0kp6j0lix/bDXkaSYqThE5LJd3TiRqUM7ExUexj1j5vP3lbu9jiTFSMUhIn7RuGp5ZgxLoVn1Cjz23lJGfa1VBUOVikNE/CaxfBk+eKQjd7SqwV9nr+cXk7/ndI5GXIWaS64AKCLii+jIcF7u25r6ibH87csMth86wegH2hIfG+V1NPETHXGIiN+ZGT+7oTEv923N8u2H6fVaGhv3HfM6lviJikNEik2P1jX54JGOHMvOodeoNOZm7Pc6kviBikNEilXbOpWYMSyF6nFl6T9uERMWbPU6klwmFYeIFLva8TFMeawTXRsn8syMVTz7yWpNUxLEVBwiUiLKR0fyZr/kfy0M9dA76RzJPuN1LCkCFYeIlJgfpyn5c++WzNuwn96vzWPrgeNexxIfqThEpMT1bZ/EhEEd2H/sFD1GpTF/4wGvI4kPVBwi4olODSozY2gKlWOjePDthXywaJvXkaSQVBwi4pm6CbFMH5ZCSsMEnp62UhfNg4SKQ0Q8VSE6krED2jEo/6L5wPGLyTqpi+aBTMUhIp4LDzOeub05f7mzJQs2HaDXa2ls3q+L5oFKxSEiAeOedklMHNSBwyfO0FN3mgcsFYeIBJQO9Svz8bAUqlWIpv+4RYxL26zp2QOMikNEAk7t+BimDu3M9U2r8NzMNTw1dSWncnK9jiX5VBwiEpDKlYlg9ANtefy6hkxK3859by5k39FTXscSVBwiEsDCwownbmrCqPuuYvWuLO4YOZdVO7O8jlXqqThEJODddmV1pgzpjAF3jZ7HzBW7vI5UqgVdcZhZczP7yMxeN7O7vM4jIiWjRc04Ph6eSsuacYz4YBl//vs6cs/qorkXSrQ4zGysmWWa2apznu9mZuvNbIOZPXWJj7kFeNU59xjQr9jCikjASSxfhvce7sh9HZIY/e1GBr2jmwW9UNJHHOOBbgWfMLNwYBR5hdAcuDf/qKKlmc0656cKMAHoa2Z/BSqXcH4R8VhURBh/6tWSP/ZqwdyM/fQclcaGzKNexypVrKTHR5tZXWCWc65F/uNOwLPOuZvzHz8N4Jx7/hKfEw5Mc871uMD2wcBggKSkpLZbt2rVMZFQs3jLQR6buITsM2f52z2tuaF5Va8jhQwzW+KcSz7ftkC4xlET2F7g8Y78587LzOqa2RjgXeCvF3qdc26Mcy7ZOZecmJjot7AiEjja1Y3nk+Gp1EuI5ZEJ6bzyVQZndd2j2AVCcfjEObfFOTfYOXe/c26u13lExFs1KpZl8pBO9Gxdkxe/+IEhE5dw7FSO17FCWiAUx06gdoHHtfKfExEplOjIcF7s04pnbm/OV+sy6TkqjY37jnkdK2QFQnEsBhqZWT0ziwL6Ap94nElEgoyZMSi1HhMGtefg8dP0HJnGV2v3eh0rJJX0cNwPgPlAEzPbYWaDnHM5wHBgNrAW+Mg5t9pP39fdzMZkZelOU5HSonODBD4ZnkKdhBgGvZPOy1/quoe/lfioKi8kJye79PR0r2OISAnKPpPLb6atZNqyndzQrCov3tOKCtGRXscKGoE+qkpExO+iI8N5oU8rfte9OV+vz6TnyDQy9up+D39QcYhIyDIzBqbU4/2HO3AkO4ceo9L49PvdXscKeioOEQl5HepXZtaIVJpUK8+w95fy/Gdryck963WsoBXSxaGL4yLyo2px0Uwa3IkHOibxxpxN9Bu7iAPHtL5HUYR0cTjnZjrnBsfFxXkdRUQCQFREGH/o2ZK/3nUl6VsP0f3VuSzfftjrWEEnpItDROR87k6uzdQhnTEz+oyez/sLt2ldcx+oOESkVGpZK45ZI1Lp2KAyv5m+kl9N+Z7sM1rXvDBUHCJSalWKjWLcgHY8fn0jJi/ZwZ2vz2P7wRNexwp4IV0cujguIpcSHmY8cWNj3u6fzPaDJ7j91bl8vT7T61gBLaSLQxfHRaSwrm9WlVkjulCjYlkeGr+Yl774QUvTXkBIF4eIiC+SKscw7bHO9G5Ti5e/ymDg+MUcPH7a61gBR8UhIlJA2ahw/vfuK3m+d0sWbDygIbvnoeIQETmHmXFv+ySmPtYZM7h79DwmLNiqIbv5VBwiIhfw45Dd1IYJPDNjFT+ftJwTp7W6oIpDROQiKsZE8Xb/djx5Y2M+XrFLqwsS4sWh4bgi4g9hYcaI6xvx7kPt2X/sNHe8OrdUz7Ib0sWh4bgi4k9dGiUya0QqjfNn2X1u5mpO55S+WXZDujhERPytRsWyTBrciYEpdRmXtoW+Y+azO+uk17FKlIpDRMRHURFh/K77FYy67yrW7znKba/M5buMfV7HKjEqDhGRIrrtyup8MiKVhHJR9Bu7iJe/zOBsKbjbXMUhInIZGiSWY8awFHq2rslLX/7AgFJwt7mKQ0TkMsVERfBin1b8qVfe3ea3vfIdS7cd8jpWsVFxiIj4gZlxX4e8u80jwvMWiBo7d3NI3m0e0sWh+zhEpKS1rBXHrOFduKZJFX4/aw3D3l/K0ewzXsfyq5AuDt3HISJeiIuJ5M1+bXnqlqbMXr2XO0amsW7PEa9j+U1IF4eIiFfMjCFdG/D+wx04diqHnqPSmLJkh9ex/ELFISJSjDrUr8ynj6fSpnYlfjF5BU9NDf61zVUcIiLFrEr5aCYMas+waxvw4eLt9H5tHlsPHPc6VpGpOERESkBEeBi/vLkpYwcks/PwSW5/dS6zV+/xOlaRqDhERErQdU2rMmtEKvUSYnl0whL+9NlacnKDa6JEFYeISAmrHR/D5CGdeLBjHcbM2cR9by4k80i217EKTcUhIuKBMhHh/HfPFrzctzUrd2Zx6ytzmbdxv9exCiWki0M3AIpIoOvRuiafDE8hrmwED7y1kFFfbwj4iRJDujh0A6CIBINGVcvzyfBUbruyBn+dvZ5H3k0n60Tg3m0e0sUhIhIsYstE8Erf1jx3xxXMydjH7SO/Y9XOwDxbouIQEQkQZkb/znWZ9GgncnIdvV+fx6TF27yO9f+oOEREAsxVSZWYNSKVDvXi+fXUlfxy8oqAuttcxSEiEoAqlyvD+IHtefy6hkxesoNeAXS3uYpDRCRAhYcZT9zUhHED2rEr/27zL9fs9TqWikNEJNBd27QKs0akUqdyDA+/m87/zl5ProdDdlUcIiJBoHZ8DFOGdOae5NqM/HoDA8Yt8mxtcxWHiEiQiI4M5y93Xcmfe7dk4eaDdH91Liu2Hy7xHCoOEZEg07d9ElOHdAbg7tHz+WBRyQ7ZVXGIiAShlrXimDUilY4NKvP0tJX8ekrJLRCl4hARCVKVYqMYN6AdI65ryKT07fR5Yz47D58s9u8N6eLQJIciEurCw4wnb2rCmAfbsmnfcbq/Wvyz7IZ0cWiSQxEpLW66ohofD0+hcmwUD7y1kDFzNuJc8QzZDeniEBEpTRoklmP6sBS6tajGnz5bx/D3l3H8VI7fv0fFISISQsqViWDUfVfx9C1NWbv7CDm5/j/qiPD7J4qIiKfMjEe7NqB/57pER4b7/fN1xCEiEqKKozRAxSEiIj5ScYiIiE9UHCIi4hMVh4iI+ETFISIiPlFxiE0wZNoAAANsSURBVIiIT1QcIiLiEyuuuUwCiZllARkXeUkccKGZEBOA4p0xrHhc7HcK5O8q6mf5+j5fXn+p117Odu1fJftdJbV/+fKewrzuYq8prv2rjnMu8bxbnHMh/wOMKep2IN3r/MXxOwfqdxX1s3x9ny+vv5z951LbtX+V7HeV1P7ly3sK87pL7EMlvn+VllNVMy9zezAqyd/Jn99V1M/y9X2+vP5y9x/tX4HzXSW1f/nynsK87mKvKfH9q1ScqrocZpbunEv2OoeEJu1fUpyKa/8qLUccl2OM1wEkpGn/kuJULPuXjjhERMQnOuIQERGfqDhERMQnKg4REfGJisNHZlbfzN42syleZ5HQY2Y9zexNM5tkZjd5nUdCi5k1M7PRZjbFzB4r6ueoOAAzG2tmmWa26pznu5nZejPbYGZPATjnNjnnBnmTVIKRj/vXDOfcI8AQ4B4v8kpw8XH/WuucGwL0AVKK+p0qjjzjgW4FnzCzcGAUcAvQHLjXzJqXfDQJAePxff/6bf52kUsZjw/7l5ndAXwKfFbUL1RxAM65OcDBc55uD2zIP8I4DXwI9CjxcBL0fNm/LM9fgL8755aWdFYJPr7+/XLOfeKcuwW4v6jfqeK4sJrA9gKPdwA1zayymY0G2pjZ095EkxBw3v0LGAHcANxlZkO8CCYh4UJ/v64xs1fM7A0u44gj4nLTlTbOuQPknX8W8Tvn3CvAK17nkNDknPsG+OZyP0dHHBe2E6hd4HGt/OdE/EH7lxSnYt2/VBwXthhoZGb1zCwK6At84nEmCR3av6Q4Fev+peIAzOwDYD7QxMx2mNkg51wOMByYDawFPnLOrfYypwQn7V9SnLzYvzTJoYiI+ERHHCIi4hMVh4iI+ETFISIiPlFxiIiIT1QcIiLiExWHiIj4RMUhIiI+UXGIiIhPVBwiHjGzWDMbaWYdvc4i4gsVh4h3hgDRQKrXQUR8oeIQ8U43YD2w3OsgIr5QcYh4wMyigXDgKuBbj+OI+ETFIeKNRuQVxzrn3Bmvw4j4QisAingjEWiM1rGXIKQjDhFv1ACmAmFmVsnrMCK+UHGIlDAziyDv2kY1YDSQ620iEd9oIScREfGJjjhERMQnKg4REfGJikNERHyi4hAREZ+oOERExCcqDhER8YmKQ0REfKLiEBERn/wfONPHDY6UPQ0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is for instance the first bin auto-spectrum \n",
-    "loglog(ell, cls[0])\n",
-    "ylabel(r'$C_\\ell$')\n",
-    "xlabel(r'$\\ell$');\n",
-    "title(r'Angular $C_\\ell$');"
+    "for cl in cls:\n",
+    "    loglog(ell, cl)\n",
+    "    ylabel(r'$C_\\ell$')\n",
+    "    xlabel(r'$\\ell$');\n",
+    "    title(r'Angular $C_\\ell$');\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -641,26 +671,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
     "id": "zIdQSRgkUYC7"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mu, cov = jc.angular_cl.gaussian_cl_covariance_and_mean(cosmo, ell, probes);"
    ]
@@ -677,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -687,27 +704,14 @@
     "id": "WX5lmHsRVXIh",
     "outputId": "64a404cf-9269-4e8b-ff67-3de6eb3ba183"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAD4CAYAAAAKA1qZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO2dd3xb15XnfwcAwd6JRrGIoiR2qlpWsa1OUcV2YjsTK5mMk3HiccpMpu2MvbNTMjvefHbms5mSeJPxxk4yieMSx4ltSVaXYsmSbUmWrUYVqlOi2NRIUWLD3T8eQIIQAOJV4IHn+/nwI/IBwr0PJO6595TfISEEGIZhmPGJJdYTYBiGYWIHGwGGYZhxDBsBhmGYcQwbAYZhmHEMGwGGYZhxjC3WE5BDQUGBmDhxYqynwTAMYyoOHDjQKYRwhHrMVEZg4sSJ2L9/f6ynwTAMYyqI6Hy4x9gdxDAMM44xhREgogeJ6IUbN27EeioMwzAJhSmMgBDiHSHEU9nZ2bGeCsMwTEJhCiPAMAzD6AMbAYZhmHEMGwGGYZhxDBsBhmGYcQwbAYZhmCg5evkGNh65Aq83cST4TVUsxjAME0v+57pj+ODMVdROyML//cIslOSnxXpKquGTAMMwTJQkWaUl8+LV23jo+d043GL+2qWYGgEiWkREu4joR0S0KJZzYRiGiYYZJTl4+1sLkG634cs/+QjnOm/FekqqUGwEiOglImonoiNB1xuJ6AQRNRPRM2O8jADQAyAFQIvSuTAMwxiBEICFCKX56fj5k3PgFQLf/OXH6BscivXUFKPmJPBTAI2BF4jICuB5ACsBVANYS0TVRFRHROuCvpwAdgkhVgL4awDfUTEXhmEY3fEKAQtJ309yZOCfH5uGo5dv4ntbTsZ2YipQHBgWQrxHRBODLs8B0CyEOAMARPQqgIeFEN8FsCbCy10DkBzqASJ6CsBTAFBSUqJ0ugzDMKrxCgECDf+8vNqFz88uxo93ncWjM4sw1ZUZw9kpQ+uYwAQAFwN+bvFdCwkRPUJE/wng5wB+EOo5QogXhBCzhRCzHY6QctgMwzCGIARANPraX6+sREayDd9552hsJqWSmAaGhRBvCiH+SAjxeSHEznDPYxVRhmHiAX9MIJC8dDu+vXQK3m/uwgdnumI0M+VobQQuASgO+LnId41hGMb0eIW46yQAAF+4twSOzGT8+9ZTxk9KJVobgX0AphBRGRHZATwO4G21L8pS0gzDxAMCd58EACAlyYo/emAS9p7pwkdnrxo/MRWoSRF9BcBeABVE1EJETwohBgF8C8AmAE0AXhdCmNNRxjAME0S4kwAAfPHeUhRkJOMHO5qNnZRK1GQHrQ1zfQOADYpnFAIiehDAg5MnT9byZRmGYWThFQCFsQKpdiuemFeK/7PlJE539KDckWHw7JRhCtkIdgcxDBMPiIA6gVCsvbcEdqsF/7XnnGFzUospjABnBzEMEw+Eyg4KpCAjGWvqPXjjQAu67wwYODPlmMII8EmAYZh4wDvGSQAAnpg/Ebf6h/DGAXMo4ZjCCDAMw8QDUhuByFZgWnEOphVl47V9FyFE/PcdMIURYHcQwzDxwFgxAT+fm12M41e6cfhS/K9ZpjAC7A5iGCaQrp4+DA55DR93rJiAn4emFyLZZsFr+y6O+dxYYwojwDAM4+fi1V7M+qetmP6PW/Dsm4dx6fptw8aOVCcQSFZKElbVefD2J5dxuz++ZabZCDAMYyq6bvUDAKo8mfj1gRY0/ut72HjkiiFjh6sYDsXvzS5Gd98gNh01Zm5KMYUR4JgAwzB+vL5g6zcXT8a2v1iISc4MfP3lA3jrE/1lyqI9CQDAvWV5KMxOMWReajCFEeCYAMMwfvwZNxYiFOel4bWn5uLesjz8+eufYu9pfVU8RYSK4WAsFsKD0wqx61QnrvlOL/GIKYwAwzCMH68v69LvlklJsuLHT9yD0rw0fPvVg+jq6dNx7Oiyg/w8NL0Qg16BDUdadZuTWtgIMAxjKrxe/0lg5FpGsg3Pf3EmrvcO4J/WN+k2drTZQX6qPVkod6Tj7U8u6zYntbARYBjGVPhPAsFumSpPFp5eOAm/OXgJe0536jS2GKNUbDREhIemTcBH566i9YZxWUxyMIUR4MAwwzB+RmICdz/2jcWTUZSbiufWNw2fGLQdO/qYgJ810zwQAth8tE3z+WiBKYwAB4YZhvEzHBMIYQVSkqz4s2VTcfTyTWzUITUz2orhQModGSh3pGPzsfhMFTWFEWAYhvEjEP4kAACfmTEBk50Z+LetJzXX7vHKjAn4aahx44MzV3GjN/6URdkIMAxjKsLFBPxYLYRvLCrHybYe7DzZofHY0dcJBNJQ7cKQV2D7ifhzCbERYBjGVPiLxSKtxWvqC+HKSsaLu85qOraA/JgAAEwryoErKzku4wJsBBiGMRWBxWLhsNsseGL+ROxu7sSxyzc1HVtuTACQ4hfLq13YeaIDdwbiS0vIFEaAs4MYhvHj9YmHjuWb/+KcUqTZrXjpfe1OA1KPYWX/d1mVC7cHhnSvapaLKYwAZwcxTPwxMOTF3tNdeHH3Wfxg+yn89uAlXat1/Qy7g8ZYjLPTkvCZGRPwzqeXNQvIShXDyqzA3En5SLNbse14fLmEbLGeAMMw5uRvfnMYr+8f3UIxyUp4/J4SPLOyEunJ+iwvwbIRkfjCnBL88sML+M3BFnx5QZnqseVWDAeSkmTFfZMLsL2pHeJhoSi2oAemOAkwDBN/tHf3YYozAx//7XIc/5+NWPfH9+H3ZhfjFx+ex4Pf343LOun8D8cEoli9aidko74oG698pE2rR6/K11hW5cLlG3dwrFW7OIVa2AgwDKMIrwDSkm3IS7cjJcmK2gnZeO6zdfjlV+eio7sPn39hLzp1cA/JOQkAwNo5JTjR1o2PL1xXPbaakwAALK50ggjY1tSuei5awUaAYRhFhMuUmVeej59/9V603+zDn7xyEEMayzd4I8hGhOKhaYVIt1vxq/3qWz0qzQ7y48hMxrSiHGw7zkaAYZgEINx6OL04B//0mVrsOd2FH+86o+mYfpMSrU89PdmGFbVurD/cqjo90ytCy1XIYVmVE59evI727juqXkcr2AgwDKOIsTJlPje7GMurXfi3rafQcq1Xs3GjqRMI5pEZRei+M6jaDSNXRTQUSypdAIAdcXIaiKkRICILET1HRN8noidiOReGYeQhosiZ/85DNSACvrvhuGbjynUHAZKLypWVjN8cbBn7yRFQWjEcSJUnE4XZKdgaJ3EBxUaAiF4ionYiOhJ0vZGIThBRMxE9M8bLPAygCMAAAHW/HYZhDEXS0Ym8IBbmpOKr95Vh/eFWHLmkTbGnv1iMZOzJrRbCw9MnYOeJDlW1DGpjAoBkRJZWubD7VGdcVA+rOQn8FEBj4AUisgJ4HsBKANUA1hJRNRHVEdG6oC8ngAoAe4QQfw7g6yrmwjCMwQgRWb/Hz1cfmITs1CR8b8tJTcaNtlgsmM9Mn4BBr8C7R5RLOqupGA5kaZVTqh4+E/vqYcVGQAjxHoCrQZfnAGgWQpwRQvQDeBXAw0KIw0KINUFf7ZB2/9d8/zf2JpFhmKiJNl0yKyUJf7igDNuPt+NUW7cm4wLyA7RVnkyUFaRjoyojoLxiOJDh6uGm2FcPax0TmAAgMA+rxXctHG8CWEFE3wfwXqgnENFTRLSfiPZ3dGgrC8swjHIEopdV/tK8UiTbLPixBqqeSmICgOSGaax1Y++ZLly71a9obCWdxUIxqnpY454HcolpYFgI0SuEeFII8cdCiOfDPOcFAN8B8LHdbjd2ggzDhEWOayQv3Y7HZhXhNwcvoaNbXQGZ3GKxQFbWujHkFdiiYAcuopCwlkO8VA9rbQQuASgO+LnId00VLCDHMPGHkOkaefK+Mgx4vfj5B+dVjas0JgAAdROyMSEnVZFLSI3xCcXiSicAYHuMs4S0NgL7AEwhojIisgN4HMDbal+UpaQZJv6QWwg8yZGBhVMdeG3fBQwOeRWP6x9WyWJMRFhZ68buU524eUeesmikBvdKcGQmY1pxDrbGuF5ATYroKwD2AqggohYielIIMQjgWwA2AWgC8LoQ4qjaSfJJgGHiDwH5C/Hj95Sg7WYfdp5QHt9TUiwWSEONG/1DXuw+1Snr/420tVQ0bEiWVca+elhNdtBaIYRHCJEkhCgSQrzou75BCDFVCFEuhHhOi0nySYBh4g+hoN/u0ionCjKS8eq+C4rH9XrV7chnluQgOzUJ22XuwEfcUNpZgaVVsa8eNoVsBJ8EGCb+UKKomWS14HOzi7D9eDuu3FC2+x2r0fxY2KwWPDDVgZ0n2ocNSjQIjWMCwEj1cCxVRU1hBBhz8c8bj2P2P23FO59ejvVUGB1RqqPz+D3F8AooVvVUExj2s6TSgc6efhyWUcUsoG1MABipHt4Vw+phUxgBdgeZiwPnr6Gzpw9//MpBPPvmIQyoCAIy8YvSnPnS/HTML8/Ha/svytqJB44LqNuRL5wq6frLcQnpERMAgCUxrh42hRFgd5C5SLNbUVOYhW8sKscrH13EX/7qU0Ufdia+8SqICfj5/D3FaLl2G/vOBYsORDcuoG5Hnpdux4ziHOw4IccIqAtIh2NejKuHTWEEGHMhANgshL9qrMR/W1GBtz65jH/dqo1uDBNfKF2Il1W5kJpkxdsKXIZa5esvqXTiUMuNqDNzhMpYRDhiXT1sCiPA7iBz4Q1wE3xjUTk+N6sIP9jRjD3N8lLymPhGigkoWxDTk21YXu3C+sOt6B+U5y7UIiYAjBRr/S7KdFWtK4YD8VcPN7Wq11aSiymMALuDzEWg3C4R4TsP16CsIB1/9etDuN3POoGJghDRNXsPx8PTC3G9dwC7m+XVDKitE/BT7cmCOyslapfQyAlE1bAh8fce3nhUubidUkxhBBhzEawzn2a34bnP1KHl2m08v6M5hjNjtETNSQAA7p/iQHZqEt7+RJ5LSKtUTSLC4koHdp3sjCp5Ydj46GAFHJnJuLcsDxsOt2r+2mPBRoDRHCl/fPS1eeX5+Mz0Qryw64zi/HAmNH2DsTldSV22lP9/u82CVXVubDnWJusetNyRL65wortvEPvOjh2gHs4OUj9sSFbXedDc3oOTGshty8EURoBjAuYiXMepP19eAa9X4Ic7+TSgFS3XelHxPzbiH94+anhQUQtZ5YZqN271D2Hv6ejTI7Ws3F0wuQB2qyWqVFGhQ8VwICtq3SAC1h0y9jRgCiPAMQFz4Q1xEgCAkvw0PDarCK98dBGtN24bP7EEpKtH0sX/6Z5z+P52Y42rFq0W55VL6ZFbjkWfHqnFuH7Sk22YW56P7VHEBbRWEQ3GmZky7BIy0qCbwggw5kJE8BV/c/FkeIXAD3eeNnhWiYl/V5yXbsf3tpzEuwb6lL1RtpeMREqSFQ9McWBrU1vUC59XgVxFJJZWOnGm4xbOdt6K+Dw9KoaDGXEJ9eg3SBBsBBjNiZQ1UpyXhkdmTsDr+y/iRq88KV/mbvzL5ncfqcP04hz81a8PGRZzEdCm1eLyahfabvZFLeGgpkgtFEv8uv5juIT0qhgOZEWtGxYC1htozE1hBDgmYC7G6sP6lQVluDPgxWv7lStJMhL+3XNKkhX/9vnpGBjy4tk3DxniTvB6oUmUdEmlExZC1C4hrwaxiECK89IwxZkxppKnv+pdr5gAILmE5pTlYf2hy4a5hExhBDgmYC7GUoio8mRh7qQ8/GzPeVXNRZjAdElgYkE6/rKhAjtOdBimSqnFSSA33Y7ZpXnYGuWctYwJ+FlS6cSHZ7vQHUWjGb1iAn5W13lwuuOWYS4hUxgBxlxE02zky/PLcOn6bWyNkV5KohAcrHxi/kRMcqTjf21okl2JK39sZSqioVhc6URT682oXFljnTSVsKTSiYEhEbHRjFfHiuFAGms9kkvokDEqvGwEGM2JZqe2vNqFCTmpePlDdgmpIXhhSrJa8N9XVuFM5y389qDq9t4RUdJPIByLKx0AgN+djC5LR2sjMKs0F1kptohxgWGDq/Oq6chMxtxJ+Vh3yJgsITYCjOZEs1OzWgiPzSrC7uZOtFzrNWhmiUcoUbOlVU7UTsjC/93ZrKu7TcsAbYUrE57sFOw4PraEhFSfoM24fmxWCxZWOLEjQqMZreQqomFNfSHOdN7Csdabuo/FRiCBudU3GBMJZ683ug/p52YXAQDeONCi84wSl5ECppFrRIRvLZ6Mc129umaZCGgXJCUiLKpwYndz55huLD3cQYCUKtrZ049DYbKUjPwoNda6YbWQIYVjbAQSlNYbt1H/nc2o+ftN+PovDuDjC9cMGzvaxaEoNw33TS7Ar/a3cL8BhfjfteBFsaHajSnODDy/o1k3l4KSHsORWFzhQE/fIPafjyzhoEdgGAAWTnXAEqHRjJEngbx0OxZMLsA7n+qfJWQKI8ApovLp6unHkFdgRkkOPjjThUd/uAf/+M4xQ7Jx5HxIf292MS5dv433T7PMtBLCNVixWAhPLyzHybYevN+sT8eqUBpRalgwuQBJVsLOMaSd9YgJAFKW0sySXGw/HjpZQe+K4WDW1HvQcu02Pm3Rd90zhRHgFFH5+DcPX1lQht1/vQRfmluKl94/i2+8/LEhWSPRflAaalzITLHhtwe5H7ESIhUwra73IC/djp/tPafL2AJQpSIaTHqyDfeW5Y+drx9Gm0oLllQ5ceTSTbTdvDtLyV8xbJANwIpqN5KshHU69+o2hRFg5BO4Q0xPtuEfH67F3z9Yjc3H2vC3vz2i6xHTKyNwl2yzYlWtB5uOXolZo20zE0nULCXJis/fU4xtTW24dF17rSavDm6ZRRUOnGrvwcWr4ZMF5Px9yWVppQtAaJeQ17d30lM2IpDstCQ8MMWB9YdbdXWXshFIUPx/MoEflq8sKMO3Fk/Ga/sv4pcf6ZeaKWTu1B6aXoievkFZTb8ZieHsoDCPf/HeEgDAyx+c12VsrXfk/m5fO0+GdwnpFRMAgKmuDBTnpWJziOYuWqqXRsuaaR603rija0yPjUCCMtIKb/Qf7J8vn4r7pxTgufVNuNClT2qm3PzxuZPy4chMxluf6JvXnoiMiJqFfr+LctOwpNKF1/dfjKpxihy8OpwmJxWkoyQvDTsj5uvrkx0ESAt8Y40b7zd34WaY6mGjYgKA1HbSbrPomiXERiBBCXUSAKSA4f9+tB5WIvyPt47oMrbcSlKrhfBgfSF2HO/AjdssKicHv4si0rr0e7OL0NnTj/ci7K4VoUOAloiwuMKB9093hnUP6hUY9tNY60b/kPeu2IRRFcOBZKYkYXGF5BIa0sklxEYgQYnkKy7MScW3l03Beyc7ou6vKmtsyPebPjjNg/4hL7axjIQsvFGkLS6qcCIv3Y5ff6xtPYbWap5+FlU6cWfAiw/DdPvSo1gskBnFuXBmJmNTkEvIqIrhYNbUF6Kjuw8fRdH9TAlsBBKUsXzFfzBvIibmp+G7G5o0DzopOa5PK8qBOyvlrg8eE5lwJ75A7DYLHppWiK3H2nG9t1/TsfXwzc+blI9kmyVslpDQ0R0ESKflFTVu7Djegdv9I6cRvTuLhWNplROpSVas00lLKKZGgIjuJ6IfEdGPiWhPLOeSaIy1ONhtFvzZ8qk42daDzTK6OkWDVDEs74NisRCWV7vwu5OjP3hmQQhheHtH/7jA2Kmaj80qQv+QF+9omG6oV6pmSpIV88vzsTPMKVWPrKRgGmvduD0whPdOjbjQ9O4xHI40uw1PzJ+Iyc4MXV5fsREgopeIqJ2IjgRdbySiE0TUTETPRHoNIcQuIcTTANYB+JnSuTB349/dR9oxra7zoDQ/TfOqUqWVpCtq3Lgz4MWuUxr7rg3gH94+ivrvbMahluuGjiuidFHUFGah0p2JNz7WLviup1tmcaUT57p6Q3b70jsmAABzyvKQk5aETUdGTqZGVgwH88zKSnxlQZkur63mJPBTAI2BF4jICuB5ACsBVANYS0TVRFRHROuCvpwB//ULAH6pYi5MEMMngQjPsVkt+PrCchy+dAPvRZDQVTK2kp3avZPykJVi0/xkYgQfX7iO7juDeOxHe/E7rQOwERjZnUZ+w4kIj84swqcXr6O5XRudeiG0LRYLZNFUX6poiNOAXrGIQJKsFiyrcmFrU9twcaXRFcNGodgICCHeAxAcqZgDoFkIcUYI0Q/gVQAPCyEOCyHWBH21AwARlQC4IYToDjUOET1FRPuJaH9Hh/l2iLFCRGMFADwyswie7BT85++06/mrNIUvyWrB0ioXtjW1ma7ZTEGGHUW5qZjsyMDX/ms/9p/TJ4gXjJy+tw9PLwQRNPMtS+0lNXmpuyjJT8MkRzp2hJCQ0FLCOhKNNW7cvDOID850+cY1tmLYKLSOCUwAcDHg5xbftUg8CeAn4R4UQrwghJgthJjtcDg0mOL4YKz8cT92mwW/P7cUe053abZDVNP+b0WNC9d6B/CRQYuoVngFkJ9ux8tfvReF2Sn4xssfoz2E9IAe4wLRvd/OrBTcU5qHdw9rE3zXs3IXABZXOPHBmS709g8GjatvYNjPfVMKkG634t0jrb5xpetsBDRGCPH3QoiIQWEWkJPPWNlBgXz+nmIkWQm/0KiqVI265ANTHUi2WbD5qLlcQgIAiJCbbsePvjQLN+8M4Jk3D+seLJa7O11Z58aJtm5NDL7eWTqLK5zoH/Ri7+nRAnhGuIMAKUC9rNqFjUeuYGDIG9OYgJ5obQQuASgO+LnId00VLCAnn1DNRsJRkJGMVXUe/PpAy127LqVjK3UTpNltuG9yAbY2tcUk20YpIqBArtKdhb9sqMD24+14W2fxLyHTT72y1gMAeFeDPgNeoW+mzD1luUizW++qZdG60XwkVtd5cK13AHtPd4WV7TY7WhuBfQCmEFEZEdkBPA7gbbUvyicB+cjxFQPAl+aWortvEG99on7RUntcX1rlQsu124Y12taKwPf6KwvKMK0oG8+tb9LEsIZDbhWrOzsFs0pzseGIOpeQETnzyTYrFkwuwI7jHaM2BHpqBwXzwFQHMpNtWHfocoB2kDFjG4WaFNFXAOwFUEFELUT0pBBiEMC3AGwC0ATgdSHEUbWT5JOAfOT6L2eV5mKqK0OTLl9qd4hLq6TMEDM1oQ/OmbdaCH+7phrt3X348a6zuo0r9yQAAKvqPGhqvRky/VLuuHoviIsrnLh0/fYo95VRgWFAcgktr3Zh09E29A1IyQpGGSCjUJMdtFYI4RFCJAkhioQQL/qubxBCTBVClAshntNiknwSkI+INj3I/yxfCuGB89dULQ7+sdXsEF1ZKaibkG0qCQkRwvDNnpiHxho3/vN3p3GjVx9NJCW705W1bgDABhUuIaNcI4sqpGSQQJeQEcVigayu9+DG7QHsbpbSqI2uGNabmAeGo4FPAvKJRk4gmM/MmAALAW+q1JjRYqe2tMqJgxevo7OnT9XrGEW4e/6TpVNwq38I/7X3nG7jAvJ+z4U5qZhenDOc9aIEo8TUCnNSUenOHNWA3siYAADcP8WBzBTbcL/mxDIBJjECjHyUZDK4slJw3xQH3vz4kio9IS12asuqXBACY3aZihe8oY4CAKoLs7Ck0omf7DmnixxGtKnAwayocePIpZu4rLDZzEilsv5L4qIKJ/adu4pun7Sz0ScBu82CFTVudHRLGxIODMcAdgfJR06KaCCPzpyAS9dvh1VwjAYt8sdrCrPgzkrBtiZzGAGp1WJovrGoHFdv9ePVfdo38lGau95QI3XQ2qKwOluPXgLhWFzhwKBX4H2fO8bImICf1fWe4e/ZCMQAdgfJR2ngrqHajYxkmyrZYamSVN0HhYiwpMqJXac60DdoAkG5CAvT7Il5uGdiLl56/6zmiq1KAsMAUO7IQLkjHZuPqcsSMmJBnFmai8wU27BLyKhisUAWlBcgOzUJAGcHMSZBaeAu1W7Fqjo33j3cqrjnr1Y+22VVTtzqH8IHZ+K/enisAqYn5k/Exau38TuNxfHU+OYbatz44MxVRUFrI9Mlk6wWPDDFgR0n2iGEMKxYLBC7zYLGGimgzkYgBrA7SD5qjutr6gtxq39IcScqrfK455cXICXJYoosIYHIi0NDtRsFGcn4xV5tqrKHx1WRr99Q7cKQV2D7Cfnv78gJRPZ/VcSiCgfau/twrPWmISqioVh7bwmKclPhyU41fGw9MYURYHeQfNTkcc8rz0dOWpLiFEKtNGVSkqy4b7ID25ra4756eCwJBbvNgrVzirH9RDsuXtWut/PIiU/+/51WlANnZrIiiY6RE4gxi/FCX6rozhMdqmRJ1DC9OAe7/3oJ8tLtxg+uI6YwAowSlH9Ik6wWNFS7sLWpXZE/XktNmaVVUrHQ8SshRWbjhmhc/WvnlIAAvPKRdgFif4xByUkgsJGPXNefkhRkNTgzpdqRHcfbY3YSSFRMYQTYHSQftf1QV9Z50NM3iN0K+gxomce9tFKqHt4e56mikjso8j0X5qRi4VQHfnNQXQpu8LiAcrdMQ40bvf1D2HNa3u9ZDDe4N24xXlzhwMcXruFab3/C+eVjiSmMALuD5DOSIqrs07KgvABZAQUy0Y+rbRGRMysF9UXZ8S8hESAgF4lHZhah9cadYY16tUTbVCYc8yblIzPZJtslJFebSgsWVTrhFcCZjlt8EtAQUxgBRj7+D6nSz4rdJnVW2n68XVaDF6Upi5FYWunCJ3FePeyNUjl1ebULmck2/FqjNo/DRlfhJ9lus2BRpRNbm9owJON0Eot+u9OKcpDv88cnmn5PLGEjkKBokb2xtMqF670DOHgx+r65/oChlh/SpVVOCBHfLiGB6PSSUpKsWF3vwbtHWjWT7QbUGd2Gahc6e/px8MI1GeP6fs8GrsZWXwwDAAY1rrcYz7ARSFBGUkSVf0jvn1oAm4VkVe2OxCK0WxxqCrPgyU6J61TRMKoRIXlkZhF6+4ew6aj6Dl9aaPgsqnAgyUqyejvH4iQAACt84nfBjWYY5ZjCCKgNDN/oHcBjP9yDjUeuxH2qodao8cpkpSRhTlmerMVXDzkBIsKSSid2nepUXMCmN0JGMHx2aS6K81Lxpqm1U/UAACAASURBVAYuIS3UPDNTkjC/vACbjkb/+RhxNxprBuaX5wPgk4CWmMIIqA0MX75xG1d7+/H0Lw7gyZ/t103WN57Qyje/tMqFU+09uNAlL7dd68DdsioXevuHNAuoao2cKlaLhfDZ6ROwu7kT7d3q+hBrVbnbUOPC+a5enIqy7aRR/QSCSbZZ8aPfn4XX/2iesQMnMKYwAmqp8mRh858+gL9bU41dpzrw2I/24Oqt/lhPS1e0kvodSdGM7jSgR0wAkArYUpOscS0oJ+eWV9cXQgio7qWs1WK8vErytW+O0kWlRwJAtDTWujGnLM/wcROVcWEEAMBmteAP7yvDz74yBxeu9uLLP/kobl0LWqDV4jCxIB3ljnRsizIo69VpcUhJsuK+KQXYFqe9h+UqW051ZWBSQboqTX9pXG2anzuzUjCjJCfquMCwO0jVqEw8MG6MgJ/5kwvw/bUzcKjlBr7zzrFYT0c3RsLC6j+mS6tc+OBMF3r6xs5m0VNYbFmVE5dv3EFTa/xVD8sVNSMirKyTBNzUnEq1DNA2VLtxqOVGVD0GlEpYM/HHuDMCgFQl+fTCcrzy0QXFeurxjpaL8ZJKJwaGBHZHoYA5cgLRfnVYXOkEETTJqtGasQTkQrGy1oMhr8AWFXLOWrpl/D0GoinMM6LRPGMM49IIAMBfNExFhSsTf/fWkah2uKZDw53aLJ+eezR5+kKnmAAg6cfcMzFPtQtFD5T0Va4pzEJxXio2HFZuBLQ09sM9BqKIUyhtWsTEH6YwAnpoByVZLfhfj9Si9cYdPL+jWbPXjRe0TOFLslqwcKoDO050jKl5o3f++KpaN0629aC5Pb5cQnLqBPwQEVbVevB+c6fijLURITdt3nGpx0DXmPOJZWCY0RZTGAG9tINmlebh4emF+Mn7Z9F2U12qXjhe/vA8nn3zMPoHo5de0AKt9d6XVDrR0d2HI5cjG2K9K0lX1nlABKw/FF8uoWgE5EKxss6DQa9QrI2kVe8GPw3VLgx6BXaciHzqM7KpDKMvpjACevIXyysw5BX4j22ndHn9F3efxSsfXcDTvziAARkaPGpRKywWzMKpDhCNLd3g1TEmAACurBTMLs2NO5eQiFJALphpRdlwZ6UobvPoVeCGijwfX4+BMeajRZEaEx+MeyNQkp+Gx2YV4VcHWlQX7oRiYn46AGnxfG59k+avHw61AnLB5GckY3pxDnaMYQT0jAn4WVXnwfEr3TjdEV1hkxFEKyAXDJGkh/PeSWXV0ELhuOHw9xjYeSJyjwE+CSQO494IAMDX7p+EgSEvfrbnnOavPeQVmFaUjSfvK8NP95zDuwq7dclFj4rOpZVOfNpyI6Kx1PoEEopGn37MhkPxcxqIVkAuFMurXbg9MKS8d4PG73U0PQb0zAJjjIWNAIBJjgw01rjx873nNc8U8goBi4Xw7MpK1E3Ixt++dcSQauURXX/tPqSLfdXDO0+ETxU1Qmfek52KWaW52HAkfuICSgLDfub6NP2VpCtLxkfhwGHnk4eMMXoMaN03gokdbAR8PL2wHDfvDOK1fRc1fV1/JanNasG/fK4e13sH8M8bj2s6Rshxff9quUBUe7LgzkqJ6BLSq2I4mFV1HjS13sTZzlu6jhMtcgTkgvFr+m87Lk/Tf2RcRcOGJdlmxaIKR8QeAxwTSBzYCPiYVpyDmSU5ePmD85rKEngDsjcq3Vl4Yv5EvLb/Io5dvqnZGKHQI4+biLC40oFdpzrDZjuN9LzVcOAQrPS7hALca913BvDVn+3D0TEymPRAbfPz5Qo0/QHp/dZjIW6ocaOzpx+fXAw9H44JJA4xNQJEVEJEvyWil4jomVjOBQC+eG8pznTewl4NlSqHvKN9xX+yZAqyU5Pwz5v0PQ1opSkTzJJKF3r6BrHv3NUw40r/6u0rLsxJxYySHKwPiAucbOvG1qZ2rP6P3bhmsECggDaa/nJdQgL67MaHewyEcQlpnYLMxA7FRsC3cLcT0ZGg641EdIKImqNY2OsAvCGE+EMAM5TORStW13uQnZqElz+8oNlrCgFYAz6k2WlJ+Nr9k7DzRAcOt+i3Y9VL22XB5HzYbZawqaJG9p5dXefBsdabOOdzCd3qG8lmefbNw/pPIAC5AnLBZKUkYe6kfGw+Jk8gz6swNTWa+cyL0GNAi6ZFTHyg5iTwUwCNgReIyArgeQArAVQDWEtE1URUR0Trgr6cAD4A8CQRbQewUcVcNCElyYrHZhVh05ErmqWLSoHh0de+NK8UmSk2XSuVtRSQCyTNbsPcSflh4wJGxQQAqdAKANb7XEK3fEH9h6cXYuPRK6NcRXojV0AuFA3VLpztvCUr9VWPmEDgfM519aI5RI8BPgkkDoqNgBDiPQDBPoE5AJqFEGeEEP0AXgXwsBDisBBiTdBXO4CvAPh7IcQSAKtDjUNETxHRfiLa39ExtoCZWtbOKcGgV+Ctg5c1eT0pJjD6k5KVkoQvz5+IjUev4FSbPvIHahuQR2JJhQNnOm+FDMoa6SuekJOKmQEuIX9m158um4qawiz84zvHcLvfGLlwJQJywSzz9c+V0+ZRiWZRtPj7+W4MkYXFKaKJg9ZLxAQAgek1Lb5r4dgI4E+I6EcAzoV6ghDiBSHEbCHEbIfDodlEwzHZmYFpRdl486D61n8AMBTGTfCVBWVITbLi/+06o8k4wegp8LWkUlocQrmEjF4cVtcX4ljrTZzp6EGvb8HPTk3C362pxpWbd/Dibn3e32DUZAf58WSnor4oW1ZcQGmRWjT4q7PXhzhRGen2Y/QlpoFhIcQRIcRjQoinhRB/Ge55egjIReKzMyagqfUmjl9Rn8ETTtslL92Oz8yYgLc+uaxLu0s9e8CW5KdhsjMjpEvIiIrhQFbVjWQJ+U8CaXYr7p2Uj4ZqF370uzOGtBNVKhsRzPIqFw5euI72KLWsBPTJDvKzul6qzg52CXE/gcRBayNwCUBxwM9Fvmuq0EtALhwPTiuEzUL4jQaNwEO5g/z8wbxS9A168asD2tYmAPpL/S6pdOLDs3c3mjEyJgBIu+fZpblYd6gVt/oGYbMQkm3Sn/WfLZ+Knr5B/GzvOd3noYU7CACWD2v6R9/JTc+3emWtJNgXHF/hfgKJg9ZGYB+AKURURkR2AI8DeFvtixp9EsjPSMbCqQ789pNLsot3ghnyhv+gVHmycM/EXPz8g/NjSjTLRe/FeHGFv9HMaGkBrXoby8G/Wz186QbSk23D73eVJwtLK534yftn0duvb88I6SSg/q4rXJkoyUuLutGMFm6oSLizU3BPad6oVFxAf8lwxjjUpIi+AmAvgAoiaiGiJ4UQgwC+BWATgCYArwshjqqdpNEnAQD47MwJaLvZhw9U1gwIIWCN8C7//txSnO/qxa5m+boxEcfVWEAumNkT/Y1mRvuvYxEw9O9Wdzd3It1uHfXYNxaX41rvAF75SPvTViBa+eb9gnLvN0fXzlMrN1QkVtd7cKKtOyiJQZ86FMZ41GQHrRVCeIQQSUKIIiHEi77rG4QQU4UQ5UKI57SYpNEnAQBYVuVCZrINb6p0CUVyBwHSApaTloQ3DrSoGicYvXuxJ1ktWFThxLam9lGnJa/BMQFA2q3OLs2FEEB6sm3UY7NK8zCnLA8v7jqj+lQXCS2zdJZXu9A/5MV7J8fOhhvr70sLVta6pR4OAS4hjgkkDqaQjYjFSSAlyYqGGjc2H7uiqiGMd4wiIrvNgoemFWLz0Su4eUf7AKaeC0RjjRtdt/qxP6B6OFYdp1b7agaCjQAA/OGCibh8405U7TGVoqV5mV2ai9y0pKiyhLSWkg6FMysFcybmYd2h1uFYAHcWSxxMYQRixcpaN7rvDKqSkfB6xZhdth6dWYS+Qe9dflc1GKHhs6jCAbvNgo0Bjd9jpSnj7ziWEcIILKtywZWVjJ9/cF638dVWDAdis1qwpNKFbU1tYzYi8uocE/Czpt6D5vYenGzr8Y3LKqKJgimMQCzcQQBw35QCpNut2Kiii5U3TIpoIPVF2ZjszMCvNXQJGVHUn55swwNTCrD56IjUQazUJV1ZKfjs9AmYVZp712M2qwVfmFOK9052DEtMaI1aAblglle7cPPOIPadDa3RNDyuDlLSoWis9cBCwPpDUhElF4slDqYwArFwBwGSS2hJlQubj8qX+PUzljsIkD5Ij84swv7z1zRbpIw6rq+ocePS9ds4ckmqqYiluuT3Pj8df7Z8asjHHp9TDJuF8PKH+pwG1ArIBfPA1AIk2yxjVg/rKRsRiCMzGXMn5WPdYcklJGL4e2a0xRRGIJasrJX83h+NsSMLR7SaMp+ZUQgiaFapbNRivKzKBauFsPGodFrSS71ULa6sFCypdOI3By9jUIdez/7mQVqRZrfh/ikF2DKGoJwwIDDsZ3W9B2c6buH4lW7uJ5BAmMIIxModBEgN1pNtFmw6qrARuFeMUhENhyc7FfdNLsBvD17SpJ/BSFMZfT+kuel23FuWN6wvo0dbS614dFYROnv6sEtBG8exUNNZLBzLq124dP02jrWGr1z36jBuOBpr3D6XUCv3E0ggTGEEYuUOAiS/98KpDmw8ckVRQVc07iA/a+o9uHC1F0e1aDijd45oAI21bpzuuIXm9m7DK4blsLjCidy0JPz6Y23TcQGf0dX4lpdWuUCEiFlCRqSI+snPSMb88gKsP9wa8Hs2ZGhGR0xhBGLNyjo3rty8g09brsv+v6GkpMOxvNoNq4U0kUCWmo2ofpmoaKiW9Hs2HW2L6x3icDrusTbcuK1tOq4ebpmCjGTMKsmN3OsXxr7Xq+s9ONt5K6B7Wxz+ohlZmMIIxNIdBEg7SKtFftcnQN5OLS/djvnl+dhwuFW1S8iro8RwMO7sFMwoyZFOSzo0uNeSR2YWoX/Qq3mvAT3cQQDQUOPCsdabaLnWG2Zc437PgJQIYLUQ1n0qvX/xaOwZeZjCCMTSHQQAOWl2zJmYh61NSoyAPNfIqjoPznX1RvQDR4Nei1I4VtS4cfjSDVy6dhtA/LoJ6ouyUe5Ix5sau4T02pEv952ytobZgBhRLBaIf6Pi//uMR7cfIw9TGIF4YHm1CyfbenC+S14KZzR1AoH4d1pqd6p69Z4NR2PN6MbvWmbKaAkR4ZGZRdh37houXg29u1aCVgJywZQVpGOyMyNsqqhXp3EjsabeM/x9fP6WGTmwEYgSf5cluS4hr1fecT0v3Y55k/Kx4XDo3q5Rj2vwUWBiQTqqPFnY7RPCi1MbAAB4sL4QAPCuiiLAYPRs7tJQ7cKHZ6+G7Iugt5R06Pm4h7/nk4D5YSMQJcV5aah0Z8pq/QdIH1KrzNVhZZ0bZzulfGzFGOwOAoBVtW4MDMV/A/KS/DTUTsjChsPK0n7DomObxyGvwI4ToTu5Gb0Q56bbh79nG2B+TGEEYh0Y9rO82oX9567i2q3+qP+PXHcQIO20iML7gaPB6KwRYKTxOxDfJwFAir18cvE6Ll2/rfq1hqtnVb9SaKYV5cCZmRzyFKq1XEW0PDJD6ho7qKMyK2MMpjACsQ4M+1le7YJXhO6tGw4ledyOzGRML85RFIgeHtdrXP64n8nODEx1ZQCIfzfBqlrJYL2rQZaQ3rURFgthWbULO0+0o29waNRjRsd+/Hz30Tr8++PTMa0otp9JRj2mMALxQm1hNlxZoXdk4fB6lQVJl1W58GnLDbRF2Ws2GK21bKJlpW9xjXMbgIkF6aj2ZGlTk2FAbURDtQu3+odCdnKLxXudbLPi4ekTWEAuAWAjIAOLhbCsyoX3TnXgzsDQ2P8BytxBwEggeluUvWaD0bvtYDi+eG8J1s4pxlRXpuFjy2V1vQcfX7iOyypdQkZEQeaXFyArxTaqsQtgnJQ0k7iwEZDJ8moXevuHsPd0dD0GlJb1T3FmoDgvVbFLyCiJ4WCcWSn47iP1SEmyjv3kGLPKF8N494i6APFwNzUdAyF2mwUNNW5sOdY2yiUkFG4yGMYPGwGZzCvPR7rdGnWWkNKdGpF06tjd3KmoSbrRxWJmpKwgHZXuTMXigH6MkmlaXe9B953BUS4h/j0zamEjIJNkmxULKxzY2tQ2pqCc//FoVERDsbzKhf5BryLVS6PlBMxKQ40b+89dRVdPn+rX0vvtXhDCJSRgfAIAk1iYwgjES4qon+XVLnR0940pKKe26fo9ZXnITLEpShU1UkDOzKyokTK+VGViGdRDIZRLyOuN/yA8E9+YwgjES4qoH7+g3FgLx3DqoMLVOMlqweIKJ7Yfb5fd2cxIATkzU+3JQlFuKjZFUOoci+EeChrNKRLBLiH+PTNqMYURiDf8gnJjpYpqsUNcVu1C161+fHJRnow1+4qjg4iwosaN3ac60dMnP/YCBDbw0W5e4Qh2CfGJj1ELGwGFLItCUE6tOwiQOpvZojh1BBOLimGzsqLGjf4hL3aGkGWIBiPls+02C1bUuLHlqOQS0ku4jhk/sBFQSEMUgnJaVJJmpyZhTlme7LhArOoEzMis0lzkp9sVu4SMbqm5qt6D7j7JJSQEom5axDCh4D8fhfgF5cZq/QeoXxyWVblwqr0H5zqjl7GWdohMNFgthOXVLuw4frcsQ1QMGwFj3vFAl1AspKSZxIKNgAqWVbmwL4Kg3HCKqEqn7bIq6dQhxyUkYiAxbGYaalzo6RvEniiLAAMR0FdALpjRLiEv/54ZVbARUMFYgnJaCYuV5PtkrGW4Kzh/XB7zywukIkAFhWOxaLrudwk1td5ktx+jipgaASKqJqLXieiHRPRYLOeihLoJkQXltAgM+2mocWP/+avojLKoycvZQbJISbJiUaUTW461yU7HHRGQM+4d97uE9Gxmw4wPFBsBInqJiNqJ6EjQ9UYiOkFEzUT0zBgvsxLA94UQXwfwB0rnEivGEpTTUlPGX9S0LUqXEAeG5bOixo3Onn58fOGarP9nZIqoH79LCIh/2W4mvlFzEvgpgMbAC0RkBfA8pMW9GsBa326/jojWBX05AfwcwONE9C8A8lXMJWYsiyAo5/VK/2rxIa32ZGFCTvRFTQLydrMMsLjCAbvVgk0yBeW8MTgJAJJLCOATH6MOxUZACPEegKtBl+cAaBZCnBFC9AN4FcDDQojDQog1QV/tvq9vAngGQEiBHCJ6ioj2E9H+jo4OpdPVjfkRBOW0dAfJLWri1EH5ZKYkYf7kfGw6JrO/s4EVw4H4XUJqEw+Y8Y3Wy8QEABcDfm7xXQsJEU0kohcA/BeAfwn1HCHEC0KI2UKI2Q6HQ9PJakEkQTmtd4gralxRFzVxEZEyVtS4cfHqbTS1Rt/fORbuIEByCf3gCzPxjcWTjR2YSShiulcUQpwTQjwlhPiiEGJ3uOfFm4BcMH5BuUOXRs/P7w5SqiIazOyJechPt0eVJcQVw8pYVuUCEWTJSxslIBeKB6Y6ML04x/BxmcRBayNwCUBxwM9FvmuqiDcBuWD8gnJbjo1eOEYCw9qMY/UFonccb0f/oDfic4XggKESHJnJmF2aK8sIGCkgxzBao7UR2AdgChGVEZEdwOMA3lb7ovF+EshJs+Oeibl3pYrqsUNsqHGhu28Qe05H7jHg5YphxayoceP4lW5c6OqN6vmxcgcxjBaoSRF9BcBeABVE1EJETwohBgF8C8AmAE0AXhdCHFU7yXg/CQDA8mr3XYJyWhWLBbJgslTUNFaWkAB4a6oQf+pltKcBfyyIYzCMGVGTHbRWCOERQiQJIYqEEC/6rm8QQkwVQpQLIZ7TYpLxfhIApC5gwGhBOT1OAilJViyqkIqaInY2Y3eQYorz0lDlyZLddpLfbsaMmCKJ0AwngZL8NFS4MsMYAW3HaqhxobOnDwciFDWxO0gdK2pcOHDhGjq6x67QHlER5XecMR+mMAJmOAkA0uK879yItIM/O0jrxWFplQvJNgvWH2oN+xwWkFPHiho3hIgsFe5npJ8Aw5gPUxgBM5wEAGBlrQdegeEUTv/ioHUxT0ayDYsrnFh/uDWszo0A1wmoodKdiZK8tKhcQv7fABfnMWaE/2w1pMqTibKCdGzwtf7Tyx0ESL1mO7r7sO9ccNG2BJ8E1CFVaLuw53Qnbt4ZiPjcYQE5NrqMCTGFETCLO4iIsLLWjb1nunD1Vr8u2UF+llY5kZJkwbpDl0M+7mUBOdWsqHFjYEhg54nIciWcIsqYGVMYAbO4gwBgVZ0HQ16BzUevaKoiGkya3YallS5sPHIFg0OhCsc4MKyWmSW5KMhIHtMlFAspaYbRClMYATNRU5iF0vw0qfWfVz93EACsqfegs6cfH5692yXEAnLqsfjaTu483h5SKtwPVwwzZoaXCY2RXEIe7DndhS5f20m98vUXVTiRZrdiXYgsIe49qw0raly41T8UsUKb3UGMmTGFETBLTMDPap9LyO9G0GtxSLVbsazKhY1HWjEQ5BJiATltmF9egMxkGzZG6DEQSwE5hlGLKYyAmWICAFA7IQtFuanY4ksV1UpFNBSr6z241jtwV1Mbwe0lNcFus2BZtQubjrbdZWj9sDuIMTOmMAJmg4iwuk5qBA7oExj2s3CqAxnJtruyhLxCcKBSI1bXeXDj9gB2N4d2CY1UDBs4KYbRCDYCOrGqzjP8vZ6Nn1KSrFju26kGy0vzoqQN908tQGaKLWyFdqzaSzKMFrAR0In6omxMyEkFoL+v2L9TfT9gp8ruIO1ItlnRUO3GpqNX0DcYPkuI32/GjJjCCJgtMAxIu8JVdZIksd5GwL9TDcwSEhAcqNSQNfUedN8ZxO5Td7uEWECOMTOmMAJmCwz7eXxOCWaX5qI0P03Xcfw71c3HRnaqXi+7g7RkweQCZKcmhXQJsYAcY2ZMYQTMSrkjA298fT5y0uy6j7W63o3uO4PY0yxlCbGAnLbYbRasqHFh87G2uwrHWECOMTP8Z5sgLJgs5bP7xetYQE57VtcXoqdvEO+dHK0lxAJyjJlhI5AgJNusWFrlxJYmKZ+djYD2zC/PR25aEtYfHu0SGlbz5vebMSFsBBKIxloPrvcO4MMzV9kdpANJVgsaa93YepdLiCuGGfNiCiNgxuygWLBwqgOpSVa8e6SVTwI6saa+ELf6h7DzRPvwNa4YZsyMKYyAWbODjCbVbsWSSic2HW3DoJdTRPXg3rI85Kfb8c6odFwJfrsZM2IKI8BET2OtG509ffjk4nVelHTA5nMJbW9qR2+/JAsyIhnObzhjPtgIJBiLK52w2/jXqidr6gtxe2AIO45LWUIcF2bMDK8WCUZGsg0PTHHEehoJzZyyPBRkJA+L9gm2AoyJYSOQgKysleQqjl6+GeOZJCZWiyQJsv14O271DQ7XCbA7iDEjbAQSkCWVTgDAVV9nM0Z71tQXom/Qi61NbewOYkwNG4EEJDfdjnmT8vH0wvJYTyVhmV2aC2dmMtYfamUBOcbU2GI9AUYfXnlqbqynkNBYLIQVNW68caAFn5tdDIBTRBlzYthJgIgmEdGLRPRGwLV0IvoZEf0/IvqiUXNhGC1YVu3C7YGh4T4OejYPYhi9iMoIENFLRNROREeCrjcS0QkiaiaiZyK9hhDijBDiyaDLjwB4QwjxNQAPyZo5w8SYuZPykG63YmtTm+8KWwHGfER7EvgpgMbAC0RkBfA8gJUAqgGsJaJqIqojonVBX84wr1sE4KLv+/AtmxgmDkm2WXH/FAdart0GwO4gxpxEZQSEEO8BuBp0eQ6AZt8Ovx/AqwAeFkIcFkKsCfpqv+tFJVogGYKwcyGip4hoPxHt7+joCPUUhokZS6tG9jecIsqYETUxgQkY2cUD0oI+IdyTiSifiH4EYAYRPeu7/CaAR4nohwDeCfX/hBAvCCFmCyFmOxxcBMXEF0sqncMnADYBjBkxLDtICNEF4Omga7cAfGWs/0tEDwJ4cPLkyTrNjmGUkZ+RjJkluThw/hq7gxhTouYkcAlAccDPRb5rDDOu8LuEuH8DY0bUGIF9AKYQURkR2QE8DuBtbaY1GpaSZuKZx+8pwdfuL0OFOzPWU2EY2USbIvoKgL0AKoiohYieFEIMAvgWgE0AmgC8LoQ4qt9UGSY+yUu3429WV7N6K2NKoooJCCHWhrm+AcAGTWcUAo4JMAzD6IMpti7sDmIYhtEHUxgB7jHMMAyjD6YwAnwSYBiG0QdTGAGGYRhGH0xhBNgdxDAMow+mMALsDmIYhtEHUxgBhmEYRh/I3yTbDBBRB4DzKl6iAECnRtMxC3zP4wO+5/GB0nsuFUKEVOA0lRFQCxHtF0LMjvU8jITveXzA9zw+0OOe2R3EMAwzjmEjwDAMM44Zb0bghVhPIAbwPY8P+J7HB5rf87iKCTAMwzCjGW8nAYZhGCYANgIMwzDjmHFhBIiokYhOEFEzET0T6/loBRG9RETtRHQk4FoeEW0holO+f3N914mI/sP3Hhwiopmxm7lyiKiYiHYQ0TEiOkpE3/ZdT9j7JqIUIvqIiD713fN3fNfLiOhD37295uvwByJK9v3c7Ht8YiznrwYishLRQSJa5/s5oe+ZiM4R0WEi+oSI9vuu6fq3nfBGgIisAJ4HsBJANYC1RFQd21lpxk8BNAZdewbANiHEFADbfD8D0v1P8X09BeCHBs1RawYB/IUQohrAXADf9P0+E/m++wAsEUJMAzAdQCMRzQXwvwH8qxBiMoBrAJ70Pf9JANd81//V9zyz8m1InQv9jId7XiyEmB5QD6Dv37YQIqG/AMwDsCng52cBPBvreWl4fxMBHAn4+QQAj+97D4ATvu//E8DaUM8z8xeAtwAsHy/3DSANwMcA7oVUOWrzXR/+O4fU8nWe73ub73kU67kruNci36K3BMA6ADQO7vkcgIKga7r+bSf8SQDABAAXA35u8V1LVFxCiFbf91cAuHzfJ9z74DvyzwDwIRL8vn1ukU8AtAPYAuA0gOtC6vUNjL6v4Xv2PX4DQL6xM9aEfwPwo7gYRAAAAghJREFUVwC8vp/zkfj3LABsJqIDRPSU75quf9tR9RhmzIkQQhBRQuYAE1EGgF8D+FMhxE0iGn4sEe9bCDEEYDoR5QD4DYDKGE9JV4hoDYB2IcQBIloU6/kYyH1CiEtE5ASwhYiOBz6ox9/2eDgJXAJQHPBzke9aotJGRB4A8P3b7rueMO8DESVBMgAvCyHe9F1O+PsGACHEdQA7ILlCcojIv5ELvK/he/Y9ng2gy+CpqmUBgIeI6ByAVyG5hP4diX3PEEJc8v3bDsnYz4HOf9vjwQjsAzDFl1VgB/A4gLdjPCc9eRvAE77vn4DkM/df/wNfRsFcADcCjpimgaQt/4sAmoQQ3wt4KGHvm4gcvhMAiCgVUgykCZIxeMz3tOB79r8XjwHYLnxOY7MghHhWCFEkhJgI6TO7XQjxRSTwPRNROhFl+r8H0ADgCPT+2451IMSgYMsqACch+VH/Jtbz0fC+XgHQCmAAkj/wSUh+0G0ATgHYCiDP91yClCV1GsBhALNjPX+F93wfJL/pIQCf+L5WJfJ9A6gHcNB3z0cA/J3v+iQAHwFoBvArAMm+6ym+n5t9j0+K9T2ovP9FANYl+j377u1T39dR/1ql9982y0YwDMOMY8aDO4hhGIYJAxsBhmGYcQwbAYZhmHEMGwGGYZhxDBsBhmGYcQwbAYZhmHEMGwGGYZhxzP8Hp9gMEo7gihoAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "semilogy(mu);"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -717,20 +721,7 @@
     "id": "KLdw1eSvVXE3",
     "outputId": "cc8fc33a-ccb2-47a8-8e3b-cf4fdc4d9eb1"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAJCCAYAAADKjmNEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3df4xld33f/9dnZna8XpZlGS+2g9fE0DFCVgTEsnZJmqoEiuSFNOYPlC+wlt0IhPRVsWmbqqWVKkPVqkpblcRJFYkmKaR2mqA0Cm66/lIKfJv+E29sEkL40eyA+GGD2drjtVmv1+vZ++kfc8b51HXYXfvOnLkfPx7S0d575q7nfXzuzDznnHPvllprAABYNzf2AAAA24k4AgBoiCMAgIY4AgBoiCMAgIY4AgBobEoclVKuL6X8z1LKSinlg5vxOQAANkOZ9vsclVLmk/x5krckuT/JHyV5V631y1P9RAAAm2AzjhwdSLJSa/16rfVMkt9KcsMmfB4AgKlb2IT/5hVJvt3cvz/JwR/0F0op3qYbALap+SRnxx5iczxUa33ZM1eOdkF2KeV9pZR7Syn3jjUDAHBuZ5MslS5fw/XNZ1u5GVv6QJIrm/v7h3X/h1rrR2ut19Var9uEGQCAKVqtk14D6f+yGVv5R0muLqW8spSymOSdSe7ahM8DAGyh1ToZe4QtMfVrjmqta6WU9yf5VNZPU/56rfVL0/48AACbYeov5X9OQ7ggGwDYevc92+U9L4yThwAA50kcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0zhlHpZRfL6UcL6X8WbNuqZTy6VLKseHPlw7rSynl9lLKSinlT0sp127m8AAA03Y+R44+luT6Z6z7YJLP1FqvTvKZ4X6SHEpy9bC8L8mvTGdMAICtcc44qrX+QZLVZ6y+IcnHh9sfT/L2Zv1v1HV/mGRvKeWHpjUsALD1lsoL6yqc57q1l9VavzvcfjDJZcPtK5J8u3nc/cO6/0sp5X2llHtLKfc+xxkAmEG9/qA9ML/Y5bYdWtiZD120Z+wxttTz3ou11pqkPoe/99Fa63W11uue7wwAzI7VOukyIo6ePZPluYXutu3utdO5/czJ3L5z79ijbJnnuge/t3G6bPjz+LD+gSRXNo/bP6wDgKf1HEhLZa67bVuZrOVDTz6W214gR5Ce6967K8nNw+2bk3yyWX/T8Kq1NyR5tDn9BgBP6zWQViZrSfo7fbhaJ/nwk4/llsXdY4+y6cr6WbEf8IBS/mOSNybZl+R7SW5L8ntJPpHkFUm+meRnaq2rpZSS5Jez/uq2U0l+ttZ6zmuKSikXfFoOALa7pTKX1ToZe4ypO7SwM3evnR57jGm479ku7zlnHG0FcQRAr3oNpAPzizl69szYYzxfzxpHfR3zA4BtpscwStZPHy7PLYw9xqYQRwDABVutk26vG+tviwCALbFxVKy3QOrzeBgAsCV6PG3YV+oBADxP4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOAAAa4ggAoCGOoLFUfEnAZjswvzj2CJvijouXsjy3MPYYU3fPiy7Nly/9kbHH2FJ+EkBjtU4EEmyyo2fPdBkRH3rysRzesau7bTv8xGq+//jxPHDJq8ceZcv4KQDPsFonY48A3Vutk+4iYmWyljufOpWD84tdbdvKZC2Hn1jNF55YzWTP/rHH2RKl1jr2DCmljD8EAFtq4yhtb7+QLM8tZKnMZbVOsjJZG3ucqVkqc7nj4qUkyVtPPTTyNFNzX631umeudOQIgFH0FkUbViZrT5+i7+k0/WqdPB1FtyzuHnmazdXPXgNg5vR6nd/KZC0rk7WnjyL15K2nHsqhhZ3dXlifiCMARtZrIG2cVutx29566qHcuri7q2urWv3tMQBmTq+n2DYCqceIuPGJ1RzesavL+OtviwBgm+k1kD785GM5tLCzu0Dqa2sAYJvq9RTbnU+d6u7aqn62BAC2uV6vrzp69kxXr87rYysAYEb0Gkgb7+nUw7bN/hYAwIzp+QL0HuJvtqcHALadWY8/cQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAACNc8ZRKeXKUsrnSilfLqV8qZTygWH9Uinl06WUY8OfLx3Wl1LK7aWUlVLKn5ZSrt3sjQAAmJbzOXK0luTnaq3XJHlDkr9dSrkmyQeTfKbWenWSzwz3k+RQkquH5X1JfmXqUwMAbJJzxlGt9bu11s8Pt7+f5CtJrkhyQ5KPDw/7eJK3D7dvSPIbdd0fJtlbSvmhqU8OALAJLuiao1LKVUl+NMk9SS6rtX53+NCDSS4bbl+R5NvNX7t/WPfM/9b7Sin3llLuvcCZAQA2zXnHUSlld5L/lOTv1Fofaz9Wa61J6oV84lrrR2ut19Var7uQvwcAsJnOK45KKTuyHkZ31lp/d1j9vY3TZcOfx4f1DyS5svnr+4d1AADb3vm8Wq0k+bUkX6m1/pvmQ3cluXm4fXOSTzbrbxpetfaGJI82p98AALa1sn5G7Ac8oJSfSPI/knwxyWRY/Y+zft3RJ5K8Isk3k/xMrXV1iKlfTnJ9klNJfrbW+gOvKyqlXNApOQCAKbjv2S7vOWccbQVxBACM4FnjyDtkAwA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAcAULM8tjD3CplieW8jhHbvGHmNLiSMAmIKVyVqWSn8/Vlcma7l77fQLKpD624sAMJLVOukykFbrJHevnc6hhZ1jj7Il+tuDADCi1ToZe4RNsVonuefsmRyYXxx7lE0njgCA87JaJ1mZrHV7fdUGcQQAnLfVOun29OGGfrcMANgUvZ463CCOAIAL1vPRoz63CgDYdL0eQRJHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0BBHAAANcQQA0DhnHJVSdpZSjpZSvlBK+VIp5cPD+leWUu4ppayUUn67lLI4rL9ouL8yfPyqzd0EAIDpOZ8jR08meVOt9XVJXp/k+lLKG5L8fJKP1FqXkzyS5D3D49+T5JFh/UeGxwEAzIRzxlFdd3K4u2NYapI3JfmdYf3Hk7x9uH3DcD/Dx99cSilTmxgAYBOd1zVHpZT5UsqfJDme5NNJvpbkRK11bXjI/UmuGG5fkeTbSTJ8/NEkl0xzaABm11Lp83LXQws7xx5hUxzesStHdu0be4wtdV7P0Frr2Vrr65PsT3IgyWue7ycupbyvlHJvKeXe5/vfAmC29BhID9dJDswvdrdtxybrx0Fu37l35Em2zgXtwVrriSSfS/JjSfaWUhaGD+1P8sBw+4EkVybJ8PGXJHn4Wf5bH621Xldrve45zg7ADFqtk7FH2BRHz57Jap10F0dHz57JradPZHluIYd37Bp7nC1xPq9We1kpZe9w++Ikb0nylaxH0juGh92c5JPD7buG+xk+/tlaa53m0ADMth4jIklWhqMsy3ML53jkbFmZrOXGJ1ZzeMeuHJhfHHucTVfO1S2llNdm/QLr+azH1Cdqrf+0lPKqJL+VZCnJHye5sdb6ZCllZ5L/kORHk6wmeWet9evn+BziCYBuLJW5LJW5p2OpJ3dcvJRbT5/o5Qjgfc92BuuccbQVxBEAvdk4MtZJRPwfbt+5N7eePjH2GNPwrHHU3zFNANgGVuuk29OHt54+kVsWd489xqbpb48BwDbSayD90pmT3b59QX97CwC2mV4D6e61011eoN3fngKAbajHa4+S9Zf69/bqPHEEADwvK5O1ro6M9bMlAMBoejoyJo4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4AABriCACgIY4A2FJLpc8fPQfmF8ceYVMcmF/MLYu7xx5jS/X5DGXT+eYGm2upzHX5dbZU5nJs9+Vjj7Ep/sXlr89tF+0Ze4yp+3f7XpMHr3lHlucWxh5ly5Ra69gzpJQy/hBcsKUyl9U6GXuMqVueW8hqnXS5bcyWjTjq8bn48Itfnku+/52xx5i6L1/6I/n897+TG59YHXuUqZrs2Z+/uXx9/svnf3XsUabtvlrrdc9c2d+vJWyZ1Trp8jfblclat7+1M1s2Ir3H5+Il3/9O7nnRpWOPMXXXHP+zvP2iPTmya9/Yo0zV3GP357ovfSLvft1NY4+yJfr7imNL9fqNe2WylqTf04fMlh6PHCXJwceP546Ll8YeY+p2n/hGLilz3cXfh598LCt/9lv5J695+9ijbDrf+Xneev3G3fNv7bBd3PjEam5Z3N3d19nBx4/nyNrp7o4gHT17Jp86diR3XvXGsUfZVH09G2ETCCTYXHc+dSoH5xe7+zr7pTMnc+dTp7o7Onb07JkceeBovnDZa7vbZxv63CqYsl6PjsF2sFonuefsmSzPLXT1w3a1TnL32unc+dSp7l7FdudTp/K7J76Rb73kFV2+is2r1QDYFjZeCNHjq0UPLezMUpnLnU+dGnuUqbrtoj05OL+YW0+fePpazRnj1WoAbF/tdX49HUFKkrvXTme1Trp7L7UPP/lY7jl7Jod37OrqCFJfzz4AZlqPR4023L12OpeUua4iIlkPpNU66eq6sT62AoBu9PxK0bvXTufqzq6tStYvPk/STSDN/hYA0KWeA6m3o0fJ+kXaDw9HkGZdf886ALrRayAdHV6d15ujZ8/k2GQthxZ2jj3K89LfMw6ArvQaSBv/VFFvViZruefsmZm++Ly/vQJAd3oNpJ63a5aPjvW3RwDoUq+vYut1u5L1o0izGEjiCADYNLN4+nC2pgUAZs6snT6cnUkBgJk1S6cPxREAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0xBEAQEMcAQA0zjuOSinzpZQ/LqX8/nD/laWUe0opK6WU3y6lLA7rLxrurwwfv2pzRgcAmL4LOXL0gSRfae7/fJKP1FqXkzyS5D3D+vckeWRY/5HhcQAAM+G84qiUsj/J25L86nC/JHlTkt8ZHvLxJG8fbt8w3M/w8TcPjwcA2PbO98jRLyT5B0kmw/1Lkpyota4N9+9PcsVw+4ok306S4eOPDo+nIwfmF8ceYVPccfFSlucWxh6DC9Dr/jq0sLPLr7MD84v5zBUHxh5jU/yVH//7efjFLx97jKl79+tuyt/6W///2GNsqXPGUSnlp5Icr7XeN81PXEp5Xynl3lLKvdP877I1ViZrXX7j/tCTj+Xwjl3d/sDt0cpkLUulv9eW3L12Okl/8Xf07Jn8wUNfzZcv/ZGxR5m6o1/8zfzDH/7rObn3qrFHmaoPrPx/efxPPpZ3veuusUfZOrXWH7gk+RdZPzL0jSQPJjmV5M4kDyVZGB7zY0k+Ndz+VJIfG24vDI8r5/gc1TJ7y1KZq8tzC6PPMe1leW6hHt6xq8tt63lZKnOjz7AZ27Q8t9Dlc/GOi5fqyb1XjT7HtJeTe6+qH7vqJ+sjL33V6LNMczmya1999+tuqtdf/wujzzLl5d5n65Jz/rpVa/1Htdb9tdarkrwzyWdrrYeTfC7JO4aH3Zzkk8Ptu4b7GT7+2ToUEH1ZrZOs1kl3v7WvTNZyz9kzWSpz3f3W3rPVOjn3g2bMap1kZbJ+9UJvX2c3PrGaPzhzMve86NKxR5mq3Se+kRse/Wa+ePFSnnzJK8YeZ2reeuqhXP3V38vkf305P3Hd/zv2OJvu+Xy1/cMkf6+UspL1a4p+bVj/a0kuGdb/vSQffH4jsp31+AMpWQ+kjfDr7YcSs2fj1GFvz8W3nnooSXLbRXu62raXPvL1HHz8eL520Z6u4u/DTz6WE3/ysZya35FfXL5+7HE2VdkOB3VKKeMPwfOyVOa6DKWNo0cbsQRj6vXr7MiufbnzqVO5e+10V9t3z4suzYtfdGn+22P359bTJ8YeZ2qWylwuPfiB/OevfSoHH/rqrO+z+2qt1z1zZT+pzqh6PL2W/MVpjR63jdnT69fZW089lEMLO3Owsxd5HHz8eP7bY/fnb+zZn0MLO8ceZ2pW6yRf/cOP5MZXvinHdl/e5XOyvy1iNDP+28NfaiOQXH/EdtBrIN34xGoOzC92FRFJcuvpE/m51ZXc/tJXdfc95J6jv5xbXvU3csfFS909J51WgwuwcYoNxtbrKbbDO3ZltU6efiuDXizPLeS/v/RVueLhPx97lKn718uH8te+e18OPn587FGei2c9rSaO4AL1+kMJtosD84u5pMx1F0hJcnLvVdl94htjjzF1n7niQF7x6Ldy9ckHxx7lQrnmCKah19MasF0cPXsmxyZr3Z1iS9Zf6n9s9+VjjzF1b37gaF6yuLubbfMdHp4DgQSba+P9xnp8J/6rTz6YOy5eGnuMqbt0dSWrddLF2xf47g7PkVNrsLlW6yRHz57p7kLmZP0C9FsWd3f3S9bBx4/njqdO5ciufWOP8ry45giAba/Ha/16fR+1pTKXg/OLOTC/mA8/+djY45yLa44AmE09nspu30etp23beLXh3Wunc3jHrrHHeU76O1YJQJd6Orqyocdt2nD07Jkk668+3Lg9K/pJVQCYQb3+I97JXwTSrG3bbE0LAJ3qOZBm7dTh7EwKAJ3r9TTbrP0blbMzKQAws2YpkGZjSgBg5s3KqcPtPyEA0I1ZOHUojgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjgAAGuIIAKAhjnhODi3sHHuETXFk174szy2MPQYXoNf9dXjHrhyYXxx7jKk7ML+YL1z22rHH2BQ3v/bGHNm1b+wxpu5jV/1k3vKWfzn2GFtqW8TR/NgDcEGWylwOLezs8ofSVbsvz50XL3W5bb06OL+YpbItvpVN1eEdu/Khi/Z091w8OL+Yf/ZD12ayZ//Yo0xdufa9+fev/qnuAuk3X/22vPvdq3nbte8de5StU2sdfUlSl8pcTWKZoeX2nXu73G8PXPLqemTXvi63rdfl8I5dXe6v23fu7fK5uDy3UN927XvrbRftGX2WaS/vetdd9d2vu6m7bXvbte+tn/zkj9Tfv/LHR59lysu9z9olY4fRRhwlAmkWl96+AWwskz3765Fd+0afw3L+y6GFnV1+Dzm8Y1e3z8V3v+6memB+cfQ5pr1cf/0v1Ldd+97utu33r/zx+l//62I9tvvy0WeZ4rL948gym8sti7tHn2EzliO79nX7Q6nX5cD8YpeBdGB+sd5x8dLoc2zG8k9e8/buIiJJPXjg/fXag7d293w8tvvyeuTIZT3tM3Fk2bzl0MLO0WfYjOWWxd0CacaW5bmF7n4gJetH1m/fuXf0OTZjufOqN9bDO3aNPse0l19cvr6+5g1/d/Q5pr0cmF+sv/mbh+vy3MLos0xhEUeWzV381m7ZLstSmevyuZj0e6T2C5e9tsvT9Mdedk09eOD9o88x7WV5bqH+q3/1+R72mTiybP7S62/ty3MLPXwTeMEtPT4Xkz6P1C6VuXpy71XdfZ0tlbn68ItfXt/9uptGn2Xay20X7anvf/9X62TP/tFneR6LOLJszdLrb+1LZa7LQ/+W2Vw6uubj6WV5bqEe2bWvy0A6smtf/dfLh0afZdrLZM/++tM//av1gUtePfosz3F51jgqQ5yMqpQy/hBM1VKZy2qdjD3G1C2VuSzPLeTo2TNjjwJZnlvIymRt7DGmanluIYd37MpqneSXzpwce5ypWSpzuXvXvpzce1Xe/MDRsceZqgcueXX+n1e+Of/+m/89V/+vL489zoW6r9Z63TNXiiO4QEtlLktlrrsfSsymHn8RWZ5byMHh3cHvfOrUyNNM17Hdl+cli7tz6erK2KNM1bGXXZNPvuSH865HvpYrHv7zsce5EOIIpmXjHZl7+6EE28VSmcvB+cU8XCfdHak9tvvyrNZJDj5+fOxRpuqBS16dL168lJ/8/ndy0aPfGnuc8/WscdTfe+7DFhBFsLlW6yT3nD2TS4ZT2T25+uSDSZJbFnd39U/fXPHwn+cnv/+dfHXn3tzzokvHHud56WevwBZbrZOuvrHBdrNaJ7l77XSunlvo7mvt4OPHc2hh59OnD3tx0aPfyumTD2Zp177csrh77HGes76ebbDFHEGCzXf32unujh4lyVtPPZQD84s50FkgHXz8eG5/9Fv54ItfPrPb5pojAGZCj6/OS5LDO3bl2GStu2urDswv5lN79uevnPjGdv5F0gXZAMy2XgNp4whLb4G0VOby0ItfnrnH7h97lL+MC7IBmG0rk7Xurj9K1qNoZbLW3enD1TrJ3GP358iufWOPckH6e4YB0LVeXwyxWidZrZPuAilZv77qtov2jD3GeXNaDQC2mR7f3DNJDi3szN1rp8ceo+W0GgDMgl6Pjs3KKw/7+z8PAB3o8chRMhvXjW3v6QCA7mz3I2PbdzIAoFvb+ciYOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaIgjAICGOAIAaCyMPcDgoSSPD38yG/bF/po19tnssc9mi/01e3742VaWWutWD/KsSin31lqvG3sOzo/9NXvss9ljn80W+6sfTqsBADTEEQBAYzvF0UfHHoALYn/NHvts9thns8X+6sS2ueYIAGA72E5HjgAARjd6HJVSri+l/M9Sykop5YNjz8O6Usqvl1KOl1L+rFm3VEr5dCnl2PDnS4f1pZRy+7AP/7SUcu14k78wlVKuLKV8rpTy5VLKl0opHxjW22fbVCllZynlaCnlC8M++/Cw/pWllHuGffPbpZTFYf1Fw/2V4eNXjTn/C1kpZb6U8sellN8f7ttnnRk1jkop80n+bZJDSa5J8q5SyjVjzsTTPpbk+mes+2CSz9Rar07ymeF+sr7/rh6W9yX5lS2akb+wluTnaq3XJHlDkr89fC3ZZ9vXk0neVGt9XZLXJ7m+lPKGJD+f5CO11uUkjyR5z/D49yR5ZFj/keFxjOMDSb7S3LfPOjP2kaMDSVZqrV+vtZ5J8ltJbhh5JpLUWv8gyeozVt+Q5OPD7Y8neXuz/jfquj9MsreU8kNbMylJUmv9bq3188Pt72f9G/cVsc+2reH//cnh7o5hqUnelOR3hvXP3Gcb+/J3kry5lFK2aFwGpZT9Sd6W5FeH+yX2WXfGjqMrkny7uX//sB7kBP0AAAIpSURBVI7t6bJa63eH2w8muWy4bT9uI8Oh+x9Nck/ss21tOD3zJ0mOJ/l0kq8lOVFrXRse0u6Xp/fZ8PFHk1yytROT5BeS/IMkk+H+JbHPujN2HDGj6vrLHL3UcZsppexO8p+S/J1a62Ptx+yz7afWerbW+vok+7N+JP01I4/ED1BK+akkx2ut9409C5tr7Dh6IMmVzf39wzq2p+9tnHoZ/jw+rLcft4FSyo6sh9GdtdbfHVbbZzOg1noiyeeS/FjWT3Fu/LuX7X55ep8NH39Jkoe3eNQXur+a5KdLKd/I+mUgb0ryi7HPujN2HP1RkquHK/0Xk7wzyV0jz8Rf7q4kNw+3b07yyWb9TcMroN6Q5NHmVA5bYLiO4deSfKXW+m+aD9ln21Qp5WWllL3D7YuTvCXr14p9Lsk7hoc9c59t7Mt3JPls9UZ1W6rW+o9qrftrrVdl/efVZ2uth2OfdWf0N4Espbw16+dw55P8eq31n486EEmSUsp/TPLGrP8r099LcluS30vyiSSvSPLNJD9Ta10dfjD/ctZf3XYqyc/WWu8dY+4XqlLKTyT5H0m+mL+4FuIfZ/26I/tsGyqlvDbrF+vOZ/0X1U/UWv9pKeVVWT8qsZTkj5PcWGt9spSyM8l/yPr1ZKtJ3llr/fo401NKeWOSv19r/Sn7rD+jxxEAwHYy9mk1AIBtRRwBADTEEQBAQxwBADTEEQBAQxwBADTEEQBAQxwBADT+N3rVH1uCgb6fAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 720x720 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "figure(figsize=(10,10))\n",
     "imshow(np.log10(cov+1e-11),cmap='gist_stern');"
@@ -757,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -790,7 +781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -800,16 +791,7 @@
     "id": "4Us1pbt1dt-h",
     "outputId": "42bfcaff-0ed7-457f-95ce-108d1d8462eb"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-2.5765703e-09\n",
-      "10 loops, best of 3: 40.5 ms per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Computing the likelihood at our fiducial params, we should get 0 since we don't\n",
     "# have the normalization term\n",
@@ -841,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -851,20 +833,7 @@
     "id": "V9vX2W1UyRhm",
     "outputId": "e5985d95-374b-4150-8b28-e16218ab9d45"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Compile a function that computes the Hessian of the likelihood\n",
     "hessian_loglik = jax.jit(jax.hessian(likelihood))\n",
@@ -889,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -899,15 +868,7 @@
     "id": "NgrRoxsSB3UZ",
     "outputId": "ec070fd3-1f46-449c-e5c5-bca82ccae07d"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 loop, best of 3: 270 ms per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%timeit hessian_loglik(params).block_until_ready()"
    ]
@@ -926,7 +887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -936,33 +897,7 @@
     "id": "pmTdQeeXk8qB",
     "outputId": "3ac0f9a9-3dc5-4dd4-b58b-fa6a6d8e1291"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Text(14.5, 0.5, 'sigma8')"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3deZyN9f//8ceLMcY+tj7WWTJaZBsmDLKnTNlKmJBsE9FG6wclaf9Jq0/fLEkiVEp9CFkqjBj7EmPKGINKicJIeP3+OBefaTLM0RzXOTOv++12bnPOda5zzfOM5TnX9b7O+xJVxRhjjMmpAm4HMMYYE1isOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWnxSEiN4rIDhFJEZFHz/F8mIgsFZH1IrJJROKc5WWd5UdE5PUsr+nmrLtVRJ73ZX5jjDF/J776HIeIFASSgeuBdGANEK+q2zKt8xawXlX/IyI1gHmqGiEixYBooCZQU1WHOOuXBdYD9VX1gIi8A0xV1cXny1KuXDmNiIjI/TdpjDF52Nq1a39W1fJZlwf58Hs2AFJU9XsAEXkf6Ahsy7SOAiWd+6WAfQCqehRYLiJRWbZ5ObBTVQ84j78AbgXOWxwREREkJSX9g7dijDH5j4jsPtdyXxZHZWBPpsfpQMMs64wCForIPUAxoM0FtpkCXCkiEc72OgHBuZDVGGNMDrk9OB4PTFHVKkAc8K6IZJtJVX8FBgEzga+BVODUudYVkQQRSRKRpAMHDpxrFWOMMRfBl8WxF6ia6XEVZ1lm/YBZAKqaCIQA5c63UVX9VFUbqmossAPPOMq51ntLVWNUNaZ8+b8dojPGGHORfFkca4DqIhIpIsFAd2BulnXSgNYAInI1nuI47+6BiFzmfC0N3A1MzOXcxhhjzsNnYxyqelJEhgALgILAZFXdKiKjgSRVnQsMAyaIyAN4BsrvVOc0LxFJxTNwHiwinYC2zhlZr4hIHefbjFbVc+5xGGOM8Q2fnY7rT2JiYtTOqjLGGO+IyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXrDiMMcZ4xYrDGGOMV6w4jDHGeMWKwxhjjFesOIwxxnjFisMYY4xXfFocInKjiOwQkRQRefQcz4eJyFIRWS8im0Qkzlle1ll+RERez/KaeBHZ7Kz/uYiU8+V7MMYY81c+Kw4RKQi8AbQDagDxIlIjy2ojgFmqGg10B8Y7y48DI4EHs2wzCHgFaKmqtYFNwBBfvQdjjDF/F+TDbTcAUlT1ewAReR/oCGzLtI4CJZ37pYB9AKp6FFguIlFZtinOrZiI/OK8NsVn78BctMOHD7N7927S0tLYvXs36enpHDlyhIyMDI4fP87x48f/dv/EiRMUKVKEYsWKnfdWpkwZKlasSKVKlahUqRJly5ZFRNx+y8bkG74sjsrAnkyP04GGWdYZBSwUkXuAYkCb821QVf8UkUHAZuAosBMYfK51RSQBSAAICwu7iPjmQlSV5ORkEhMTWbt2Lbt27TpbFKdOnSI8PJzw8HDCwsKoWrUqFStWpEiRIoSEhJz9mvl+oUKFOH78OEePHs32tnfvXjZv3sy+ffvYv38/+/bt48iRI1SqVInw8HAiIiLOft+oqChq1qxJmTJl3P5RGZOn+LI4ciIemKKqY0UkFnhXRGqq6ulzrSwihYBBQDTwPfAa8BgwJuu6qvoW8BZATEyM+ih/vvLbb7+xevVqVq1aRWJiIqtWraJEiRLExsZy7bXX0qZNG8LCwggPD6d06dKXbC/g+PHj7N27l9TUVHbv3s3u3bv56quvmDhxIlu3bqV48eLUrFmTmjVrUqtWLWrWrEmNGjUoWrToJclnTF7jy+LYC1TN9LiKsyyzfsCNAKqaKCIhQDngp2y2WddZ9zsAEZkF/G3Q3eSeH3/8kVmzZjFjxgw2btxIdHQ0sbGx9OvXj4kTJ1KxYkW3IxISEkK1atWoVq3a355TVfbs2cOWLVvYvHkzixcv5uWXXyY5OZnKlSufLZNGjRoRGxtL6dKlXXgHxgQWXxbHGqC6iETiKYzuwO1Z1kkDWgNTRORqIAQ4cJ5t7gVqiEh5VT0AXA98m+vJ87nDhw/z0UcfMWPGDFavXk379u0ZMWIEbdq0ITg42O14XhERwsLCCAsLIy4u7uzykydPkpKSwpYtW9iwYQNjx45l9erVhIeH06RJE5o0aULTpk2JjIy08RNjshBV3x3FcU6vfRkoCExW1adFZDSQpKpznbOsJgDF8QyUP6yqC53XpuIZ/A4GDgFtVXWbiAwE7gP+BHYDd6rqL+fLERMTo0lJST55j3nJypUrGTt2LF988QWtWrUiPj6em2++Od8c0vnzzz/ZuHEjK1asOHs7ffr02SJp0qQJ0dHRFCpUyO2oxlwSIrJWVWP+ttyXxeEvrDjOb+3atYwcOZKtW7fy2GOP0b17d0JDQ92O5TpVJTU19S9FkpaWRsuWLYmLi6Ndu3ZUqVLF7ZjG+IwVhxXH32zevJnHH3+c1atXM3z4cPr160fhwoXdjuXXfvrpJxYsWMD8+fNZuHAhFStWpF27drRr144mTZoE3KE8Y87HisOK46xffvmFe++9l8WLF/PII48wcOBAihQp4nasgHPq1CnWrFnD/PnzmT9/PsnJybRs2fJskVStWvXCGzHGj2VXHDZXVT6zfPlyoqOjqVChAikpKTzwwANWGhepYMGCNGrUiCeffJLVq1eTnJzMLbfcwrJly4iOjqZevXo899xz7Nq1y+2oxuQq2+PIJ06dOsVzzz3Ha6+9xqRJk7jpppvcjpSnnTp1iq+++oqZM2fy0UcfERERQbdu3ejatavtiZiAYYeq8nFx/PDDD/Tq1Ys//viD6dOn24DuJXby5EmWLFnCrFmzmDNnDldeeSXdunXjtttuo1KlSm7HMyZbdqgqn0pJSaFBgwY0bNiQJUuWWGm4ICgoiLZt2zJx4kT279/PiBEjWLduHddccw3Nmzdn/Pjx/Pzzz27HNCbHrDjysF27dtG6dWtGjBjBmDFjCApye4YZExwcTFxcHO+88w779+9n6NChLF++nKioKLp3784XX3zB6dPnnHHHGL9hxZFH/fjjj7Ru3ZqHH36YhIQEt+OYcwgJCaFjx45Mnz6dXbt2cd111/Hggw8SFRXF008/zd69WWfoMcY/WHHkQceOHaN9+/bccccdDB58zsmDjZ8pXbo0gwcPZv369cyaNYu0tDRq1qxJ+/btmTt3LidPnnQ7ojFn2eB4HtSzZ09EhKlTp9o8SwHsyJEjzJ49mwkTJpCamkqfPn3o27fvOSdzNMYXbHA8n/jiiy9YuXIlb731lpVGgCtevDh9+vRh5cqVLFq0iIyMDBo1asRNN93EkiVLyA+/9Bn/ZMWRh5w4cYJ77rmHl19+2T7Ul8dcc801vPTSS6SlpdG5c2eGDBlCdHQ0U6dO5cSJE27HM/mMFUce8sorrxAZGUn79u3djmJ8pEiRIvTv358tW7bw3HPPMW3aNCIjI3n22Wc5ePCg2/FMPmHFkUfs3buX559/nldeecUOUeUDBQoU4MYbb2ThwoXMnz+fnTt3EhUVxeDBg0lOTnY7nsnjrDjyiGeeeYb+/ftTvXp1t6OYS6x27dpMnjyZbdu2UaZMGZo2bUrHjh358ssvbRzE+IQVRx5w8uRJZs+ebZ/XyOcqVKjAU089RWpqKnFxcQwYMIDmzZvbQLrJdVYcecCSJUuIiIjg8ssvdzuK8QNFixblrrvuYtu2bSQkJDBw4EBatGjB0qVL3Y5m8ggrjjxg1qxZdOvWze0Yxs8EBQXRs2dPtm3bRv/+/UlISKBFixYsW7bM7WgmwFlxBLgTJ04wZ84cbrvtNrejGD8VFBREr169+Pbbb+nTpw/9+/enZcuWfPnll25HMwHKiiPAffnll1xxxRWEhYW5HcX4uaCgIHr37s327dvp3bs3ffv2pVWrVnz11VduRzMBxoojwH377bfUr1/f7RgmgAQFBXHnnXeyfft2evXqRZ8+fWjTpg3r1q1zO5oJEFYcAS41NZWIiAi3Y5gAVKhQIfr06cP27du59dZbiYuLo1evXqSlpbkdzfg5K44AZ8Vh/qlChQoxaNAgdu7cSUREBNHR0TzyyCMcOnTI7WjGT1lxBDgrDpNbSpQowVNPPcWmTZv4+eefufLKKxk/frxN6W7+xoojwFlxmNxWuXJlJk2axMKFC/nggw+oW7cuixYtcjuW8SM+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nWr+EiGzIdPtZRF725XvwZydPnuTQoUOULVvW7SgmD6pTpw6LFy9mzJgxDBo0iA4dOtg8WAbwYXGISEHgDaAdUAOIF5EaWVYbAcxS1WigOzDeWX4cGAk8mHllVf1dVeueuQG7gY989R78XVBQEMHBwWRkZLgdxeRRIkKnTp3YunUrzZo1o3HjxgwfPtz+zuVzvtzjaACkqOr3qnoCeB/omGUdBUo690sB+wBU9aiqLsdTIOckIlcAlwFf53bwQFKqVCkOHz7sdgyTxxUuXJgHH3yQTZs2kZKSQq1atezwVT7my+KoDOzJ9DjdWZbZKKCniKQD84B7vNh+d2CmZjN7m4gkiEiSiCQdOHDAi80GltDQUCsOc8lUqlSJmTNn8uqrr5KQkECPHj348ccf3Y5lLjG3B8fjgSmqWgWIA94VkZxm6g7MyO5JVX1LVWNUNaZ8+fK5ENU/2R6HcUNcXBxbtmyhcuXK1KpViwkTJnD69Gm3Y5lLxJfFsReomulxFWdZZv2AWQCqmgiEAOUutGERqQMEqera3IkauEqVKmXn2xtXFCtWjBdeeIFFixYxadIkmjVrxtatW92OZS4BXxbHGqC6iESKSDCePYS5WdZJA1oDiMjVeIojJ8eV4jnP3kZ+ctlll7F//363Y5h8rE6dOqxYsYIePXrQokULGzzPB3xWHKp6EhgCLAC+xXP21FYRGS0iHZzVhgEDRGQjniK488yYhYikAi8Bd4pIepYzsrpixQFATEwMq1evdjuGyecKFizIoEGDzg6e165dm5UrV7ody/iI5Icrg8XExGhSUpLbMXxi1apVDBo0iPXr17sdxZizPv74YwYOHEj//v15/PHHCQ4OdjuSuQgislZVY7Iud3tw3PxD0dHRJCcnc+TIEbejGHNWp06d2LBhAxs3biQ2NpZt27a5HcnkIiuOAFe4cGHq1KnDmjVr3I5izF9UqFCBuXPnMnDgQJo3b86rr75qZ17lEVYceUBsbCyJiYluxzDmb0SEAQMGkJiYyIwZM7jhhhtIT093O5b5h6w48oDGjRuzfPlyt2MYk62oqCi+/vprWrRoQb169Zgxw85tCWQ2OJ4H/Pbbb4SFhZGSkkK5chf8GIwxrlq7di09e/akbt26vPnmm5QqVcrtSCYbNjieh5UsWZKbbrrJfoszAaF+/fqsW7eOMmXKEBMTw6ZNm9yOZLxkxZFH9O7dm3feecftGMbkSJEiRXjjjTd48sknad26NVOnTnU7kvGCFUce0bp1a3744Qeb8sEElNtvv51ly5bx9NNPM3DgQI4fz3ZCbONHrDjyiIIFC9KrVy/b6zAB55prrmHNmjX8/PPPXHfddaSmprodyVyAFUce0rt3b6ZNm2bXiDYBp2TJksyePZv4+HgaNmzI559/7nYkcx5WHHnIVVddRUREBJ988onbUYzxmogwdOhQPvjgA/r168eoUaM4deqU27HMOVhx5DHDhw9n1KhR9gldE7Cuu+461q5dy9KlS7n55pv57bff3I5ksrDiyGPi4uIoVqwYs2fPdjuKMRetQoUKLF68mMjISJo2bcqePXsu/CJzyVhx5DEiwujRo2033wS8oKAg3njjDXr37k1sbCzr1q1zO5JxWHHkQddffz3lypVj+vTpbkcx5h8REYYNG8Yrr7zCDTfcwH//+1+3IxmsOPKkM3sdTz75JH/++afbcYz5x2699VY+/fRT+vfvz/jx492Ok+9ZceRRLVu2JCwsjHfffdftKMbkikaNGrFixQpeffVVhg0bZieAuOi8xSEil4vIZBEZIyLFRWSCiGwRkdkiEnFpIpqLNWbMGJ544gl+//13t6MYkysuv/xyVq5cSVJSErfddhvHjh1zO1K+dKE9jinAGuAIsArYDrQDPgcm+zSZ+ccaN27M9ddfz8iRI92OYkyuKVOmDAsXLqRIkSK0bt2aQ4cOuR0p37lQcZRQ1f+o6nNASVUdq6p7VHUSUPoS5DP/0AsvvMD7779vZ6SYPKVw4cK8++67NGzYkDZt2nDw4EG3I+UrFyqO0yJyhYhcCxQVkRgAEYkCCvo8nfnHypUrx3PPPUdCQoJNRWLyFBFh3LhxtGrVipYtW3LgwAG3I+UbFyqOh4FPgalAJ+AxEUkBVgJ2/CNA9O7dm9DQUMaOHet2FGNylYjw/PPP0759e1q0aMEPP/zgdqR8Ieh8T6rqYuDKTIuWi0g54FdVtU+XBQgRYeLEiVx77bW0b9+eGjVquB3JmFwjIowZM4bChQvTokULFi9eTOXKld2OlaedtzgyE5GaQA0gxHmMqtrVVwJEREQETz31FH369GHFihUEBeX4j96YgDBy5EiCg4Np3rw5S5YsISwszO1IeVaOPschIk8Arzm3lsALQAcf5jI+kJCQQIkSJRgzZozbUYzxiUceeYTBgwfTvHlzdu3a5XacPCunHwDsArQGflDVPkAd4IJXmBeRG0Vkh4ikiMij53g+TESWish6EdkkInHO8rLO8iMi8nqW1wSLyFsikiwi20Xk1hy+h3yvQIECTJs2jYkTJ9r1Dkye9cADD/Dggw/SokULmxzRR3J6vCJDVU+LyEkRKQn8BFQ93wtEpCDwBnA9kA6sEZG5qrot02ojgFmq+h8RqQHMAyKA43gG32s6t8yGAz+p6hUiUgAok8P3YPDMOjpjxgy6dOnC6tWrCQ8PdzuSMblu8ODB/PHHH9xwww0sX76cMmXsv4nclNM9jiQRCQUmAGuBdUDiBV7TAEhR1e9V9QTwPtAxyzoKlHTulwL2AajqUVVdjqdAsuoLPOusd1pVf87hezCO6667jocffpguXbrwxx9/uB3HGJ8YOnQocXFxdOjQgYyMDLfj5Ck5Kg5VvVtVD6nqm3j2IHo7h6zOpzKQeT8x3VmW2Sigp4ik49nbuOd8G3TKC+ApEVnnTH3yr5y8B/NXQ4cOJSwsjPvvv9/tKMb4zAsvvEBERATx8fH2OaZclONJDkWktoh0AOoBUSJySy58/3hgiqpWAeKAd53DT9kJAqoAK1W1Hp69nv+XTd4EEUkSkST7YNDfiQhvv/02ixcvtokQTZ5VoEABJk+ezLFjxxg8eDCq6nakPCGnZ1VNxjM31a1Ae+d28wVetpe/joNUcZZl1g+YBaCqiXhO9S13nm3+AhwDPnIez8ZTZH+jqm+paoyqxpQvX/4CUfOnkiVL8uGHHzJ06FA2b97sdhxjfCI4OJgPP/yQpKQkRo8e7XacPCGng+ONVNXbT42tAaqLSCSewugO3J5lnTQ8Z2tNEZGr8RRHtrsHqqoi8inQAljivHZbduubC6tVqxbjxo2jc+fOrFy5kssuu8ztSMbkuhIlSjBv3jyaNGlCxYoVSUhIcDtSQMtpcSSKSI0sZ0Sdl6qeFJEhwAI881pNVtWtIjIaSFLVucAwYIKIPIBnoPxOdfYlRSQVz8B5sIh0Ato63/8RPIe0XsZTMhcaazEX0LNnT3bs2MFNN93E0qVLKV68uNuRjMl1//rXv/j8889p1qwZVapUIS4uzu1IAUtycsxPRJoDc4EfgD8AwbMDUNu38XJHTEyMJiUluR3Dr6kqAwYMID09nU8//ZRChQq5HckYn0hMTKRTp06sWrWKyMhIt+P4NRFZq6oxWZfndHB8EtALuJH/jW+0z714xm0iwptvvkmhQoXo16+fDSKaPCs2Npbhw4fTpUsXjh8/1xn/5kJyWhwHVHWuqu5S1d1nbj5NZi65oKAgZs6cyc6dO3nsscfcjmOMz9xzzz1Ur16de++91+0oASmnxbFeRKaLSLyI3HLm5tNkxhVFixbls88+4+OPP+aVV15xO44xPnFmxuivv/6at99+2+04ASeng+NF8IxttM20TPnfabEmDylbtiwLFiygadOmVKhQgW7durkdyZhcV7x4cT788EOaN29OdHQ0devWdTtSwMhRceTgU+ImjwkPD2fevHm0adOGkiVL0q5dO7cjGZPratSowWuvvUaXLl1ISkoiNDT0wi8yOT6r6tVzLD6M57TaT3I9VS6zs6ou3qpVq+jQoQMTJ06kQwebSd/kTffddx9paWl89NFHiIjbcfzGPz2rKgSoC+x0brXxfBK8n/N5CpNHNWrUiHnz5jFgwAA+/PBDt+MY4xMvvvgiqampTJ1q16bLiZyOcdQGmpy5XKyI/Af4GmgK2FwVeVxMTAwLFiygXbt2nDhxgvj4eLcjGZOrgoODefvtt2nbti1t2rSxS89eQE73OEoDmT9OXAwo4xSJzcudD9StW5dFixYxbNgw3nnnHbfjGJPr6taty913381dd91ln2O6gJwWxwvABhF5W0SmAOuBF0WkGPCFr8IZ/1KzZk2WLFnC8OHDmThxottxjMl1//73v9mzZw/Tp093O4pfy9HgOICIVMRzcSaANaq6z2epcpkNjueunTt30rp1ax599FHuvvtut+MYk6tWr15Nx44d2bZtG6VLl3Y7jqsuanBcRK5yvtYDKuK5MNMeoIKzzORD1atX58svv+TFF1/kueees916k6c0aNCAW265hUcffdTtKH7rvHscIvKWqiaIyNJMi8++QFVb+TJcbrE9Dt/Yu3cvN998M9deey1vvPGGTYxo8ozDhw9To0YNZs+eTePGjd2O45qL2uNQ1TOT1v8H6KiqLYGleD7D8WCupzQBpXLlynz11Vekp6fTvn17fvvtN7cjGZMrSpUqxTPPPMMjjzxie9TnkNPB8RGq+puINAVaARPxlInJ50qUKMHcuXOJjIykadOm7Nmz58IvMiYA9OzZkwMHDrBo0SK3o/idnBbHKefrTcAEVf0vEOybSCbQBAUFMX78eHr16kVsbCzr1693O5Ix/1jBggUZNWoUjz/+uO11ZJHT4tgrIv8HdAPmiUhhL15r8gER4aGHHuLll1+mbdu2zJs3z+1IxvxjXbt25ciRI/b3OYuc/uffFc8lYG9Q1UNAGeAhn6UyAatLly7MnTuXfv368Z//2NFME9gKFCjAk08+aXsdWeSoOFT1mKp+pKo7ncf7VXWhb6OZQBUbG8vy5ct5+eWXGTJkCCdOnHA7kjEXrXPnzpw+fZqPP/7Y7Sh+ww43GZ+oVq0a33zzDXv27KF58+Y2aG4C1pm9jieeeML2OhxWHMZnQkNDmTNnDp06daJBgwZ88YXNTmMCU/v27Tlx4gSJiYluR/ELVhzGpwoUKMAjjzzC9OnTueOOO3j66ac5ffq027GM8YqI0Lt3b5vg02HFYS6Jli1bsmbNGubNm0fHjh359ddf3Y5kjFd69erF7NmzycjIcDuK66w4zCVTuXJlli1bRlRUFDExMfZ5DxNQqlSpQv369Zk7d67bUVxnxWEuqUKFCjFu3DieffZZ2rZty6RJk2zA0QQMO1zlYcVhXNG1a1e++uorxo0bR7du3Th48KDbkYy5oM6dO5OYmMj+/fvdjuIqnxaHiNwoIjtEJEVE/jZHsYiEichSEVkvIptEJM5ZXtZZfkREXs/ymmXONjc4t8t8+R6M71x99dUkJSVRpUoVateuzYIFC9yOZMx5FStWjE6dOjFr1iy3o7jKZ8UhIgWBN4B2QA0gXkRqZFltBDBLVaOB7sB4Z/lxYCTZz8DbQ1XrOrefcj+9uVRCQkJ46aWXmDp1KgMGDGDIkCEcO3bM7VjGZKt169YsX77c7Riu8uUeRwMgRVW/V9UTwPtAxyzrKFDSuV8K2AegqkdVdTmeAjH5QKtWrdi0aROHDh2iXr16rFmzxu1IxpxTbGxsvv88hy+LozKeqwWeke4sy2wU0FNE0oF5wD053PbbzmGqkSIi51pBRBJEJElEkg4cOOBldOOG0NBQpk2bxujRo7n55psZPXo0J0+edDuWMX9x+eWXc+LEiXw9G4Lbg+PxwBRVrQLEAe+KyIUy9VDVWsB1zq3XuVZS1bdUNUZVY8qXL5+roY1vde3alXXr1rFixQqaNGlCcnKy25GMOUtE8v1ehy+LYy9QNdPjKs6yzPoBswBUNREIAcqdb6Oqutf5+jswHc8hMZPHVK5cmc8//5w77riDxo0bM27cONv7MH7DisN31gDVRSRSRILxDH5n/eRMGtAaQESuxlMc2R5XEpEgESnn3C8E3Axs8UF24wdEhMGDB7Ny5Uo+++wzGjZsiF073vgDKw4fUdWTwBA81/H4Fs/ZU1tFZLSIdHBWGwYMEJGNwAzgTnU+DSYiqcBLwJ0iku6ckVUYWCAim4ANePZgJvjqPRj/cMUVV/DFF19w//33c/PNN3Pffffx+++/ux3L5GPVq1cnNTXV7Riukfzwqd2YmBi131Tzhl9++YWHH36YhQsX8tprr9GpUye3I5l86OjRo5QrVy7Pz1slImtVNSbrcrcHx43xStmyZZk0aRLTpk3jscceo2PHjqSlpbkdy+QzRYsW5eTJk/n2ImVWHCYgNW/enA0bNhATE0O9evVs8NxcUiJCqVKlOHz4sNtRXGHFYQJW4cKFGTly5NnB8wYNGrBy5Uq3Y5l8olSpUhw6dMjtGK6w4jAB78zg+bBhw+jWrRvx8fF2+Mr4nO1xGBPgRIQePXqwfft2rrzySqKjo3n88cc5cuSI29FMHpWRkUFISIjbMVxhxWHylGLFijFq1Cg2bNjAd999x1VXXcWUKVM4deqU27RRwb4AABInSURBVNFMHqKq7N69m4iICLejuMKKw+RJVatW5b333uODDz5gwoQJ1KtXj4ULF7ody+QRP/30E0WLFqV48eJuR3GFFYfJ0xo1asTy5ct54oknGDx4MDfccAMbN250O5YJcKmpqfl2bwOsOEw+ICLccsstbNu2jfbt29O2bVt69eplkyeai2bFYUw+UahQIYYMGcLOnTu54ooraNKkCb1792bnzp1uRzMBJjk5mcjISLdjuMaKw+Q7JUuWZOTIkaSkpFCtWjViY2O58847SUlJcTuaCRCffPIJN954o9sxXGPFYfKtUqVK8fjjj5OSkkJkZCSNGjWiT58+fPfdd25HM34sJSWFPXv20Lx5c7ejuMaKw+R7oaGhPPHEE6SkpBAeHk7Dhg3p27cv33//vdvRjB+aPXs2t956K0FBQW5HcY0VhzGO0NBQRo0axc6dO6latSoNGjSgX79+7Nixw+1oxo/MnDmTbt26uR3DVVYcxmRRunRpnnzySZKTk6latSrNmjWjffv2LF26lPxwGQKTva1bt/LTTz/RtGlTt6O4yorDmGyUKVOGUaNGkZqaSocOHbj77rupV68e7777br6dTjs/U1UeeughHnjgAQoWLOh2HFdZcRhzAUWKFGHAgAFs3bqVZ555hqlTpxIZGcmzzz7LwYMH3Y5nLpFPP/2UXbt2cd9997kdxXVWHMbkUIECBWjXrh2LFi1i/vz5JCcnExUVxeDBg+2zIHlcRkYG999/P6+99hrBwcFux3GdFYcxF6F27dq8/fbbbN26ldKlS9O4cWM6duzIvHnzbELFPOj555+nfv36tGnTxu0ofsGuOW5MLjh27BjvvfceEyZMYP/+/fTt25e+ffsSHh7udjTzD61fv57rr7+edevWERYW5nacS8quOW6MDxUtWpQBAwawevVqPvvsMw4ePEi9evW44YYb+OCDD2wwPUClp6fToUMH/u///i/flcb5WHEYk8vq1KnDa6+9Rnp6OnfccQevv/46VatW5aGHHmL79u1uxzM5dPDgQW666Sbuvfdebr31Vrfj+BUrDmN8pEiRIvTo0YNly5bx9ddfU6BAAVq0aEGzZs2YMmVKvr3saCA4dOgQbdu25frrr+fBBx90O47fseIw5hK44ooreP7559mzZw8PPPAAc+bMoWrVqnTs2JHp06fz+++/ux3ROPbu3Uvbtm1p2rQpL774IiLidiS/Y8VhzCVUqFAhOnfuzCeffEJaWhq33HIL06ZNo0qVKnTp0oVZs2Zx9OhRt2PmW/PmzaN+/fp06NCBcePGWWlkw6fFISI3isgOEUkRkUfP8XyYiCwVkfUisklE4pzlZZ3lR0Tk9Wy2PVdEtvgyvzG+FBoaSu/evZk3bx7ff/897dq1Y+LEiVSqVInu3bszZ84cjh8/7nbMfOHPP//k4Ycf5q677mLWrFmMGDHCSuM8fFYcIlIQeANoB9QA4kWkRpbVRgCzVDUa6A6Md5YfB0YC5zy4KCK3AEd8kdsYN5QtW5Z+/fqxcOFCUlJSaNGiBa+++ioVKlQgPj6eadOmceDAAbdj5kmpqak0a9aMrVu3sn79epo1a+Z2JL/nyz2OBkCKqn6vqieA94GOWdZRoKRzvxSwD0BVj6rqcjwF8hciUhwYCozxVXBj3FS+fHkGDhzI0qVL2b59Oy1btuTDDz8kKiqKBg0a8MQTT7Bq1Sr7oOE/dOjQIUaOHEn9+vXp0qULn376KeXKlXM7VkDwZXFUBvZkepzuLMtsFNBTRNKBecA9OdjuU8BY4FguZDTGr1WoUIGEhATmzJnDgQMHeP7558nIyGDAgAFUqFCBHj162N6Il37//XfGjBlDVFQUe/fuJSkpiWHDhlGggA355pTbP6l4YIqqVgHigHdFJNtMIlIXqKaqcy60YRFJEJEkEUmyf1QmLwgODqZly5a88MILbN68mXXr1tG8efO/7I38+9//Zt68efz6669ux/U7x44d48UXXyQqKopvv/2WlStXMnny5Hx97fCL5ctLWO0FqmZ6XMVZllk/4EYAVU0UkRCgHPBTNtuMBWJEJBVP9stEZJmqtsi6oqq+BbwFnilHLv5tGOOfqlatSkJCAgkJCZw4cYIVK1awdOlSxo4dy+rVqwkPD6dJkyY0adKEpk2bEhkZme8GfE+ePMmSJUuYMWMGn3zyCa1atWLJkiVcc801bkcLaD6bq0pEgoBkoDWewlgD3K6qWzOtMx+YqapTRORqYDFQWZ1QInInEKOqQ86x/QjgM1WteaEsNleVyW/+/PNPNm7cyIoVK87eTp8+fbZImjRpQq1atShSpIjbUXOdqrJq1SqmT5/O7NmzCQsLIz4+nq5du1K5ctaj5eZ8spuryqeTHDqn174MFAQmq+rTIjIaSFLVuc5ZVhOA4ngGyh9W1YXOa1PxDJwHA4eAtqq6LdO2I7DiMCZHVJXdu3efLZGVK1eyY8cOwsLCqFWrFjVr1qRmzZrUqlWLatWqBdT1tFWVHTt2kJiYSGJiIosWLSIkJITbb7+d7t27U716dbcjBixXisNfWHEY83d//vknycnJbNmyhS1btrB582a2bNnCvn37uPLKK88WylVXXUV4eDjh4eGEhoa6HZtff/2VtWvXni2Kb775hhIlShAbG0tsbCwtWrSgVq1a+e6wnC9YcVhxGJMjR48eZdu2bWcLZceOHezevZvdu3cjIoSHhxMWFkalSpWoVKkSFStWpFKlSpQvX55ixYr95Va0aNEcna106tQpMjIyOH78OEePHmXv3r2kpaWd/b5n7qelpXH69Gnq1q1LbGwsjRo1IjY2looVK16Cn0z+Y8VhxWHMP6KqHDp0iNTUVPbs2cP+/fvZt28f+/btY//+/Rw4cICjR4/+5ZaRkUFISMhfiiRzSRw/fpyMjAxOnTpFkSJFCAkJoUiRIlSuXPnsXk5YWNhf7oeGhtrexCWSXXEEzoFMY4yrRITSpUtTunRpoqOjc/Sa06dPk5GRcbZIjh07RlBQECEhIWdLIiQkhEKFClkZBBArDmOMzxQoUODs3obJO9z+AKAxxpgAY8VhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxis+LQ4RuVFEdohIiog8eo7nw0RkqYisF5FNIhLnLC/rLD8iIq9nec3nIrJRRLaKyJsiUtCX78EYY8xf+aw4nP/Q3wDaATWAeBGpkWW1EcAsVY0GugPjneXHgZHAg+fYdFdVrQPUBMoDt/kgvjHGmGz4co+jAZCiqt+r6gngfaBjlnUUKOncLwXsA1DVo6q6HE+B/PUFqr85d4OAYGcbxhhjLhFfFkdlYE+mx+nOssxGAT1FJB2YB9yTkw2LyALgJ+B34INs1kkQkSQRSTpw4ICX0Y0xxmTH7cHxeGCKqlYB4oB3ReSCmVT1BqAiUBholc06b6lqjKrGlC9fPjczG2NMvubL4tgLVM30uIqzLLN+wCwAVU0EQoByOdm4qh4HPuHvh7+MMcb4kC+LYw1QXUQiRSQYz+D33CzrpAGtAUTkajzFke1xJREpLiIVnftBwE3Adh9kN8YYk40gX21YVU+KyBBgAVAQmKyqW0VkNJCkqnOBYcAEEXkAzyD3naqqACKSimfgPFhEOgFtgV+AuSJSGE/pLQXe9NV7MMYY83fi/D+dp8XExGhSUpLbMYwxJqCIyFpVjcm63O3BcWOMMQHGisMYY4xXrDiMMcZ4JV+McYjIAWC32zmyUQ742e0QXrC8vhdomS2vb7mZN1xV//ZBuHxRHP5MRJLONfjkryyv7wVaZsvrW/6Y1w5VGWOM8YoVhzHGGK9YcbjvLbcDeMny+l6gZba8vuV3eW2MwxhjjFdsj8MYY4xXrDiMMcZ4xYojl+XgOutDRWSbc431xSISnum5UyKywbnNzbRcRORpEUkWkW9F5F4/z/t1puX7RORjP8/bWkTWOcuXi0iUn+dt5eTdIiLvODNF+0PeMBFZ6Pwd3SYiEc7ySBH5xtnmTGe2bH/OO8TZnopIji7z4HLe95xtbhGRySJSKDczn5Oq2i2XbnhmAf4OuBzPZW03AjWyrNMSKOrcHwTMzPTckWy22weYChRwHl/mz3mzvP5D4A5/zgskA1c79+/Gc3Exv8yL55e9PcAVzuPRQD8/ybsMuN65XzzTerOA7s79N4FBfp43GogAUoFyuZHVx3njAHFuM3Lr53u+m+1x5K4LXmddVZeq6jHn4So8F7i6kEHAaFU97WzjJz/PC4CIlMRzhcbc2uPwVV7FM4U/QClgnx/nLQucUNVk5/Ei4Fa384pIDSBIVRc56x1R1WMiInj+Dpy5xPM7QCd/zevcX6+qqbmU8VLknacOYDVe/Bu9WFYcuSsn11nPrB8wP9PjEPFcJ32VeK5BckY1oJvz3HwRqe7nec/oBCxW1d/+eVTAd3n7A/NEJB3oBTznx3l/BoJE5Mwnibvw1yttupX3CuCQiHwkIutF5EURKYin6A6p6skcbtPtvL7k07zOIapewOe5mPmcfHYhJ3N+ItITiAGaZ1ocrqp7ReRyYImIbFbV7/BcW/24qsaIyC3AZOA6P857Rjww8VLmPMPLvA8Acar6jYg8BLyEp0z8Mq+IdAfGieeCZguBU5cyazZ5g/D8nYzGc2XPmcCdeC7v7Dov8k5yI19WF5l3PPCVqn7t63y2x5G7cnKddUSkDTAc6KCqf5xZrqp7na/f4zmeGe08lQ585NyfA9T287w4g4oNgP/mUlaf5BWR8kAdVf3GWW0m0Nhf8zqPE1X1OlVtAHyFZ4zG7bzpwAbnMMxJPIcn6+G5amdopgH8c27Tj/L6ks/yisgTQHlgqI+y/5WvB1Hy0w3PbwXfA5H8b/DrmizrROMZIKueZXlpoLBzvxywE2fgDM+hk77O/RbAGn/O6ywbCLzj7z9fZ5s/87/B5n7Ah/6a13l8mfO1MLAYaOUHeQs665d3Hr8NDHbuz+avg+N3+3PeTOukkruD4776+fYHVgJFcivrBd/LpfpG+eWG5wyHZOcPf7izbDSe3x4AvgB+BDY4t7nO8sbAZucvx2YynSkDhOL5zX0zkIjnN2S/zes8vwy4MUB+vp0zPbcMuNzP874IfAvsAO73h5+v89z1wCYn7xQg2Fl+OZ5B2xQ8JVLYz/Pei+c3/JN4TpSY6Od5TzrbO/Oax3P7313Wm005Yowxxis2xmGMMcYrVhzGGGO8YsVhjDHGK1YcxhhjvGLFYYwxxitWHMach4hUEZFPRGSniHwnIq/k5uyuxgQiKw5jsuFM0PcR8LGqVsczX1Bx4GlXgxnjMisOY7LXCs8cYW8DqOopPPNa9RWRu0XkYxFZJCKpzjUchjoT0K0SkTIAIlJNRD4XkbXiuU7JVZmWrxKRzSIyRkSOOMuLO9dhWOc81zGbbIhIhIhsF5Ep4rlWy3si0kZEVjh7SA18/hMy+ZIVhzHZuwZYm3mBemb6TcMzfURN4BbgWjx7IcdUNRrPp/vvcF7yFnCPqtYHHsQzER3AK8ArqloLz6eUzzgOdFbVeniuzTDW2fPJThQwFrjKud0ONHW+178v4j0bc0E2O64xF2+pqv4O/C4ih4FPneWbgdoiUhzP1CGzM/3fX9j5Gsv/rksxHfh/zn0BnhGRZsBpPNNu/wv4IZsMu1R1M4CIbMUzjb2KyGY8FyMyJtdZcRiTvW14rndxlnNxqjA88wP9kemp05ken8bzb6sAnmtR1PXie/bAM8tpfVX9U0RSgZDzrH+hDMbkOjtUZUz2FgNFReQOAOfCOWPxTDB37DyvA84e1tolIrc5rxcRqeM8vYr/Xbmve6aXlQJ+ckqjJRCeG2/EmNxkxWFMNtQzA2hn4DYR2YlnVtPjeDd20APoJyIbga3871Kh9wNDRWQTnnGKw87y94AY51DTHcD2f/xGjMllNjuuMS4QkaJAhjMe0R2IV9Vsz6Ayxp/YMVBj3FEfeN05Y+oQ0NflPMbkmO1xGOPnRKQsnvGWrFqr6i+XOo8xVhzGGGO8YoPjxhhjvGLFYYwxxitWHMYYY7xixWGMMcYrVhzGGGO88v8Bjugk/8WdHIIAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light",
-      "tags": []
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can now plot contours obtained with this \n",
     "plot_contours(F, params, fill=False);\n",
@@ -988,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -1006,7 +941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -1020,7 +955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1030,20 +965,7 @@
     "id": "t3kVMfEaGyuJ",
     "outputId": "339ec1c1-4f47-43e9-f692-9c9070f5f0a2"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
-      "/usr/local/lib/python3.6/dist-packages/jax/lax/lax.py:5222: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
-      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can now evaluate the jacobian at the fiducial cosmology\n",
     "dmu = jac_mean(params)"
@@ -1051,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1061,27 +983,14 @@
     "id": "H6uzzV-jHnNe",
     "outputId": "ed61a0df-5f6f-485b-ebbc-33ddaaa15c20"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(500, 2)"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dmu.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1091,15 +1000,7 @@
     "id": "X9ZDB3RtHFnG",
     "outputId": "07f53328-fb3a-4ead-bdaf-d6528136a8aa"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10 loops, best of 3: 31.6 ms per loop\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For fun, we can alsi time it\n",
     "%timeit jac_mean(params).block_until_ready()"
@@ -1117,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -1131,7 +1032,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1141,21 +1042,7 @@
     "id": "zUv4GmcVH1z8",
     "outputId": "4b7fb3e2-3271-4492-f781-45c205c2e57c"
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEJCAYAAACDscAcAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO3dd3xUVfrH8c8zCUloSQRCJ4aqxNAjvQmoCK7ACgKKiqKujbW7rq67/Oyru7oquq6ggigosBZcQSxL6C10Qg09oSR0khBCMuf3x72wM0MSMpjJTXner9e8mHtu4TuUPHPvufccMcaglFJKFZXL6QBKKaXKFi0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKLwEtHCLSX0S2ikiyiDyTz/poEZknImtEZL2IDLDba9rtGSIy3mef4fa2SSLy10DmV0opdSEJ1HMcIhIEbAOuBVKAlcBIY8wmj20+BNYYY/4pIrHAbGNMjIhUBdoBcUCcMeZhe/uawBqggzEmXUQmA58aY34pLEutWrVMTExM8X9IpZQqx1atWnXYGBPl2x4cwN+zI5BsjNkJICJfAIOATR7bGCDcfh8B7AcwxmQCi0Skmc8xmwDbjTHp9vLPwM1AoYUjJiaGxMTEX/FRlFKq4hGRPfm1B7JwNAD2eSynAJ18thkH/CgiY4GqQL+LHDMZuEJEYuzjDQZCiiGrUkqpInK6c3wkMMkY0xAYAEwRkQIzGWOOAQ8AXwILgd1AXn7bish9IpIoIonp6en5baKUUuoSBLJwpAKNPJYb2m2exgDTAYwxS4EwoFZhBzXGfGeM6WSM6QJsxepHyW+7D40x8caY+KioCy7RKaWUukSBLBwrgeYi0lhEQoARwCyfbfYCfQFEpCVW4Sj09EBEatu/XgY8CEws5txKKaUKEbA+DmNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOspHG/s2LxHZjdVxHiIig4Hr7Duy3haRNvZv84IxJt8zDqWUUoERsNtxS5P4+Hijd1UppZR/RGSVMSbet93pznGllFJljBYOpZRSftHCoZRSyi9aOJRSSvlFC4dSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyixYOpZRSfgkO5MFFpD/wNhAETDTGvOazPhqYDETa2zxjjJktIjWBmcDVwCRjzMMe+4wEngUMsB8YZYw5HMjPoX6900ePcvrIEc4cP07OyZOcOXGC3FOnOHvqFLmnTpEZHExa48aEhYVRtWpVr1d1Y6gSEUFYZCTi0u86SjktYIVDRIKA94BrgRRgpYjMMsZs8tjsT8B0Y8w/RSQWmA3EANnA80Cc/Tp3zGCsQhRrjDksIq8DDwPjAvU51MUZYzh06BApmzdz9rvvOLN9O7J3L2FpaUScOEGd7GwuM4bKhRzjF2BYAesWAd0AN5ABnAoK4mhYGJnVq3OmZk3cdeoQFB1N1dhYanboQL2OHQmpVq2YP6VS6pxAnnF0BJKNMTsBROQLYBDgWTgMEG6/j8A6g8AYkwksEpFmPscU+1VVRI7Y+yYH7BOofGVmZpKYmMjSpUtZunQpy5YtIy0tjcuB3Zd4zLBC1lW1f3UB1YHqeXnUz8yEzEw4eBCSkry2dwMHXC7SqlXjyxtvpEHXrsTFxREXF0fNmjUvMaFS6pxAFo4GwD6P5RSgk88244AfRWQs1s+HfoUd0BhzVkQeADYAmcB24KH8thWR+4D7AKKjoy8hvjrn1P79bHjtNc4mJBC1YwfvnT7N+8ZcsF0qkId1zdFfhZ2NVC1kXX5cQD23m3onT9J16lSypk49v65evXrExcUxODycVuHh1OzVi8tvuIGqtWtfQmqlKqaA9nEUwUisPoy/i0gXYIqIxBlj3PltLCKVgAeAdsBO4F3gj8BLvtsaYz4EPgSIj4+/8KecKlT28eOsffVVzNSptE1JoavHum7A+/nsk4t1ytgon3VngVMinBEhx+UiJyiIs0FBnA0OJjc4mEPVqzOkfXuys7PJzMw8/8rIyCBv/37OuN2E+vkZdgBZPm0HDhzgwIED3An0APjkE9zA9tBQDjRujKtHD6JvvZVGPXtqf4pSBQhk4UjF+2dIQ7vN0xigP4AxZqmIhAG1gLQCjtnW3nYHgIhMB54pxswVWl5ODuv+8Q8yJ06k9fbtdC5guy75tFWpUoWmTZuyIjOTnVWqYBo1IqRZM6rHxREVH09UXBw1QkIK/f0HXCRfbnY2mWlpHE9O5sSWLWRs387ZPXswKSmEHDpE9aNHqZWVRR23GxfWaWlB4jzeu4DmZ87QfMsW2LIFJkzgkMvFznr1OBMfT9SgQbQYPpxKVapcJKFSFUMgC8dKoLmINMYqGCOAW3222Qv0BSaJSEusS93phRwzFYgVkShjTDpWx/vmYk9ewZzNymLp/ffTZOpU2uflXXT7xkDHmBiu6NGDzp0706VLF1q1akVwcGBPYIPDwoiIjiYiOhr69ClwuzMnT3Jw5Uoik5N57fhxNmzYwMaNG9m8eTM5OTkEA1de5Peq43ZTJzUVUlPh22/JuvtukiIiOB4XR6Vnn6XjtddSqVKlYv18SpUVYvK5Vl1sBxcZAPwD67L3x8aYl0XkBSDRGDPLvpNqAlANq6P8aWPMj/a+u7E6v0OA48B1xphNInI/8AjW1Y89wGhjzJHCcsTHx5vExMSAfMayLC8nh6UPP0yjTz7h8tzcQrdNCQoiuV07Kl9/PU1uvZWo2NgSSll8zp49S3JyMpsTE6kxYQJhycnUPXyY6LNni/xA00mgJlAlPJxrr72WAQMG0L9/f+rXrx/A5Eo5Q0RWGWPiL2gPZOEoLbRweHO73cyYMYN6Y8bQMzOzwO3SRdgUF0eNhx4i7t57y+01/xN79rB9yhQy5s4lYuNGWhw/XmCH/FfAzfm0t2nThj9GR3PltdcSO2aMXtZS5YIWDi0cACQnJzNy5EgSExO5C/jYZ302kNikCZXvuYc2jz1GcFhhN8qWT2ezstg+cybpX39NyMqVND5wgLpu636Ne4CP8tknCDiM9STrCWBTgwbkXncdcc89x2VNm5ZYdqWKkxYOLRx88cUX3HfffZw6dQqwfthtBppjXfdbGhtL80mTqHf11Q6mLH2M203KokXsmTqVaYcPM2PBAtLTvbviugML89n3LLA2KoozgwbR6vnnrf4ZpcoILRwVuHBkZWXxyCOPMHHixAvWjRThgWbNiJk4kUY9ezqQruxxu92sWrWKOXPmMGfOHJYvX87LxvDHi+x3Blhbpw65N99M6+eeo7r2i6hSTgtHBS0cybNmsWr0aG49dgzfh2MGDRrE66+/TosWLRzJVl4cOXKE9W+8QaXp07li926iivB/6jSwrn593MOG0ebZZ/UBRFUqaeGogIVj0+TJNBg9mgjgz8CLdntoaChvvfUW999/PyLiYMLyx52by5bPPyft449ptGwZTXNyLrrPPSEhZAwZwt13302/fv1wldObEFTZo4WjghWOzZ99Rr077iDS/vvNw3pg5kCLFkyfPp02bdo4mq8iMG4327/+mv1vvUXMihXEnD17wTbZQG3glL0cExPDmDFjGD16NA0bNizJuEpdQAtHBSocO+fMIXLgQGr4/N3ObtmSnitWUE1Hji1xxu1m65dfcvDtt2m6ahWN7OdmvgZ+m8/2LpeLl9q2pc/119P+T3/S23uVIwoqHHpOXM4c3ryZoJtuuqBoJHTrxg0bN2rRcIi4XFw5ciS9ly2j4ZkzJH38MQkdOvBNAaP1Greb4atX0+nVVzlavToJXbuy57//LeHUSuVPzzjKkbycHJJq1aL1qVNe7QkdO9Jr6dJy+wBfWeZ2u1m4cCETJ05k5syZZGdnA9AHa44SX6svu4zsUaO4+rXX9CxEBZyecVQAi+6444KisbB5cy0apZjL5aJXr15MmTKF/fv3M378eNq0acO9BWzf/tgxur77Lunh4SQMHMiJPXtKNK9SoGcc5cbhzZsJvuqq853hYH07jdu7V2fDK2OMMWz+7DMOv/IK7bZsoXoh254CVrdtS5O339bncFSx0zOOcm7z4MFeReMUUO/HH7VolEEiQuztt9Nz82bkwAEWjh7NhgL+HqsDvdaupX6vXixt2JAN//pXyYZVFZIWjnJg40cf0WPbNq+2VQMGUC/+gi8KqoypVrcuPT75hFanTrH9q69YcNVVF0xOBdbwMV1SU7nq/vsZ3K4d06dPJ/ciIx4rdam0cJRxxu2GRx7xatsREkLXL790KJEKlOZDhtBz40ZOb93KvH79OJRPv9Us4Nu1axk+fDjNmjXj7bff5vTp0yUfVpVrWjjKuO1ff02cz9DoJ158US9RlWM1W7Tgmp9+IvLYMRbdcw9bPUYwftNjuz179vDoo4/SpEkTq4D43Dih1KXSwlHG7X/rLa/lVTVq0P7ppx1Ko0pSaHg43SdMoEVmJqtff51vLr883xF6Dx48yHuPPsqxyEjm33wzp48eLfGsqnzRwlGGGWN4Yv9+7gJ+AHKB07/N7zlkVZ6Jy0X7p55i8O7dJCUlce+99xIaGuq1zfNAfbebXl99xYmoKOYPHUr28ePOBFZlnt6OW4atWbOG9u3bn1+uV6kSm3btIrJBAwdTqdIgLS2Nv/3tb7z33ns0zMpiE1YHuqcDLhfbhgyh08SJhEVGOhFTlXJ6O2459KVPB3h8//5aNBQAtWvX5vXXX2fXrl08f+ONnMlnm3puN73+/W+O1azJ/GHDOHPyZInnVGWTFo4y7IcffvBaHj58uENJVGlVu3ZtRn33HZkbNpDQoUO+t/LWc7vpNXMmaTVrsmTsWNx6G6+6CC0cZZQxhl27dnm19e3b16E0qrSLioujd2JioQWkUW4uXcePZ0tEBGvffrvEM6qyQwtHGXX8+HFOelxaCAsLo06dOg4mUmXBuQKSsW4dCe3bk98THrFZWbR99FGW163LzjlzSjyjKv20cJRRKYmJDAOuBqKAmMsv19n8VJHVbt2a3qtWcWrdOua3asWFU0zB1YcOUX/AAKb36cNRvYVXedDCUUZl/vwz04EVQBrwif7HVpegduvW9Fq/ntQff2Spz40VLqAS8NK8eTRr1ox3332Xs/nMYqgqHi0cZVT21q1eyzlRUQ4lUeVBzLXX0iUlhQ0ffOA1oOJEYANw7Ngxfv/739OmTRvmzp3rWE5VOgS0cIhIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jIeI/tq4vIWo/XYRH5RyA/Q6mVlua16NbCoYpBq9/9jrgTJ1j22GNsqlSJ533Wb968mf79+zN8+HAO+NycoSqOgBUOEQkC3gNuAGKBkSIS67PZn4Dpxph2wAjgfbs9G+th1yc9NzbGnDLGtD33AvYAXwXqM5Rq1X1macjK7z4ZpfwnLhed33yTJidO8Pirr+Y73fC66dMJbtqUBSNH6u27FVAgzzg6AsnGmJ3GmBzgC2CQzzYGCLffRwD7AYwxmcaYRVgFJF8i0gKoDfkOz1PuuWrU8F7WAexUMQurXJlnnnmGbdu2cffdd3vdfPEBEGUMPb/4gqTLLmPbzJnOBVUlLpCFowGwz2M5xW7zNA4YJSIpwGxgrB/HHwF8aQoYM0VE7hORRBFJTE9P9+OwZUOQT+EI9hkhV6niUq9ePT766CNWrFhB+/btuQPo7bG+VUYGTYYNI6FTJzJ9LqGq8snpzvGRwCRjTENgADBFRIqaaQQwraCVxpgPjTHxxpj4qHJ4/T/E5zOF6KUqFWDx8fEsX76c20eMwPf8NhjovWIFRxs0YOULLzgRT5WgQBaOVKCRx3JDu83TGGA6gDFmKRAG1LrYgUWkDRBsjFlVPFHLntDatb2Xz+Q3GpFSxSs4OJh+06ZxavlyltWrd8H6Rrm5XP2Xv7AkOppDa9c6kFCVhEAWjpVAcxFpLCIhWGcIs3y22Qv0BRCRlliFoyjXlUZSyNlGRVClYUOv5TpZWdZsgEqVgPodO9J5/36WPfMM+4N8x92Frvv2Edq+PUt8ZqdU5UPACocxJhd4GJgLbMa6eypJRF4QkZvszZ4A7hWRdViFYPS5PgsR2Y01odloEUnxuSPrFip44bi8Xz+v8YZqu92kLlniWB5VMXV+9VWq791LQrt25PmsizSGru+8w+KYGI7rrbvlis7HUYati4igjcd4VUsefpiu777rYCJVkW36/HO47z5i8+lvO+Bysf/VV+mgs1OWKTofRzl0rGVLr+WzCxY4lEQpiL3tNlocPUpCPvN/1HO7+fAPf+DRRx/l9On8hlZUZYkWjjKs8jXXeC1HJSc7lEQpS3BoKL2/+469X33F1rCw8+3/AT4E3n77bTp06MDq1asdy6h+PS0cZViT227zWm6elcVpHexQlQLNhwwh5tAhEjp14iBwj8e6zZs306lTJ1555RVy9anzMkkLRxkWFRfHvMqV+RcwGogDEpYtczaUUrbQ8HB6L1vGztmzqRwT47UuNzeX5557jj49e5K6cqUzAdUl08JRxk297TbuByYD24BPp0xxOJFS3rrecAPr1q3j7rvvvmDdDUuXEtapE4mvvOJAMnWptHCUcaNGjfJa/uabbzh+/LhDaZTKX3h4OB999BFff/01tWpZz/jeBPwRqGkM7Z97joQ+fXTAxDJCC0cZ16NHD2I8LgNkZ2czffp05wIpVYjBgwezceNGbr/mGiZ7tLuA3vPmsap+fY5u3+5UPFVEWjjKOJfLxR133OHVNnny5AK2Vsp5derUYdKPP7L2uusueGjw6vR0slq2ZNOnnzqSTRWNFo5ywLdwrFqyhB16u6MqxVzBwfSeO5d1r79Ousdw7QAN8/JoeuedLBg1SofRKaW0cJQDTZs2pUf37nTGmifhILDv4YcdTqXUxbV/6ilyly/3mq4WIBTo+fnnLG7RgqzDh50JpwqkhaOc+L+WLVkK/A6IBNotXarjA6kyod7VV3PFgQPMb9PmgnXdd+xgb3Q0B/SW3VJFC0c5ET9uHEc9TvkjgLW33+5cIKX8EFKtGr3WrmXJ2LFk+Ky78vRp6NyZrXrTR6mhhaOcqF6/Puuvu86rrcPixRzZutWhREr5r+s773Dw22/ZERLi1V7P7ab+8OGsfPFFh5IpT1o4ypH4SZO8OhqrAxv0rEOVMc1uuonau3axvG5dr/aqwKvjxvGvf/3LmWDqPC0c5Ui1unVJGjjQq63jypWkb9zoUCKlLk31+vWJ37PHq9/jceBrt5v777+fP/zhD7j1jivHaOEoZzp+8gmHXP/7a60CbPK5XVepsiAoJIRea9cyf8gQ3gbe9lj3+uuvM2LECB2i3SFaOMqZKrVqsWXIEK+2TmvWsE/n6lBlVK+vviLmm2+oXLmyV/uMGTPo27cv6elFmW1aFadCC4eINBGRj0XkJRGpJiITRGSjiMwQkZiSiaj81WniRK95oMOAg0OH6sNUqswaNGgQ8+fPp06dOl7tS5cu5dMrr2T/8uUOJauYLnbGMQlYCWQAy4AtwA3AD8DHAU2mLllYZCQ7fC5PXZ2ezrKnnnIokVK/3tVXX82yZcto6THz5evAE0ePktu9OymLFjkXroIpdM5xEVljjGlnv99rjInOb11pV17nHC+MOzeXDTVres1JftDlovKuXURERxeyp1Kl2/Hjx7n5t7+lz7x5POfRnhoURO7cuVzet69j2cqbS51z3C0iLUTkaqCKiMTbB2sGBBW+q3KSKziYqlOmkOPRVtftZt311zuWSaniEBkZyZzvv6dPgwZe7Q3y8gi57jp2zpnjULKK42KF42ngO+BTYDDwRxFJBpYAzwc4m/qVmt10E0u6dvVqy9qyhZ++/96hREoVj5DKlbk6OZnFPmfP9dxuqt14IztmzXIoWcVQ6KWqfHcQqQUcM8b4johcalXES1XnnD56lAP16lEzJ4fHsTqmGjVqxMaNGwkPD3c6nlK/Sl5ODktiY+mxY4dX+2ERjn75JS2GDXMoWflwqZeqPA8QJyK3AAOA20REHw4oAyrXqEHGRx/RWuT83Qz79u1j7Nix+PulQanSJigkhG5btrDgiiu82msZQ63hw9n8+ecOJSvfilQ4ROQvwLv26xqsmxluCmAuVYxajxrFLU884dX26aefMnHiRIcSKVV8XMHBdN+4kflxcV7tNYyh/qhRbJs506Fk5VdRzziGAn2Bg8aYu4A2WAOwFkpE+ovIVhFJFpFn8lkfLSLzRGSNiKwXkQF2e027PUNExvvsEyIiH4rINhHZIiI3F/EzVGgvvPCC122MAA8//DCrVq1yKJFSxccVHEzPdetIaOd9o2cEED58OCmLFzsTrJwqauE4bYxxA7kiEg6kAY0K20FEgoD3sJ77iAVGikisz2Z/Aqbbt/WOAN6327OxOt+fzOfQzwFpxpgW9nHnF/EzVGiVK1dm5syZVK1a9XxbTk4OU/v355jP9WGlyiJxueiVmEhCp05e7XXdbnL69OHItm0OJSt/ilo4EkUkEpgArAJWA0svsk9HINkYs9MYkwN8AQzy2cYA53poI4D9AMaYTGPMIqwC4utu4FV7O7cxRqcHK6LY2FgmTJgAQGWspzv/fvgwyV264M7NdTKaUsVCXC56LVnC/LZtvdqb5OSwv0MHMo8edShZ+VKkwmGMedAYc9wY8wFwLXCnfcmqMA2AfR7LKXabp3HAKBFJAWYDYws7oF28AF4UkdX20Cd1CttHeRs5ciTPjh7NUuBOu+3q9HQW9O/vZCylio24XPRYuZIljbwvinyWkcHw228nV78k/Wr+3FXVWkRuAtoDzUTkt8Xw+48EJhljGmLdrTVFRArLFAw0BJYYY9pjnfX8rYC894lIoogk6iBo3v7y7ru4fOZ47vnLL6x67TWHEilVvFzBwXTYuJHVkZHkYn1Jeh34fvZsfve73+kdhb9SUe+q+hjrEYCbgd/Yrxsvslsq3v0gDe02T2OA6QDGmKVY4/HVKuSYR4As4Ct7eQZWIbuAMeZDY0y8MSY+KirqIlErlpBq1aj5888c9pj0yQXEPPssu3/6yblgShWj0PBwmq5fz/1Nm/KpR/vHH3/M88/r88u/RlHPODrbP4TvNMbcZb/uvsg+K4HmItJYREKwOr99H+fci3W3FiLSEqtwFHh6YKyvCd8Bve2mvsCmIn4G5aF+p07sfe01PMfLrWkMrgEDSFu/3rFcShWniEaNeHHhQmJiYrzaX375ZZ1J8FcoauFYms8dUYUyxuQCDwNzgc1Yd08licgL9iUvgCeAe0VkHTANGG0XB0RkN/AmMFpEUjx+/z8A40RkPXC7fQx1Cdo//TQL+vXzaovOzeVI586c2r/foVRKFa969eoxd+5catXyvpgxduxYVi5c6FCqsq1IQ46ISC+ss4WDwBlAsE4AWgc2XvGoyEOOXIxxu1ncvDndd+70al9Vowat9uwhxKcvRKmyavny5fTp04esrCzA+sY5NiiIaklJ1PR58lxZfu2QIx9hfbvvz//6N35TfPGUU8TlotOGDaz0+TbW4ehRVsbF6W26qtzo1KkTkydPJhyYiXVXzeV5eezq1o28nJyL7K08FbVwpBtjZhljdhlj9px7BTSZKjGVqlSh5YYNJHk8HAjQbc8eFnTu7FAqpYrf0KFDmdqtG57DTcQfOcLC665zLFNZVNTCsUZEporISBH57blXQJOpElWtbl3qrFzJrkqVvNp7r1pFwm/05FKVH9f9+CPrq1f3aus5fz4rX3jBoURlT1ELR2Wsvo3rKPrtuKqMqdWyJcE//8whl/c/izb/+Q9T3nnHoVRKFa9KVapQOyGBdJ/b0ZuOG6djWhVRUZ8cvyuf18Vux1VlUKOePTn22Wecm3D2FNZgY3c88ggffPCBg8mUKj5127cn9e9/x3NSoRrGcPK668jJyHAsV1kRXJSNRCS/r5sngERjzLfFG0k57cqRI1mdkkLM009zE7Dcbn/ggQfIycnh97//vZPxlCoWbR97jISffqK3x1SzsVlZJAwYQO8FCxxMVvoV9VJVGNAW2G6/WmM9CT5GRP4RoGzKQe2feopln3/OCp8+j0ceeYQ33njDoVRKFa9e//kPy+vW9WrrvnChTgB1EUUtHK2Ba4wx7xpj3gX6AVcCQ7D6PVQ5NODWW/nmm28IDQ31an/66ad59f/+z6FUShUfcbm4YvFiDnr06wUDrnvu0UtWhShq4bgM8HwSrCpQw553/Eyxp1KlxoABA/juu++oXLny+bYqQPdx40jo2RPjdhe8s1JlQGSTJux99lmvtiuys1midxMWqKiF43VgrYh8IiKTgDXAGyJSFfg5UOFU6XDttdcye/ZsqlatShjWEAI9gN4LFzK/a1ctHqrM6/jiiyxq3NirrUtCAjs9+j/U/xRpyBEAEamHNTkTwEpjTJkZzEiHHCkeixcv5lDv3vzW52nyBbGxdF21iuCwMIeSKfXrHduxg7MtWlDb44vQ6ssuo93hw4iryDNQlCuXNOSIiFxp/9oeqIc1MdM+oK7dpiqQbt260eKDDzjh095z0ybWREeTcfCgI7mUKg6XNW1K8oMPnl8+BUw+dozPpkxxLlQpVegZh4h8aIy5T0TmeTSf38EY0yeQ4YqLnnEUr82ffUbdO+7gMp9/O5srV+ayRYuo216/U6iyybjdrI6KYvfRozyCNYFQ3bp12blzp1c/X0VxSWccxpj77Lf/BAYZY64B5mE9w/FksadUZULLUaM4/O9/kxoU5N1++jTujh3Z9u9/O5RMqV9HXC4uW7CAUWFh52edO3jwIP/85z8dzVXaFPXC3Z+MMSdFpDvQB5iIVUxUBdV8yBCCVqxgs8+3sPp5edQdOpRVr77qUDKlfp0mV111wUOur732GpmZmQ4lKn2KWjjOPZk/EJhgjPkeCAlMJFVW1G3fnkY7d7Kidm2v9nCgzbPPsuCOO5wJptSv9NRTT1HNYy6a9BMzqHIAABs5SURBVPR0xo8f72Ci0qWohSNVRP4FDAdmi0ioH/uqcqxa3bp02LeP+a1aebUHAz2nTCGhSxed00OVObVq1eKRRx7xanv9r3/l5JEjDiUqXYr6w/8WrClgrzfGHAdqAE8FLJUqU4JCQui5di3zBw/G94mO3suW8UVcHMePH3ckm1KX6vHHHyc8PBywZrD74dgxVt9yi7OhSomijo6bZYz5yhiz3V4+YIz5MbDRVFkiLhe9vv6aFU8/TZZHewrw6NatxMfHs3btWqfiKeW3GjVq8NKdd7IYmANcDbT77385sUfnsNPLTapYdf7rX9n18ceki5ADDAXSgR07dtClSxcmTZrkbECl/HDHk0/S0mPejghgzUMPOReolNDCoYrdVXfdRc7ixfyladPzQ7IDZGdnc9ddd3HfffeRnZ3tWD6liioiOpp1fft6tTX4+ecKP8yOFg4VEA26dGFcUhIPPPDABesmTJjAg23asE/nPFBlwFVvvYXn7R3Nz5xhy7RpjuUpDbRwqIAJDQ3l/fff59NPP/V66rYR8Pq2bVTr3ZuVOjy7KuWi4uJY7XPLeVoFn5NGC4cKuNtvv51ly5bRrFkzQoAZQC3gMmO4etw4Enr0IFcvXalSLO+227yW49avr9DzdWjhUCWidevWJCYm8lbbtnTyWdd70SK21KrF7p9+ciSbUhfT7s9/5rhHJ3lNY1jz8ssOJnKWFg5VYiIiInhg1SoSBgw4PxTBOXGZmURddx3zb7utwnc8qtInLDKS9bGxXm1m8mSH0jgvoIVDRPqLyFYRSRaRZ/JZHy0i80RkjYisF5EBdntNuz1DRMb77JNgH3Ot/arte1xVeonLRe/vv2fDW2+R5jPHQVWg19SprKxbl0P6zIcqZWo89pjXcpsDBziblVXA1uVbwAqHiAQB7wE3ALHASBGJ9dnsT8B0Y0w7YATwvt2eDTxPwSPw3maMaWu/0oo/vQq0to8+iqxfz/K6dS9Y1zE9neD27Vn6lA5OoEqPq+66iwMeX3YqA9tnznQukIMCecbREUg2xuw0xuQAXwCDfLYxWGPigfVszX4AY0ymMWYRVgFR5VTUVVfRMTWVhaNHc8pnXU1j6PK3v7GwWTNO7N3rSD6lPInLxe569bza0mfNciiNswJZOBpgzRZ4Tord5mkcMEpEUoDZwNgiHvsT+zLV8yIePVYeROQ+EUkUkcT09HQ/o6uSIi4XPT75hGPz5rEuPPyC9T127OBkkyasfecdB9Ip5S2nXTuv5UorVzqUxFlOd46PBCYZYxoCA4ApInKxTLcZY1oBPezX7fltZIz50BgTb4yJj4qKKtbQqvhF9+5NXHo6Cf37k+OzrlFeHuMfeYQHH3xQB0tUjqoxcKDXcnRqagFblm+BLBypWM96ndPQbvM0BpgOYIxZCoRh3eJfIGNMqv3rKWAq1iUxVQ4EhYTQe84cdn3xBdtDQ8+3zwI+Av75z3/SsmVLpk+fTmFTHisVKM1HjCAH2IN17f2NvDwOVMDiEcjCsRJoLiKNRSQEq/Pb94LgXqAvgIi0xCocBV5XEpFgEallv68E3AhsDEB25aArhg+n0cGDJHTowEHgXo91Bw8eZPjw4QwcOJBdu3Y5FVFVUGGRkfymfXtisC6XvAMsr4CXqwJWOIwxucDDWPN4bMa6eypJRF4QkZvszZ4A7hWRdcA0YLSxv0qKyG7gTWC0iKTYd2SFAnNFZD2wFusMZkKgPoNyTlhkJL0TE0n+7jvCmzW7YP2cOXO4JjaWeTfeWGFviVTOiG7f3mv54MGDDiVxTnAgD26MmY3V6e3Z9meP95uAbgXsG1PAYTsUVz5V+nW/8UY29OvHK6+8wmuvvcbZs2fPr3s5O5trvv+ebTVrkvPuu8Tdc4+DSVVFERkZ6bVcEfvdnO4cV+qiwsLCeOGFF1i3bh09evQAoB9wbvSgFtnZxN57Lwvi4nSSHRVwERERXssnTpxwKIlztHCoMqNly5YkJCTw0cSJvBYU5LXOBfRMSuJMkyYsvOsunedcBYwWDi0cqoxxuVzcPWYMl69fz+ImTS5YX9vtpsekSWwND2fd+PH5HEGpX8f3UtUJvVSlVNlQKzaWbjt2sOaNN9hdqdIF61uePk2bsWNZ2qiRThililXj1FQ2YN0SegJ45JdfHE5U8rRwqDKt3ZNPUjctjYSePTmdz/ouKSlE9epFQseO2v+hioXs20cc1kNq4YDb57JpRaCFQ5V5YZGR9J4/nyOLFrGkUaML1wO9V64kr3Fj5t52Gzk5vs+mK1V0Z7dv91rO9hm/qiLQwqHKjYbdutF1717Wv/8+m6pUuWB9DWOYPHWqPn2ufhXXvn1eyxIT40gOJ2nhUOVO6wce4MoTJ1h0zz1ew2AnYg0TsXPnToYPH0779u359ttvtYAov1RN857JIezKKx1K4hwtHKpccgUH033CBCIOHSKhXz9OYU3u4lki1q5dy+DBg+nQoQP/fe89nXlQFUmNU96TAFzmM2JuRaCFQ5VrVWrVovdPP5G9bRtXPfggQfl0ZKasWUPnhx9mS7VqLH/uOS0gqkDHd+2iocfoBQB1Ola8cVa1cKgKIap5c9577z2SkpIYNmyY17qngSpYt/B2euUVtlSrxornn9cCoi6w4cUX8bz5e1elSkRERzuWxylaOFSFcsUVVzB9+nTWr1/P0KFDqQ086LNNy9On6fjSS2yuXp0Vf/6zFhB1XmWfGf/2dO7sUBJnaeFQFVKrVq2YMWMG83/4gXUNfCemtMRmZdHxxRfZXL06S8aO1VF4K7gjW7fS9sgRr7aGTzzhUBpnaeFQFdqV119Pl5QUtk2fzrL69fPdJjYri67jx5MWHk7CjTfqg4QVVNKLL3oNJ749NJRmgwY5lsdJWjiUAloMG0bn1FS2fvklywp4oKtBXh69v/8eV0wM89u106FMKpCcjAwazJjh1ZbaLd8ZISoELRxKebjillvovH8/W7/4osACUh3otXYtb/TuzbBhw1i6dGnJhlQlbsnw4TT1GXHg8qefdiiN87RwKJWPK4YPp/P+/eycPZsFsbH49m4cBz42hpkzZ9K1a1e6dOnCjBkzyNXh3Mud1NRUJv3yC4c82ha2aEHj6693LJPTtHAoVYgmN9xAz6QkTm/Zwry+fTlkP4n+LyDTY7tly5Zxyy23EBMTw5RbbyVl0SJH8qri99RTTzH5zBmuAP4BpIvQ8ptvnI7lKC0cShVBzSuu4Jqffyby2DEWjhnDzwUMM3E4NZUB06ZRv0cPEmvVYunjj5OTkVHCaVVxmT17NtOmTQOsIdQfA77529+o1bKlo7mcpoVDKT+EhofTY+JEfty0iZ9++okbbrjBa/1goCbWf6z4I0fo8tZbnAwPJyE+nh3/+Y8TkdUlWr9+PSNGjPBqa9u2LXc/8ohDiUoPLRxKXQIRoV+/fsyePZukpCTuvfdeqlSpwj35bFvLGHqvWkXT3/yG9eHhLLr3XrIOHy7xzKro9uzYwcCBAznlMS6ViPDee+/lO2xNRaOFQ6lfKTY2lg8//JAD+/dT6fbbSapatcBtW586RfeJEzkbFcXCFi1IfPllfbCwlNm/fDk5LVsSl5Li1f7mm2/StWtXh1KVLlo4lCom4RER9Pr0U67KyGDrl18yv1Urjovku20E0GP7duL/9CdOVqvGgpYtWTBrFnl5eSUbWnnZNnMmZ7t3p/nZs3wD3Gi3P/TQQzyil6jOk4owF0F8fLxJTEx0OoaqgE4fPcrq556j6rRptD1xosDt0oD6QK06dRg6dCjDhw+nW7duuFz63a4kGLebhaNG0XHaNMI82nOA/+vbl//74QeCg4ML2r3cEpFVxpj4C9q1cChVMnbNncueP/+Zq1auJMrn/937wEM+2zdo0IBhw4ZxR9eutBkyBFcF/MFVEk7s3cumbt3o4nNpCmBpgwbEb99OpcqVHUjmvIIKR0C/zohIfxHZKiLJIvJMPuujRWSeiKwRkfUiMsBur2m3Z4jI+AKOPUtENgYyv1LFqfH119N7+XIiMzJIfOklFjZvfv5S1pf5bJ+amsqH//gHLW65hSMhISxq2pQlY8dy1GfOa3XpNk6cyPGmTfMtGgtbtCB+27YKWzQKE7AzDhEJArYB1wIpwEpgpDFmk8c2HwJrjDH/FJFYYLYxJkZEqgLtgDggzhjzsM+xfwsMBVobY+IulkXPOFRplZORwdq//533tm/n61mzvO7iARgGTPfZJw/YVK0aRzp2pPadd3Llrbfq2Yifts2cydHf/57OBw5csO4UsP7BB+n23nslH6yUceKMoyOQbIzZaYzJwZru2XcoSQOE2+8jgP0AxphMY8wiINv3oCJSDXgceClQwZUqKSHVqtHxL39h8mefkZaWxjfffMPIkSOpat+ZNTyffYKAVhkZ9P7vf4m98049G/HDztmzWRIdbQ1qmU/R2FK5Mkd+/FGLxkUEsnA0APZ5LKfYbZ7GAaNEJAWYDYwtwnFfBP4OFwwfpFSZFhYWxqBBg5g6dSppaWnMnDGDmjExFNylbokyhu47d9J1/HhqtGhBclgYC1u25Ks33mDHjh1UhH7MwhhjWLFiBf+Ji+PygQPpum9fvtvNb9WKmP37ibn22hJOWPY4fcvGSGCSMaYhMACYIiIFZhKRtkBTY8zXFzuwiNwnIokikpienl58iZUqAVWqVOHmoUPpvWsXVTIzWffOOyR07szWsLCL7tvszBl6bNnCk08/TbNmzahXrx4333wzb775JsuXLyfHZ5TX8mrTpk08//zzNG/enE6dOrEmKYn8Ht3bWLUqq//6V3qtX09YZGSJ5yyLAtnH0QUYZ4y53l7+I4Ax5lWPbZKA/saYffbyTqCzMSbNXh4NxJ/r4xCRB4Dnse6SCwZqA0uMMb0Ly6J9HKo8OZCYSPL48QT//DOxqalE5LcN1u29+XkxOJgbq1blePPmBLdtS81evYgZMIDKNWoEMHXgGbebPb/8wtdLljD5669Zt26d1/orgc0ey1sqV+bkk09y9bhxiN72nK8Svx1XRIKxOsf7AqlYneO3GmOSPLaZA3xpjJkkIi2BX4AGxg7lWzh8jh8D/Ec7x1VFdjYri6QJEzg+bRp116+nxenTuICZWB3r+VkA9PBpywP2VqrEoagosps1I7RDB+r060d0nz4EF+EsxwmZaWlsnzaN43PmUHndOpocOkSUMTwAfFDAPmuAaqGhpI8dS6dXX9WbCi7Ckec47Ntr/4HVn/exMeZlEXkBSDTGzLLvpJoAVMPqKH/aGPOjve9urI7zEKzpD67zuSMrBi0cSnk5sXcv26dMYU1yMtP27GH58uVkeQxpEoI1ymtRS0E2sDcsjGMREZxs0IB1I0dy+eWXEx0dTYMGDahTpw6VKlUKwCexuHNzObxpE2krV3IqKYkz27bh2rWLqF27aH76NPn92F8A9PJpCwkJYeDAgfyub1/63XsvQSEhActcnugDgFo4VAV09uxZ1q1bx+LFi1m8eDFZ8+bxn0scYDEJ6/54TyJCVFQU/zp7lkYinA0NJTcsDHdYGO4qVaBKFahaFalenaDwcFzVq0NuLnkZGbhPnyYzKIg1sbFkZ2eTnZ3N6dOnycjIICUlhXcXLqRxTk6Ri5ynaCDV5aJv376MHDmSIUOGEKn9F37TwqGFQymM203qkiXsnT6dnNWrqbxjB3UPH+byIsxcOBsYWMC6ZKDpJeTZALQuYN0mwN9ZLzKA7ZGRbL3nHno/8QR169a9hFTqnIIKh17gU6oCEZeLht2707B7d6/2jIMH2TNnDkcXLCBv/Xqq795Nw+PHqeN2n99mTyHHzX929osr7GxiLxcvHLsrVSKlUSPcHTtSZ/Bgmg4aRLuwMNpdYh5VNFo4lFJUq1uXq+66C+66y6v9yNatHFi0iJMbN1I9N5eHjGH37t2kpKRw4MAB0tLSiACqXOLvW1jhOFeoTgAHw8I4ER7O6Tp1MA0bUqVDB5rceisxLVsSc4m/t7p0eqlKKXXJzp49y6GUFE4kJJC1bx+5J06Qd/IkeadOYU6dgsxMyMjAdfo0ruxsgs6cwbhc5IWEYEJDya5WjYS+fQkLCyMsLIzKlSsTFhZGvXr1aFK9Og0aNyYiOtrpj1lh6aUqpVSxq1SpEg0bN6Zh48aXfIzrijGPKhn61ItSSim/aOFQSinlFy0cSiml/KKFQymllF+0cCillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX7RwKKWU8osWDqWUUn7RwqGUUsovWjiUUkr5RQuHUkopv2jhUEop5RctHEoppfyihUMppZRftHAopZTyS0ALh4j0F5GtIpIsIs/ksz5aROaJyBoRWS8iA+z2mnZ7hoiM99nnBxFZJyJJIvKBiAQF8jMopZTyFrDCYf9Afw+4AYgFRopIrM9mfwKmG2PaASOA9+32bOB54Ml8Dn2LMaYNEAdEAcMCEF8ppVQBAnnG0RFINsbsNMbkAF8Ag3y2MUC4/T4C2A9gjMk0xizCKiDeOxhz0n4bDITYx1BKKVVCAlk4GgD7PJZT7DZP44BRIpICzAbGFuXAIjIXSANOATML2OY+EUkUkcT09HQ/oyullCqI053jI4FJxpiGwABgiohcNJMx5nqgHhAK9Clgmw+NMfHGmPioqKjizKyUUhVaIAtHKtDIY7mh3eZpDDAdwBizFAgDahXl4MaYbOBbLrz8pZRSKoACWThWAs1FpLGIhGB1fs/y2WYv0BdARFpiFY4CryuJSDURqWe/DwYGAlsCkF0ppVQBggN1YGNMrog8DMwFgoCPjTFJIvICkGiMmQU8AUwQkcewOrlHG2MMgIjsxuo4DxGRwcB1wBFgloiEYhW9ecAHgfoMSimlLiT2z+lyLT4+3iQmJjodQymlyhQRWWWMifdtd7pzXCmlVBmjhUMppZRftHAopZTyS4Xo4xCRdGCP0zkKUAs47HQIP2jewCtrmTVvYDmZ93JjzAUPwlWIwlGaiUhifp1PpZXmDbyyllnzBlZpzKuXqpRSSvlFC4dSSim/aOFw3odOB/CT5g28spZZ8wZWqcurfRxKKaX8omccSiml/KKFQymllF+0cBSzIsyz/riIbLLnWP9FRC73WJcnImvt1yyPdhGRl0Vkm4hsFpHfl/K8Cz3a94vIN6U8b18RWW23LxKRZqU8bx8770YRmWyPFF0a8kaLyI/2v9FNIhJjtzcWkeX2Mb+0R8suzXkfto9nRKRI0zw4nPdz+5gbReRjEalUnJnzZYzRVzG9sEYB3gE0wZrWdh0Q67PNNUAV+/0DwJce6zIKOO5dwKeAy16uXZrz+uz/b+CO0pwX2Aa0tN8/iDW5WKnMi/Vlbx/Qwl5+ARhTSvImANfa76t5bDcdGGG//wB4oJTnbQfEALuBWsWRNcB5BwBiv6YV159vYS894yheF51n3RgzzxiTZS8uw5rg6mIeAF4wxrjtY6SV8rwAiEg41gyNxXXGEai8BmsIf4AIYH8pzlsTyDHGbLOXfwJudjqviMQCwcaYn+ztMowxWSIiWP8Gzk3xPBkYXFrz2u/XGGN2F1PGksg729iAFfjxf/RSaeEoXkWZZ93TGGCOx3KYWPOkLxNrDpJzmgLD7XVzRKR5Kc97zmDgF2PMyV8fFQhc3nuA2SKSAtwOvFaK8x4GgkXk3JPEQ/GeadOpvC2A4yLylYisEZE3RCQIq9AdN8bkFvGYTucNpIDmtS9R3Q78UIyZ8xWwiZxU4URkFBAP9PJovtwYkyoiTYD/isgGY8wOrLnVs40x8SLyW+BjoEcpznvOSGBiSeY8x8+8jwEDjDHLReQp4E2sYlIq84rICOAtsSY0+xHIK8msBeQNxvo32Q5rZs8vgdFY0zs7zo+8HzmRz9cl5n0fWGCMWRjofHrGUbyKMs86ItIPeA64yRhz5ly7MSbV/nUn1vXMdvaqFOAr+/3XQOtSnhe7U7Ej8H0xZQ1IXhGJAtoYY5bbm30JdC2tee3lpcaYHsaYjsACrD4ap/OmAGvtyzC5WJcn22PN2hnp0YGf7zFLUd5AClheEfkLEAU8HqDs3gLdiVKRXljfCnYCjflf59dVPtu0w+oga+7TfhkQar+vBWzH7jjDunRyt/2+N7CyNOe12+4HJpf2P1/7mIf5X2fzGODfpTWvvVzb/jUU+AXoUwryBtnbR9nLnwAP2e9n4N05/mBpzuuxzW6Kt3M8UH++9wBLgMrFlfWin6WkfqOK8sK6w2Gb/Zf/nN32Ata3B4CfgUPAWvs1y27vCmyw/3FswONOGSAS65v7BmAp1jfkUpvXXp8A9C8jf75DPNYlAE1Ked43gM3AVuDR0vDna6+7Flhv550EhNjtTbA6bZOxikhoKc/7e6xv+LlYN0pMLOV5c+3jndvnz8X9/873pUOOKKWU8ov2cSillPKLFg6llFJ+0cKhlFLKL1o4lFJK+UULh1JKKb9o4VCqECLSUES+FZHtIrJDRN4uztFdlSqLtHAoVQB7gL6vgG+MMc2xxguqBrzsaDClHKaFQ6mC9cEaI+wTAGNMHta4VneLyIMi8o2I/CQiu+05HB63B6BbJiI1AESkqYj8ICKrxJqn5EqP9mUiskFEXhKRDLu9mj0Pw2p73aACsiEiMSKyRUQmiTVXy+ci0k9EFttnSB0D/iekKiQtHEoV7CpglWeDsUb63Ys1fEQc8FvgaqyzkCxjTDusp/vvsHf5EBhrjOkAPIk1EB3A28DbxphWWE8pn5MNDDHGtMeam+Hv9plPQZoBfweutF+3At3t3+vZS/jMSl2Ujo6r1KWbZ4w5BZwSkRPAd3b7BqC1iFTDGjpkhsfP/lD71y78b16KqcDf7PcCvCIiPQE31rDbdYCDBWTYZYzZACAiSVjD2BsR2YA1GZFSxU4Lh1IF24Q138V59uRU0VjjA53xWOX2WHZj/d9yYc1F0daP3/M2rFFOOxhjzorIbiCskO0vlkGpYqeXqpQq2C9AFRG5A8CeOOfvWAPMZRWyH3D+stYuERlm7y8i0sZevYz/zdw3wmO3CCDNLhrXAJcXxwdRqjhp4VCqAMYaAXQIMExEtmONapqNf30HtwFjRGQdkMT/pgp9FHhcRNZj9VOcsNs/B+LtS013AFt+9QdRqpjp6LhKOUBEqgCn7f6IEcBIY0yBd1ApVZroNVClnNEBGG/fMXUcuNvhPEoVmZ5xKFXKiUhNrP4WX32NMUdKOo9SWjiUUkr5RTvHlVJK+UULh1JKKb9o4VBKKeUXLRxKKaX8ooVDKaWUX/4fiMNLKoYl9uIAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light",
-      "tags": []
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can now plot contours obtained with this \n",
     "plot_contours(F, params, fill=False,color='black',lw=4);\n",

--- a/docs/notebooks/jax-cosmo-intro.ipynb
+++ b/docs/notebooks/jax-cosmo-intro.ipynb
@@ -468,41 +468,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import jax.numpy as np\n",
-    "\n",
-    "#@jit\n",
-    "def mag_bias(z):\n",
-    "    #print(\"mag_bias\")\n",
-    "    return np.sqrt(1. + z)*10.0"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<function __main__.mag_bias(z)>"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mag_bias"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 13,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -515,36 +481,16 @@
     "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.))  ]\n",
     "\n",
     "probes_mag = [ \n",
-    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=mag_bias)  ]\n"
+    "           jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=jc.bias.test_mag_bias(0.00))]\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "mb = jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=mag_bias)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DeviceArray(20., dtype=float32)"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mb.config[\"mag_bias\"](3.0)"
+    "mb = jc.probes.NumberCounts(nzs, jc.bias.constant_linear_bias(1.0),mag_bias=3.0)#mag_bias)"
    ]
   },
   {
@@ -559,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 15,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -571,25 +517,15 @@
    },
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "Argument '<function mag_bias at 0x7f8ca82aa1e0>' of type <class 'function'> is not a valid JAX type",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-50-3a8f13f67b17>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# And compute the data vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcls_nomag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobes_nomag\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mcls_mag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mangular_cl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobes_mag\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mangular_cl\u001b[0;34m(cosmo, ell, probes, transfer_fn, nonlinear_fn)\u001b[0m\n\u001b[1;32m    102\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0msimps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mintegrand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz2a\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzmax\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mconst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc\u001b[0m \u001b[0;34m**\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    103\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 104\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mcl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    105\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36mbatched_fun\u001b[0;34m(*args)\u001b[0m\n\u001b[1;32m    856\u001b[0m     \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_mapped_axis_size\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0min_tree\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0margs_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_axes_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"vmap\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    857\u001b[0m     out_flat = batching.batch(flat_fun, args_flat, in_axes_flat,\n\u001b[0;32m--> 858\u001b[0;31m                               lambda: flatten_axes(out_tree(), out_axes))\n\u001b[0m\u001b[1;32m    859\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mtree_unflatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mout_tree\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_flat\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    860\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/interpreters/batching.py\u001b[0m in \u001b[0;36mbatch\u001b[0;34m(fun, in_vals, in_dims, out_dim_dests)\u001b[0m\n\u001b[1;32m     32\u001b[0m   \u001b[0;31m# executes a batched version of `fun` following out_dim_dests\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m   \u001b[0mbatched_fun\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbatch_fun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfun\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_dims\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_dim_dests\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m   \u001b[0;32mreturn\u001b[0m \u001b[0mbatched_fun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall_wrapped\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0min_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m@\u001b[0m\u001b[0mlu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtransformation_with_aux\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/linear_util.py\u001b[0m in \u001b[0;36mcall_wrapped\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m    148\u001b[0m     \u001b[0mgen\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    149\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 150\u001b[0;31m     \u001b[0mans\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    151\u001b[0m     \u001b[0;32mdel\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    152\u001b[0m     \u001b[0;32mwhile\u001b[0m \u001b[0mstack\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mcl\u001b[0;34m(ell)\u001b[0m\n\u001b[1;32m    100\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mT\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    101\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 102\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msimps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mintegrand\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz2a\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzmax\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mconst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mc\u001b[0m \u001b[0;34m**\u001b[0m \u001b[0;36m2\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    103\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    104\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mcl\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/scipy/integrate.py\u001b[0m in \u001b[0;36msimps\u001b[0;34m(f, a, b, N)\u001b[0m\n\u001b[1;32m    196\u001b[0m     \u001b[0mdx\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mb\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0mN\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    197\u001b[0m     \u001b[0mx\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlinspace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mb\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mN\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 198\u001b[0;31m     \u001b[0my\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    199\u001b[0m     \u001b[0mS\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdx\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m3\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msum\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m4\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maxis\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    200\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mS\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36mintegrand\u001b[0;34m(a)\u001b[0m\n\u001b[1;32m     84\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     85\u001b[0m             \u001b[0;31m# Compute the kernels for all probes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 86\u001b[0;31m             \u001b[0mkernels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvstack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma2z\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mprobes\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     87\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[0;31m# Define an ordering for the blocks of the signal vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/angular_cl.py\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     84\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     85\u001b[0m             \u001b[0;31m# Compute the kernels for all probes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 86\u001b[0;31m             \u001b[0mkernels\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvstack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0ma2z\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mprobes\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     87\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m             \u001b[0;31m# Define an ordering for the blocks of the signal vector\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax_cosmo-0.1rc4.dev65+g574cf57.d20200603-py3.6.egg/jax_cosmo/probes.py\u001b[0m in \u001b[0;36mkernel\u001b[0;34m(self, cosmo, z, ell)\u001b[0m\n\u001b[1;32m    290\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    291\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmag_bias\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 292\u001b[0;31m             \u001b[0mkernel\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mmag_kernel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcosmo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpzs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mz\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmag_bias\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    293\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    294\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mkernel\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36mf_jitted\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    151\u001b[0m       \u001b[0mdyn_args\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    152\u001b[0m     \u001b[0margs_flat\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_tree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtree_flatten\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdyn_args\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 153\u001b[0;31m     \u001b[0;32mfor\u001b[0m \u001b[0marg\u001b[0m \u001b[0;32min\u001b[0m \u001b[0margs_flat\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0m_check_arg\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    154\u001b[0m     \u001b[0mflat_fun\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mout_tree\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mflatten_fun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_tree\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    155\u001b[0m     out = xla.xla_call(flat_fun, *args_flat, device=device, backend=backend,\n",
-      "\u001b[0;32m~/flowpm/lib/python3.6/site-packages/jax/api.py\u001b[0m in \u001b[0;36m_check_arg\u001b[0;34m(arg)\u001b[0m\n\u001b[1;32m   1681\u001b[0m   \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcore\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTracer\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0m_valid_jaxtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1682\u001b[0m     raise TypeError(\"Argument '{}' of type {} is not a valid JAX type\"\n\u001b[0;32m-> 1683\u001b[0;31m                     .format(arg, type(arg)))\n\u001b[0m\u001b[1;32m   1684\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1685\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0m_valid_jaxtype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: Argument '<function mag_bias at 0x7f8ca82aa1e0>' of type <class 'function'> is not a valid JAX type"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in asarray is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype float64 requested in array is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n",
+      "/home/ben.horowitz/flowpm/lib/python3.6/site-packages/jax/lax/lax.py:5385: UserWarning: Explicitly requested dtype <class 'jax.numpy.lax_numpy.int64'> requested in astype is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.\n",
+      "  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))\n"
      ]
     }
    ],
@@ -604,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -614,10 +550,57 @@
     "id": "VSKlZxxARxYO",
     "outputId": "3d39a4d7-165e-428d-d2a8-d482353d2064"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+       "             0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+       "             0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,\n",
+       "             0., 0., 0., 0., 0.], dtype=float32)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Let's check the shape of these Cls\n",
     "cls_mag[1]-cls_nomag[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x7f0844042160>]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAe0UlEQVR4nO3deVxV5b4G8Oe3GUUmBRRFEBQVFRVlLlPLIctMK/OaTadjmuWU2mCn2zmnzq17rMwhzaFMbbI8lTlkk+ZUMRMqKgjiACgCDkAqk7z3j6xr5sCw4V177+f7+fDHXnuvtZ6t7+dhsfe71hKlFIiIyPqZdAcgIqKmwcInIrIRLHwiIhvBwicishEsfCIiG8HCJyKyEfa6A1yLt7e3CgwM1B2DiMiipKSkFCulfC5fbujCDwwMRHJysu4YREQWRUSOXGk5P9IhIrIRhix8ERkuIstKSkp0RyEishqGLHyl1Aal1AQPDw/dUYiIrIYhC5+IiMyPhU9EZCNY+ERENsLQ0zLrK+vnHTh3+hgcmnnA0cUdTs3d0czVAy6uHmjm4gYx8fccEdkeqyz8kq3zEVG6+YrPVSsTSsQNZSYPnLX3QIVjC1Q5tUSNizdM7m3h7OUP99bt0bJNB7h7evGXAxFZDass/Haj/o3MwlxUnS9D1fkyVJ8vRU3FL1DlZVAVpTCdPwWHitNwrjwNr3OH4P5LGjyKy2CSP94M5pxyQrGdN047+eG8WyDEqyNcfDvDK6AbWvsHw87eKv/5iMhKWWVj+QZ0gm9ApzqtU11ViaITuTh9/BDOFh1B1ek8oCQfjmePw6M8D51O7IJLYQWw/9fXVyp7HLVrh5Ouwaj26Q4X/15o2zkCXr7+/KuAiAzJKgu/PuwdHNG6XUe0btfxis+rmhoUFRxF4eF9OHs8EzVFWWhWkg3/0p/RunQzcBDANuAU3JHvFIxffMLg0iEaAT36o4VPmyZ9L0REVyJGvKetiAwHMDw4OHh8VlaW7jjXVXLyBPIyU1B2JA2mwr3wKt2H9tWHYS81AIA88UWBWygutI1Aq56DEBgSzr8CiKjRiEiKUiriT8uNWPi/iYiIUJZ68bRzv5Tg8J6fUJodB8eCVLQ7uxetcArAr38FHHbtjaqAm9AmbDD8g3vyFwARmQ0L3wCOH8lEbuq3kMM7EVCSjNY4CQAoREsc9oyBQ9eh6BR7J1zdW2hOSkSWjIVvMKqmBvk5+3As7VvYHd6OTr8kwR1nUanskOncE2fbD4Rf1Ej4B/fQHZWILAwL3+CqKitwIHkLynZvhG/hDgTW5AIADpv8cbzdbWgbOwbtu4ZrTklEloCFb2GOHcrA0fjP4XZoE7pWpMMkCodNATjebija3nAf2of00R2RiAyKhW/Bio8dwcEdH8Et50uEXCz/HFMgCjvejeCBf4W3r7/uiERkICx8K1F07DAObv8ILQ+uRefqA6hWJqQ3j0ZNzzHoPmA0nJxddEckIs1Y+FboSEYqjm1fgeDjG+CD0zgDV2R634rWA59AYNc//V8TkY1g4Vux6qpK7PthPapSP0CP0p1wlGrsdeyB8rBH0GPg/XB0ctYdkYiaEAvfRpwqzEfm10vQ/tDHaKsKUQxPZLe7B0FDJ131shFEZF1Y+DbmQnU10nd8DiS9gx7nElEDwS73AXC/ZTo69e6nOx4RNSKLKnxLu5aO0R07lIGjX89DaMEXcJXz2OvYE1XRk9BzwL0w2dnpjkdEZmZRhf8bHuGbV+mZk9i38U0EZb+H1jiJI6Z2ONH9UfQa9hhn9xBZERY+/a6qsgK7vl6BFruWouOFHBSiJXK6PIqwEdPg7OKqOx4RNRALn/5E1dQg/Yd1sNv5OrpVpf/6BW/wI+g5cjpcXD10xyOiemLh0zXt/WkT1PbZCK1Iw2m4IyPoIfS46yleuZPIAl2t8HkRdgIAdL/hdoQ+tx0Zt3+KXOcuiD20EFVv9ET8hy+h/PxZ3fGIyAxY+PQHIVGD0XPWZhy4cx3ynIIRkzUHJbN7IPGzuaiuqtQdj4gagIVPV9S5zwD0eG4r0gd/gDP23oja808cf6UXUjYtR82FC7rjEVE9sPDpmkJvHI7Of4tH2o2LUS0OCE+cgZxXIpH+4wbd0Yiojlj4dF1iMiFs8FgE/C0VyX3+DdcLpQj97gGkvToURzLTdMcjolpi4VOt2dnbI+LOx+H5TBrigiYj+Gwa/D66GQkLH8Gpwnzd8YjoOlj4VGfOLq6IffhlVDyRjBSfkQgv+gIOi8IR/94LqCg/pzseEV0FC5/qzat1O0RPXoH8+7bgoEsvxOQsQOHscOz6fo3uaER0BSx8arD2IX0Q9uw32D3gXSgR9NoxHrtmD0FedrruaER0CRY+mU3PAffA99lUxAc/ieBzu9Dq/f6IWzYFZ8vO6I5GRGDhk5k5Ojkj5oEXcf6xROzyHIjYY+/h7JzeSNm0HKqmRnc8IpvGwqdG4d22PSKnr0HGsM9QatcC4YkzsOfVwcjP2as7GpHNYuFTowqJHITAWfGI7/IMOpzfC+9V/RH37jOczUOkgSELX0SGi8iykpIS3VHIDOwdHBFz3/M4/1g80t37IvboUhTODkf6znW6oxHZFEMWvlJqg1JqgocHr8luTXzaBiJ85hfYc/MKCGoQuuUhJL8xCqeLjuuORmQTDFn4ZN169L8b3s+kIr7dOPQs+R5YFInk9Yv5pS5RI2PhkxbOzZoj5tE3cGzMtyi090NE6izseXUwjh3K0B2NyGqx8EmrwK4RCJ71IxJCZqHj+XR4ruyH+A9f5LX3iRoBC5+0s7O3R/SY51D26I844NIbMVlvIGf2jTi0L0l3NCKrwsInw/D1D0avp79CSuQc+FQXwO+TWxG34llUVVbojkZkFVj4ZChiMiF82KNQT8Rjj3s/xB5ZgiOzY3FwT7zuaEQWj4VPhtSylR/CZ36B1NiF8LxwEgGf3o645TNRWVGuOxqRxWLhk6H1ufVB2E9OwC6PWxCb+w7yZ0fj4O6fdMciskgsfDI8T29fRMz4FGl9l8Ct5gz8P7sDcStncSYPUR2x8MlihA26D/aTE7DHvT9iDy9GzuwbeU9dojpg4ZNF8fT2RfjMtUiJegOtqo+h9UeDEP/Rv1Bz4YLuaESGx8InixR++zhUT4xDhks4Yg68jv2z++P4kUzdsYgMjYVPFsvbNwC9nv4KST1fQvuKbLi+2x/J65fwmjxEV8HCJ4smJhMi756G0r9sQ55jECJSn0Xq3HtQcqpIdzQiw2Hhk1VoGxSCTs9sR1zg4+hZuh3lC6KR/sN63bGIDIWFT1bD3sERsX/5Nw6NWItKcULo5gcRv3gi765FdBELn6xO5z794TUzHgleIxFzYjXyXrsRRw9w+iYRC5+skourB6KnrELajYvhdaEQ3h8OQeLaBfxCl2waC5+sWtjgsagc/wMOOXVB1K4XkDJ3FErPnNQdi0gLFj5ZvVZ+QQh5ZiviAychrHQrfpkfi4zkLbpjETU5Fj7ZBDt7e8T85RVk3/EfAArBG0Yh7r0XeIYu2RQWPtmUkMhBcJ0Wj11u/RCbswB7Xh+KM8UFumMRNQkWPtkcd08v9JmxFgndnkfXc6moWHgDMhK/0x2LqNGx8MkmicmE6NHP4Ojd61At9gj+cjTi3/87P+Ihq8bCJ5sW3Ksv3KbFYbdrX8QcnI/dr9/Oj3jIajVZ4YuISUReFpE3ReThptov0fW4e3qh98x1SAiZhW7nknF+YV9kpe3UHYvI7GpV+CLyrogUikj6ZcuHikimiGSLyKzrbGYEgHYAqgDk1S8uUeMQkwnRY57D4RGfQwAErL0LiZ/N0x2LyKxqe4S/EsDQSxeIiB2ARQBuA9ANwH0i0k1EeojIxst+WgHoAuAnpdQMAI+b7y0QmU/nPv3hNGknDjj3QNSefyBx/v0oP39Wdywis6hV4SuldgA4ddniKADZSqkcpVQlgI8BjFBK7VFK3XHZTyF+Pao/fXFdfjNGhtXCpw26Pf0d4vweQdTpjch9vR9vrkJWoSGf4fsByL3kcd7FZVfzOYBbReRNADuu9iIRmSAiySKSXFTEa5qTHnb29ogdPw9pNy6Gb3U+mq24Bbu3faY7FlGDNNmXtkqpc0qpcUqpKUqpRdd43TKlVIRSKsLHx6ep4hFdUdjgsTjz4Hc4bfJG963jEP/+33kBNrJYDSn8fAD+lzxud3EZkVXxD+6B1jN2IM2tP2IOzkfKvHtRfu4X3bGI6qwhhZ8EoJOIBImII4AxAHiLIbJKLq4e6DNjLeKCJqFPyRbkzumPgtxs3bGI6qS20zJXA4gD0EVE8kRknFKqGsBkAN8A2A9gjVJqb+NFJdJLTCbEPvwKdvdbgjbV+XBYfgsyEr7VHYuo1kQppTvDn4jIcADDg4ODx2dlZemOQ/QnRzJSYfrkfrSuOYG0Hv+NqFEzdEci+p2IpCilIi5fbshLKyilNiilJnh4eOiOQnRF7UP6wH3qTmQ064Oo9BcR/9Z4XKiu1h2L6JoMWfhElsCjhTe6P/U14luPQUzhGqTPuQ1lJZefrkJkHCx8ogaws7dHzONLkdD97+h2LgXF8wfg2GGepEXGxMInMoPoe2cic9AKeNUUw3nlIGQkbdYdiehPDFn4IjJcRJaVlJTojkJUa6E3jcCZsZtwTpojaOMYJG9YqjsS0R8YsvD5pS1ZqoDOYXCdtA3ZTiGISHkGce8+wzNzyTAMWfhElszT2xedZm5GksdQxB5diuQFY1FZUa47FhELn6gxODo5I2LaasQFTEDkma+Q+cZQlJ45qTsW2TgWPlEjEZMJsX99DUlhLyOkfDdOLriZl2MgrVj4RI0scuRkZA5aAe8LhbBbPgjZu37UHYlslCELn7N0yNqE3jQCxaPX4QLs0Obzu7F766e6I5ENMmThc5YOWaOg7tGwm7AFBfZt0XXbBCR9sVB3JLIxhix8Imvl0zYQraZuQYZzT0SmPY/4lX/jtE1qMix8oibm5tESXWZ8jWT3QYg5vAiJb43jhdeoSbDwiTRwdHJGn2lrEO97P6KLP8euuSN5Fy1qdCx8Ik1MdnaImfgW4js/hT5nd+LQ3CEoOVWkOxZZMUMWPmfpkC2JGfsCUiLnoGNlJk4vvBkn8g7qjkRWypCFz1k6ZGvChz2KA4NXwPtCMdQ7Q3AkI1V3JLJChix8IlsU2vdOFNz9GexRDY+PhyMz+XvdkcjKsPCJDCS4142oeGgTzkpz+G8YwxO0yKxY+EQG49ehO5we24Lj9n7oum0Cktcv0R2JrAQLn8iAvH390WrqFhxwCkVE6rOI//Al3ZHICrDwiQzKzaMlOk7/Cqmu/RCTNQdxS6fwrFxqEBY+kYE5N2uOXk+uRYLXSMQefw9JC+5HdVWl7lhkoQxZ+JyHT/T/7OztETVpBeL8xyPqzCbsmTuCZ+VSvRiy8DkPn+iPxGRC7LjXkRAyC73OxiFnHu+gRXVnyMInoiuLHvMcUqNeQ3DFPhS9ORDFBUd1RyILwsInsjARw8Yj85Z30Kb6GCqWDkJ+zl7dkchCsPCJLFCP/ncjb8QauKhzcHrvdhzc/ZPuSGQBWPhEFqpznwEovW8jqmGPVp/djb0/bdIdiQyOhU9kwdp3CYM8+i1O2Xkj+JuH8PO3H+iORAbGwieycK3bdYTHE5tx2KEjev44GYmfzdMdiQyKhU9kBTy9feH/5LfY2ywCUXv+gbhVz/OsXPoTFj6RlXBx9UDI9I1Idh+E2EMLkbBkImouXNAdiwzEkIXPM22J6uf3e+W2Go2Ywk+QOn80KivKdccigzBk4fNMW6L6M9nZIXriUsQFTUJE6WZkzB2Gs2VndMciAzBk4RNRw4jJhNiHX0Fij3+i+/kU5M8fjNNFx3XHIs1Y+ERWLOqe6dh940IEVB1C2eKBKDiapTsSacTCJ7JyvYc8gJzbPoBnzWmY3h2Cw/uTdUciTVj4RDagW8xQFI/6AgKFlp/ciYyEb3VHIg1Y+EQ2okNoNKoe/hol4oHATWORtnm17kjUxFj4RDakbVAImj++GbkOgQjd+QSSPp+vOxI1IRY+kY1p2coPbadtxr5mvRG5+++IW/U3npVrI1j4RDaouZsnQqZvunhW7iIkLJ7As3JtAAufyEb9flZu6zGIKfoPfp43ChXl53THokbEwieyYSY7O0Q/thjxHaYivOx7ZM29DWUlp3THokbCwieycWIyIeahfyEp7BWElO/GiQWDUFyQqzsWNQJDFj4vnkbU9CJHTsLeAcvQtjoPFUsHIi87XXckMjNDFj4vnkakR6+b70Xu8I/hos6h2Qe3Iyttp+5IZEaGLHwi0qdLxC0oG7sRlXBE27WjsGfHWt2RyExY+ET0JwGdw2A/YTNO2Pmiy5ZxSF6/RHckMgMWPhFdkU/bQHhP/R5ZTt0Rkfos4j/4p+5I1EAsfCK6KndPL3Sc/jVSXfsjJnsu4hfztomWjIVPRNfk3Kw5wqavRYLPKMScWI3UeffyBC0LxcInousy2dkh6vG3EddhKiLKtvAELQvFwieiWhGTCbEP/QtJYS8jpHw3ChcMRPGxI7pjUR2w8ImoTiJHTsa+AW+jTXU+qpYNxJHMNN2RqJZY+ERUZz1vHoX8kZ/CEZXwWD0MGYnf6Y5EtcDCJ6J66dS7H8of+gq/iBsCv7wPP3/7ge5IdB0sfCKqN78O3eHy+BYcceiAnj9ORsIns3VHomtg4RNRg7Rs5YeA6Vuwp3kMove/grhlU3kHLYNi4RNRgzVr7obQ6euR0PJOxB5bhZR5o1FZUa47Fl2GhU9EZmHv4IioyasQ134iIkq/w4E3bkXpmZO6Y9ElWPhEZDZiMiH2kdlI6v2/6FK+BycX3IyC3GzdsegiFj4RmV3kiCeQOWgFvC8UwrR8MA7uidcdiWDQwucdr4gsX+hNI1A8eh0UBK0/Hcnr6huAIQufd7wisg5B3aMh47eg0K41QraMQ+LaBboj2TRDFj4RWY9WfkHwmbYVGc69ELXrBcS9M53TNjVh4RNRo3PzaImQmV8jscUdiM17Fym8xLIWLHwiahIOjk6InPI+4oImI6J0M3LmDMKZ4gLdsWwKC5+ImoyYTIh9+GWkRM5Bh8oDKFt0M/Ky03XHshksfCJqcuHDHsWh2z+CqypD8w+GYn/CN7oj2QQWPhFpERI9BGcf+Bq/iBs6bhqL5PVLdEeyeix8ItKmXXAo3CdvQ5ZTN0SkPou45TM5g6cRsfCJSCsPr9boNPM7JHrejtjcd5A69x6Unz+rO5ZVYuETkXaOTs6InPoh4jpMRXjZ9zgy5xYUF+TqjmV1WPhEZAi/3ST959gFCKjKQdWSm3FoX5LuWFaFhU9EhtL71oeRN/Iz2KMaPp8Mx66t/9EdyWqw8InIcDr17ocL4zajwL4tQreNR/yHL/HLXDNg4RORIfn6B6Pt9K3Y5doXMVlzkPTmg7yLVgOx8InIsFxcPRA2Yx3i/B5B1OmNyJozCKeLjuuOZbFY+ERkaCY7O8SOn4fk8FcRXJGBc2/1x5H9KbpjWSQWPhFZhIjhj+Hw8DVwUhVo+fEw7Pp+je5IFoeFT0QWo0vELaj+62YU2rdBj+0TEP/+3/llbh2w8InIovgGdEKb6duQ5tYPMQfnI2XeaJ6ZW0ssfCKyOC6uHug94wvEtZ+IiNLvcHTOABQdO6w7luGx8InIIonJhNhHZuPnGxahXdURYNkAHEjdpjuWobHwicii9R7yAE6M3oAqcUD7daOQtO4t3ZEMi4VPRBYvqHs0mj2xA9lOXRH583OIXzwR1VWVumMZDgufiKxCC5826PzUZiT4jELMidXY//oQ3jP3Mix8IrIaDo5OiJ60HIm9/oUu5XtwblE/5KQn6I5lGCx8IrI6UXdNRc7wNXBQlfD9z3CkfrVCdyRDaLLCF5GbRGSJiLwjIj811X6JyDaFRAyETNiOXIcg9El4EnFvT8OF6mrdsbSqVeGLyLsiUigi6ZctHyoimSKSLSKzrrUNpdROpdREABsBrKp/ZCKi2vFu2x6BT21FYothiM1fifTXh6LkVJHuWNrU9gh/JYChly4QETsAiwDcBqAbgPtEpJuI9BCRjZf9tLpk1bEAPjJDdiKi63JydkHklA+Q0P0FdD2firI3+9rsnbRqVfhKqR0ATl22OApAtlIqRylVCeBjACOUUnuUUndc9lMIACISAKBEKVV2tX2JyAQRSRaR5KIi2/1NTETmIyYTou99CjnDPoGzKkfrT4YhZZPtfa7fkM/w/QBcepfhvIvLrmUcgGv+KyullimlIpRSET4+Pg2IR0T0RyFRg6EmbMdRhw4IT3wScUun2NTn+k06S0cp9Q+lFL+wJSJtfNoGosPT25DgNRKxx9/DvtcG28x8/YYUfj4A/0set7u4jIjI0BydnBE9ZRUSe7yILuW7cX5hX2Tv+kF3rEbXkMJPAtBJRIJExBHAGADrzROLiKjxRd3zJA6P+BwChXafj0TSFwt1R2pUtZ2WuRpAHIAuIpInIuOUUtUAJgP4BsB+AGuUUnvNEUpEhovIspKSEnNsjojoqjr36Q/HJ3Yg27k7ItOeR8KbD1vtzdJFKaU7w1VFRESo5ORk3TGIyAZUV1UiefmTiCn4EBn2XdHykdVo5RekO1a9iEiKUiri8uW8tAIREQB7B0fETHwLKVHzEFCVA9PbA7D3p026Y5kVC5+I6BLhtz+CojFf4by4oMs39yP+wxet5r65LHwiosu07xoOzyd/xB7XGxCT9QZS37gLZ8vO6I7VYIYsfH5pS0S6uXm0RNjMDYjvOA1hZdtRPLcvjmSm6Y7VIIYsfKXUBqXUBA8PD91RiMiGicmEmAdfwv7B78GtpgReHw3Fz99Y7rUfDVn4RERGEtr3TlQ9ug35DgHoHTcV8UuesMhbKLLwiYhqoXW7jgh8ahsSvO9GTMGHyHxtIIoLcq+/ooGw8ImIasnJ2QXRk1cgqff/okNFBmqW9ENG4ne6Y9UaC5+IqI4iRzyB4/duRKU4oeOX/4X41S9bxNRNQxY+Z+kQkdF1CI2G29QfkN48GjGZryJl7ijDT900ZOFzlg4RWQKPFt7oNXMj4oImoXfp9yia2xdHDxh36qYhC5+IyFKY7OwQ+/Ar2D9oFTxqStDyw6FI/Xql7lhXxMInIjKD0JtGoGLcVuQ7BKBP/DRDTt1k4RMRmYmvf/Afpm4eeO0WFBcc1R3rdyx8IiIz+m3qZnKffyOoIhNqST/sT/hGdywALHwiokYRcefjOH7vRlSIM4I33Yf4j/5H+9RNQxY+p2USkTXoEBoN92k//jp188BrSJ17j9apm4YsfE7LJCJr4e7p9fvUzbDSrSiaexNys3ZpyWLIwicisia/Td3cN3AVPGrOoMUHtyL1m/ebPkeT75GIyEb16DcCFX/9Hscc/NEnbjLilk5p0qmbLHwioibkG9AJ7Z/ajgSvEYg9/h4yXh+MU4X5TbJvFj4RURNzcnZB9JT3kNjrf9CpfC8q3+qHA6nbG32/LHwiIk2i7pqCo3ethYIgcN3dSPz0jUbdHwufiEijTmE3odnkH5Dp3BNR6S8icf5YlJ8/2yj7MmThcx4+EdkST29fdHv6O8T5/QVRp79E7pz+KDiaZfb9GLLwOQ+fiGyNnb09YsfPx883LIJndTHO/2L+E7Tszb5FIiKqt95DHkD5TXfBp1lzs2/bkEf4RES2zLkRyh5g4RMR2QwWPhGRjWDhExHZCBY+EZGNYOETEdkIFj4RkY0wZOHzTFsiIvMTpZTuDFclIiUArnV+sQeAq/1W8AZQbPZQje9a78nI+6rvtuqzXm3Xqc3rrvUaji/j7Ksh26rruk01vq71fEPHV3ullM+fliqlDPsDYFl9nweQrDt/Y7xno+6rvtuqz3q1Xac2r7vOGOL4Msi+GrKtuq7bVOPrWs831vgy5Ec6l9jQwOctUVO+J3Puq77bqs96tV2nNq+71ms4voyzr4Zsq67rNtX4qsu+zMLQH+k0hIgkK6UidOcg68TxRY2pscaX0Y/wG2KZ7gBk1Ti+qDE1yviy2iN8IiL6I2s+wiciokuw8ImIbAQLn4jIRthM4YtIBxFZLiKf6s5C1kdERorI2yLyiYgM0Z2HrIuIdBWRJSLyqYg8Xt/tWHThi8i7IlIoIumXLR8qIpkiki0iswBAKZWjlBqnJylZojqOry+UUuMBTATwXzrykmWp4/jar5SaCGA0gBvru0+LLnwAKwEMvXSBiNgBWATgNgDdANwnIt2aPhpZgZWo+/j674vPE13PStRhfInInQC+BLCpvju06MJXSu0AcOqyxVEAsi8e0VcC+BjAiCYPRxavLuNLfjUbwFdKqdSmzkqWp679pZRar5S6DcD99d2nRRf+VfgByL3kcR4APxHxEpElAHqLyHN6opEVuOL4AjAFwCAAo0Rkoo5gZBWu1l8DRGSBiCxFA47w7RuazlIopU7i189XicxOKbUAwALdOcg6KaW2AdjW0O1Y4xF+PgD/Sx63u7iMyBw4vqgxNer4ssbCTwLQSUSCRMQRwBgA6zVnIuvB8UWNqVHHl0UXvoisBhAHoIuI5InIOKVUNYDJAL4BsB/AGqXUXp05yTJxfFFj0jG+ePE0IiIbYdFH+EREVHssfCIiG8HCJyKyESx8IiIbwcInIrIRLHwiIhvBwicishEsfCIiG8HCJyKyEf8HFN4aft+xt9sAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "loglog(ell, cls_mag[1])\n",
+    "loglog(ell, cls_nomag[1])\n"
    ]
   },
   {
@@ -632,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -642,7 +625,19 @@
     "id": "-Xc458aidYL8",
     "outputId": "960b3f8d-8bb4-4018-f45d-869de305ca19"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'cls' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-18-c1e6f3533326>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# This is for instance the first bin auto-spectrum\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mfor\u001b[0m \u001b[0mcl\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m     \u001b[0mloglog\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m     \u001b[0mylabel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mr'$C_\\ell$'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0mxlabel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mr'$\\ell$'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m;\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'cls' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# This is for instance the first bin auto-spectrum \n",
     "for cl in cls:\n",

--- a/jax_cosmo/bias.py
+++ b/jax_cosmo/bias.py
@@ -26,6 +26,22 @@ class constant_linear_bias(container):
         b = self.params[0]
         return b * np.ones_like(z)
 
+    
+
+@register_pytree_node_class
+class test_mag_bias(container):
+    """
+    Class representing a more complex bias for magnitude biasing term, just for testing?
+
+    Parameters:
+    -----------
+    b: redshift independent bias value
+    """
+
+    def __call__(self, cosmo, z):
+        b = self.params[0]
+        return 2.0/5.0 + b * np.sqrt(1.0+z)
+
 
 @register_pytree_node_class
 class inverse_growth_linear_bias(container):

--- a/jax_cosmo/probes.py
+++ b/jax_cosmo/probes.py
@@ -63,9 +63,9 @@ def mag_kernel(cosmo, pzs, z, ell, s):
         # Stack the dndz of all redshift bins
         dndz = np.stack([pz(z_prime) for pz in pzs], axis=0)
         
-        mag_lim = (2.0-5.0*s(z_prime))/2.0
+        mag_lim = (2.0-5.0*s(cosmo, z_prime))/2.0
         
-        return dndz * np.clip(chi_prime - chi, 0) / np.clip(chi_prime, 1.0)
+        return dndz * np.clip(chi_prime - chi, 0) / np.clip(chi_prime, 1.0)*mag_lim
 
     # Computes the radial weak lensing kernel
     radial_kernel = np.squeeze(simps(integrand, z, zmax, 256) * (1.0 + z) * chi)


### PR DESCRIPTION
I implemented the new kernels to the best of my knowledge, based on the formulas here: https://arxiv.org/pdf/1812.05995.pdf

One thing I had to do for the RSD version is change the kernel to take a z1 variable (corresponding to z_{ell+1}).

NOTE! I wasn't able to get any of these functions working in CCL so I don't really have anything to compare directly against. In particular the s(z) function for the mag_bias I have no idea what a reasonable version would look like...