### PR TITLE
Remove duplicate `sqrtk` accessor

### DIFF
--- a/jax_cosmo/core.py
+++ b/jax_cosmo/core.py
@@ -185,10 +185,6 @@ class Cosmology:
         return np.sqrt(np.abs(self._Omega_k))
 
     @property
-    def sqrtk(self):
-        return self._sqrtk
-
-    @property
     def h(self):
         return self._h
 


### PR DESCRIPTION
This PR aims at removing that duplicate entry. 
I could not find any `self._sqrtk` attribute defined in the code. 

An other possibility is that the above method is renamed `def sqrtk(self)` => `def _sqrtk(self)`
But I don't see the purpose.