### PR TITLE
(WIP) Pytree dataclass as data containers

### DIFF
--- a/jax_cosmo/background.py
+++ b/jax_cosmo/background.py
@@ -220,7 +220,7 @@ def radial_comoving_distance(cosmo, a, log10_amin=-3, steps=256):
         \chi(a) =  R_H \int_a^1 \frac{da^\prime}{{a^\prime}^2 E(a^\prime)}
     """
     # Check if distances have already been computed
-    if not "background.radial_comoving_distance" in cosmo._workspace.keys():
+    if not "background.radial_comoving_distance" in cosmo._cache.keys():
         # Compute tabulated array
         atab = np.logspace(log10_amin, 0.0, steps)
 
@@ -233,9 +233,9 @@ def radial_comoving_distance(cosmo, a, log10_amin=-3, steps=256):
         chitab = chitab[-1] - chitab
 
         cache = {"a": atab, "chi": chitab}
-        cosmo._workspace["background.radial_comoving_distance"] = cache
+        cosmo._cache["background.radial_comoving_distance"] = cache
     else:
-        cache = cosmo._workspace["background.radial_comoving_distance"]
+        cache = cosmo._cache["background.radial_comoving_distance"]
 
     a = np.atleast_1d(a)
     # Return the results as an interpolation of the table
@@ -260,9 +260,9 @@ def a_of_chi(cosmo, chi):
       Scale factors corresponding to requested distances
     """
     # Check if distances have already been computed, force computation otherwise
-    if not "background.radial_comoving_distance" in cosmo._workspace.keys():
+    if not "background.radial_comoving_distance" in cosmo._cache.keys():
         radial_comoving_distance(cosmo, 1.0)
-    cache = cosmo._workspace["background.radial_comoving_distance"]
+    cache = cosmo._cache["background.radial_comoving_distance"]
     chi = np.atleast_1d(chi)
     return interp(chi, cache["chi"], cache["a"])
 
@@ -458,7 +458,7 @@ def _growth_factor_ODE(cosmo, a, log10_amin=-3, steps=128, eps=1e-4):
         Growth factor computed at requested scale factor
     """
     # Check if growth has already been computed
-    if not "background.growth_factor" in cosmo._workspace.keys():
+    if not "background.growth_factor" in cosmo._cache.keys():
         # Compute tabulated array
         atab = np.logspace(log10_amin, 0.0, steps)
 
@@ -482,9 +482,9 @@ def _growth_factor_ODE(cosmo, a, log10_amin=-3, steps=128, eps=1e-4):
         ftab = y[:, 1] / y1[-1] * atab / gtab
 
         cache = {"a": atab, "g": gtab, "f": ftab}
-        cosmo._workspace["background.growth_factor"] = cache
+        cosmo._cache["background.growth_factor"] = cache
     else:
-        cache = cosmo._workspace["background.growth_factor"]
+        cache = cosmo._cache["background.growth_factor"]
     return np.clip(interp(a, cache["a"], cache["g"]), 0.0, 1.0)
 
 
@@ -506,9 +506,9 @@ def _growth_rate_ODE(cosmo, a):
         Growth rate computed at requested scale factor
     """
     # Check if growth has already been computed, if not, compute it
-    if not "background.growth_factor" in cosmo._workspace.keys():
+    if not "background.growth_factor" in cosmo._cache.keys():
         _growth_factor_ODE(cosmo, np.atleast_1d(1.0))
-    cache = cosmo._workspace["background.growth_factor"]
+    cache = cosmo._cache["background.growth_factor"]
     return interp(a, cache["a"], cache["f"])
 
 
@@ -531,7 +531,7 @@ def _growth_factor_gamma(cosmo, a, log10_amin=-3, steps=128):
 
     """
     # Check if growth has already been computed, if not, compute it
-    if not "background.growth_factor" in cosmo._workspace.keys():
+    if not "background.growth_factor" in cosmo._cache.keys():
         # Compute tabulated array
         atab = np.logspace(log10_amin, 0.0, steps)
 
@@ -542,9 +542,9 @@ def _growth_factor_gamma(cosmo, a, log10_amin=-3, steps=128):
         gtab = np.exp(odeint(integrand, np.log(atab[0]), np.log(atab)))
         gtab = gtab / gtab[-1]  # Normalize to a=1.
         cache = {"a": atab, "g": gtab}
-        cosmo._workspace["background.growth_factor"] = cache
+        cosmo._cache["background.growth_factor"] = cache
     else:
-        cache = cosmo._workspace["background.growth_factor"]
+        cache = cosmo._cache["background.growth_factor"]
     return np.clip(interp(a, cache["a"], cache["g"]), 0.0, 1.0)
 
 

--- a/jax_cosmo/background.py
+++ b/jax_cosmo/background.py
@@ -109,7 +109,7 @@ def Esqr(cosmo, a):
     -----
 
     The Hubble parameter at scale factor `a` is given by
-    :math:`H^2(a) = E^2(a) H_o^2` where :math:`E^2` is obtained through
+    :math:`H^2(a) = E^2(a) H_0^2` where :math:`E^2` is obtained through
     Friedman's Equation (see :cite:`2005:Percival`) :
 
     .. math::
@@ -374,7 +374,7 @@ def growth_factor(cosmo, a):
 
     Parameters
     ----------
-    cosmo: `Cosmology`
+    cosmo: Cosmology
       Cosmology object
 
     a: array_like
@@ -392,7 +392,7 @@ def growth_factor(cosmo, a):
     assuming the $f = \Omega^\gamma$ growth rate, otherwise the usual ODE for
     growth will be solved.
     """
-    if cosmo._flags["gamma_growth"]:
+    if cosmo.gamma is not None:
         return _growth_factor_gamma(cosmo, a)
     else:
         return _growth_factor_ODE(cosmo, a)
@@ -403,7 +403,7 @@ def growth_rate(cosmo, a):
 
     Parameters
     ----------
-    cosmo: `Cosmology`
+    cosmo: Cosmology
       Cosmology object
 
     a: array_like
@@ -434,7 +434,7 @@ def growth_rate(cosmo, a):
 
     see :cite:`2019:Euclid Preparation VII, eqn.32`
     """
-    if cosmo._flags["gamma_growth"]:
+    if cosmo.gamma is not None:
         return _growth_rate_gamma(cosmo, a)
     else:
         return _growth_rate_ODE(cosmo, a)
@@ -494,7 +494,7 @@ def _growth_rate_ODE(cosmo, a):
 
     Parameters
     ----------
-    cosmo: `Cosmology`
+    cosmo: Cosmology
       Cosmology object
 
     a: array_like
@@ -553,7 +553,7 @@ def _growth_rate_gamma(cosmo, a):
 
     Parameters
     ----------
-    cosmo: `Cosmology`
+    cosmo: Cosmology
         Cosmology object
 
     a : array_like

--- a/jax_cosmo/core.py
+++ b/jax_cosmo/core.py
@@ -54,11 +54,8 @@ class Cosmology:
         self._w0 = w0
         self._wa = wa
 
-        self._flags = {}
-
         # Secondary optional parameters
         self._gamma = gamma
-        self._flags["gamma_growth"] = gamma is not None
 
         # Create a workspace where functions can store some precomputed
         # results
@@ -97,7 +94,7 @@ class Cosmology:
 
     # Operations for flattening/unflattening representation
     def tree_flatten(self):
-        params = (
+        children = (
             self._Omega_c,
             self._Omega_b,
             self._h,
@@ -106,40 +103,15 @@ class Cosmology:
             self._Omega_k,
             self._w0,
             self._wa,
+            self._gamma,
         )
+        aux_data = None
 
-        if self._flags["gamma_growth"]:
-            params += (self._gamma,)
-
-        return (
-            params,
-            self._flags,
-        )
+        return children, aux_data
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        # Retrieve base parameters
-        Omega_c, Omega_b, h, n_s, sigma8, Omega_k, w0, wa = children[:8]
-        children = list(children[8:]).reverse()
-
-        # We extract the remaining parameters in reverse order from how they
-        # were inserted
-        if aux_data["gamma_growth"]:
-            gamma = children.pop()
-        else:
-            gamma = None
-
-        return cls(
-            Omega_c=Omega_c,
-            Omega_b=Omega_b,
-            h=h,
-            n_s=n_s,
-            sigma8=sigma8,
-            Omega_k=Omega_k,
-            w0=w0,
-            wa=wa,
-            gamma=gamma,
-        )
+        return cls(*children)
 
     # Cosmological parameters, base and derived
     @property

--- a/jax_cosmo/core.py
+++ b/jax_cosmo/core.py
@@ -1,10 +1,5 @@
 import jax.numpy as np
-from jax.experimental.ode import odeint
 from jax.tree_util import register_pytree_node_class
-
-import jax_cosmo.constants as const
-from jax_cosmo.utils import a2z
-from jax_cosmo.utils import z2a
 
 __all__ = ["Cosmology"]
 

--- a/jax_cosmo/core.py
+++ b/jax_cosmo/core.py
@@ -1,166 +1,87 @@
+from dataclasses import field
+from functools import partial
+from pprint import pformat
+from typing import Any
+from typing import Optional
+
 import jax.numpy as np
-from jax.tree_util import register_pytree_node_class
+
+from jax_cosmo.dataclasses import pytree_dataclass
 
 __all__ = ["Cosmology"]
 
 
-@register_pytree_node_class
+@partial(pytree_dataclass, frozen=True)
 class Cosmology:
-    def __init__(self, Omega_c, Omega_b, h, n_s, sigma8, Omega_k, w0, wa, gamma=None):
-        """
-        Cosmology object, stores primary and derived cosmological parameters.
+    """
+    Cosmology parameter class, including primary, secondary, and derived parameters; immutable.
 
-        Parameters:
-        -----------
-        Omega_c, float
-          Cold dark matter density fraction.
-        Omega_b, float
-          Baryonic matter density fraction.
-        h, float
-          Hubble constant divided by 100 km/s/Mpc; unitless.
-        n_s, float
-          Primordial scalar perturbation spectral index.
-        sigma8, float
-          Variance of matter density perturbations at an 8 Mpc/h scale
-        Omega_k, float
-          Curvature density fraction.
-        w0, float
-          First order term of dark energy equation
-        wa, float
-          Second order term of dark energy equation of state
-        gamma: float
-          Index of the growth rate (optional)
+    Parameters:
+    -----------
+    Omega_c : float
+      Cold dark matter density fraction.
+    Omega_b : float
+      Baryonic matter density fraction.
+    h : float
+      Hubble constant divided by 100 km/s/Mpc; unitless.
+    n_s : float
+      Primordial scalar perturbation spectral index.
+    sigma8 : float
+      RMS of matter density perturbations in an 8 Mpc/h spherical tophat.
+    Omega_k : float
+      Curvature density fraction.
+    w0 : float
+      First order term of dark energy equation.
+    wa : float
+      Second order term of dark energy equation of state.
+    gamma : float, optional
+      Exponent of growth rate fitting formula.
 
-        Notes:
-        ------
+    Notes:
+    ------
 
-        If `gamma` is specified, the emprical characterisation of growth in
-        terms of  dlnD/dlna = \omega^\gamma will be used to define growth throughout.
-        Otherwise the linear growth factor and growth rate will be solved by ODE.
+    If `gamma` is specified, the growth rate fitting formula
+    :math:`dlnD/dlna = \Omega_m(a)^\gamma` will be used to model the growth history.
+    Otherwise the linear growth factor and growth rate will be solved by ODE.
 
-        """
-        # Store primary parameters
-        self._Omega_c = Omega_c
-        self._Omega_b = Omega_b
-        self._h = h
-        self._n_s = n_s
-        self._sigma8 = sigma8
-        self._Omega_k = Omega_k
-        self._w0 = w0
-        self._wa = wa
+    """
 
-        # Secondary optional parameters
-        self._gamma = gamma
+    # Primary parameters
+    Omega_c: float
+    Omega_b: float
+    h: float
+    n_s: float
+    sigma8: float
+    Omega_k: float
+    w0: float
+    wa: float
 
-        # Create a workspace where functions can store some precomputed
-        # results
-        self._workspace = {}
+    # Secondary optional parameters
+    gamma: Optional[float] = None
+
+    # cached intermediate computations
+    _cache: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
 
     def __str__(self):
-        return (
-            "Cosmological parameters: \n"
-            + "    h:        "
-            + str(self.h)
-            + " \n"
-            + "    Omega_b:  "
-            + str(self.Omega_b)
-            + " \n"
-            + "    Omega_c:  "
-            + str(self.Omega_c)
-            + " \n"
-            + "    Omega_k:  "
-            + str(self.Omega_k)
-            + " \n"
-            + "    w0:       "
-            + str(self.w0)
-            + " \n"
-            + "    wa:       "
-            + str(self.wa)
-            + " \n"
-            + "    n:        "
-            + str(self.n_s)
-            + " \n"
-            + "    sigma8:   "
-            + str(self.sigma8)
-        )
+        return pformat(self, indent=4, width=1)  # for python >= 3.10
 
-    def __repr__(self):
-        return self.__str__()
-
-    # Operations for flattening/unflattening representation
-    def tree_flatten(self):
-        children = (
-            self._Omega_c,
-            self._Omega_b,
-            self._h,
-            self._n_s,
-            self._sigma8,
-            self._Omega_k,
-            self._w0,
-            self._wa,
-            self._gamma,
-        )
-        aux_data = None
-
-        return children, aux_data
-
-    @classmethod
-    def tree_unflatten(cls, aux_data, children):
-        return cls(*children)
-
-    # Cosmological parameters, base and derived
+    # Derived parameters
     @property
     def Omega(self):
-        return 1.0 - self._Omega_k
-
-    @property
-    def Omega_b(self):
-        return self._Omega_b
-
-    @property
-    def Omega_c(self):
-        return self._Omega_c
+        return 1.0 - self.Omega_k
 
     @property
     def Omega_m(self):
-        return self._Omega_b + self._Omega_c
+        return self.Omega_b + self.Omega_c
 
     @property
     def Omega_de(self):
         return self.Omega - self.Omega_m
 
     @property
-    def Omega_k(self):
-        return self._Omega_k
-
-    @property
     def k(self):
-        return -np.sign(self._Omega_k).astype(np.int8)
+        return -np.sign(self.Omega_k).astype(np.int8)
 
     @property
     def sqrtk(self):
-        return np.sqrt(np.abs(self._Omega_k))
-
-    @property
-    def h(self):
-        return self._h
-
-    @property
-    def w0(self):
-        return self._w0
-
-    @property
-    def wa(self):
-        return self._wa
-
-    @property
-    def n_s(self):
-        return self._n_s
-
-    @property
-    def sigma8(self):
-        return self._sigma8
-
-    @property
-    def gamma(self):
-        return self._gamma
+        return np.sqrt(np.abs(self.Omega_k))

--- a/jax_cosmo/dataclasses.py
+++ b/jax_cosmo/dataclasses.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from dataclasses import fields
+from dataclasses import is_dataclass
+
+from jax.tree_util import register_pytree_node
+
+
+def pytree_dataclass(cls, aux_fields=None, **kwargs):
+    """Register python dataclasses as custom pytree nodes.
+
+    Parameters
+    ----------
+    cls : type
+        Class to be registered, not a python dataclass yet.
+    aux_fields : str or Sequence[str], optional
+        Fields to be treated as pytree aux_data; unrecognized ones are ignored.
+    kwargs
+        Keyword arguments to be passed to python dataclass decorator.
+
+    Returns
+    -------
+    cls : type
+        Registered dataclass.
+
+    Raises
+    ------
+    TypeError
+        If cls is already a python dataclass.
+
+    .. _Augmented dataclass for JAX pytree:
+        https://gist.github.com/odashi/813810a5bc06724ea3643456f8d3942d
+
+    """
+    if is_dataclass(cls):
+        raise TypeError("cls cannot already be a dataclass")
+    cls = dataclass(cls, **kwargs)
+
+    if aux_fields is None:
+        aux_fields = []
+    elif isinstance(aux_fields, str):
+        aux_fields = [aux_fields]
+    akeys = [field.name for field in fields(cls) if field.name in aux_fields]
+    ckeys = [field.name for field in fields(cls) if field.name not in aux_fields]
+
+    def tree_flatten(obj):
+        children = [getattr(obj, key) for key in ckeys]
+        aux_data = [getattr(obj, key) for key in akeys]
+        return children, aux_data
+
+    def tree_unflatten(aux_data, children):
+        return cls(**dict(zip(ckeys, children)), **dict(zip(akeys, aux_data)))
+
+    register_pytree_node(cls, tree_flatten, tree_unflatten)
+
+    return cls

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,21 @@
+from dataclasses import FrozenInstanceError
+
+from numpy.testing import assert_raises
+
+from jax_cosmo import Cosmology
+
+
+def test_Cosmology_immutability():
+    cosmo = Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.67,
+        sigma8=0.8,
+        n_s=0.96,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+    )
+
+    with assert_raises(FrozenInstanceError):
+        cosmo.h = 0.74  # Hubble doesn't budge on the tension


### PR DESCRIPTION
* `frozen` dataclass is semi-immutable
* `aux_fields` can be specified to be the pytree `aux_data`
  - I will add a `Cosmology.config` using this
  - this might be more flexible than the `Container`, worth switching?
* cached intermediate results survive through JAX transformation unflattening.
  Are there cases where this is not desirable?