### PR TITLE
Fix halofit issue at small scale factor `a`

### DIFF
--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -85,3 +85,49 @@ def test_halofit():
     )
 
     assert_allclose(pk_ccl, pk_jax, rtol=0.5e-2)
+
+
+def test_halofit_nl_scales():
+    """This test checks that the halofit correction doesn't become
+    unstable when the nonlinear scales are very small.
+    """
+    # We first define equivalent CCL and jax_cosmo cosmologies
+    cosmo_ccl = ccl.Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Neff=0,
+        transfer_function="eisenstein_hu",
+        matter_power_spectrum="halofit",
+    )
+
+    cosmo_jax = Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+    )
+
+    # Test array of scales
+    k = np.logspace(-4, 2, 512)
+
+    # Computing matter power spectrum
+    pk_ccl = ccl.nonlin_matter_power(cosmo_ccl, k, 0.01)
+    pk_jax = (
+        power.nonlinear_matter_power(
+            cosmo_jax,
+            k / cosmo_jax.h,
+            a=0.01,
+            transfer_fn=tklib.Eisenstein_Hu,
+            nonlinear_fn=power.halofit,
+        )
+        / cosmo_jax.h ** 3
+    )
+
+    assert_allclose(pk_ccl, pk_jax, rtol=0.5e-2)


### PR DESCRIPTION
This PR aims to solve the issue identified by @jecampagne in #77 

We will prevent the computation of non-linear scales from returning negative numbers.