### PR TITLE
Adds luminosity distance and distance modulus

### DIFF
--- a/jax_cosmo/background.py
+++ b/jax_cosmo/background.py
@@ -19,7 +19,8 @@ __all__ = [
     "angular_diameter_distance",
     "growth_factor",
     "growth_rate",
-    "luminosity_distance"
+    "luminosity_distance",
+    "distance_modulus",
 ]
 
 
@@ -601,3 +602,23 @@ def luminosity_distance(cosmo, a):
     """
 
     return transverse_comoving_distance(cosmo, a) / a
+
+
+def distance_modulus(cosmo, a):
+    """
+    Compute the distance modulus for a given scale factor a
+
+    Parameters
+    ----------
+    cosmo : `Cosmology'
+        Cosmology object
+
+    a : array_like
+        Scale factor
+
+    Returns
+    -------
+    mu : Distance modulus corresponding to scale factor a
+    """
+
+    return 5 * np.log10(luminosity_distance(cosmo, a) * 1e5)

--- a/jax_cosmo/background.py
+++ b/jax_cosmo/background.py
@@ -19,6 +19,7 @@ __all__ = [
     "angular_diameter_distance",
     "growth_factor",
     "growth_rate",
+    "luminosity_distance"
 ]
 
 
@@ -580,3 +581,23 @@ def _growth_rate_gamma(cosmo, a):
     see :cite:`2019:Euclid Preparation VII, eqn.32`
     """
     return Omega_m_a(cosmo, a) ** cosmo.gamma
+
+
+def luminosity_distance(cosmo, a):
+    """
+    Compute the luminosity distance in [Mpc] for a given scale factor a
+    Parameters
+    ----------
+    cosmo : `Cosmology'
+        Cosmology object
+
+    a : array_like
+        Scale factor
+
+    Returns
+    -------
+    d_L :  ndarray, or float if input scalar
+        Luminosity distance corresponding to the requested scale factor
+    """
+
+    return transverse_comoving_distance(cosmo, a) / a

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -246,6 +246,7 @@ def test_luminosity_distance():
     dl_jax = bkgrd.luminosity_distance(cosmo_jax, a) / cosmo_jax.h
     assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)
 
+
 def test_distance_modulus():
     cosmo_ccl = ccl.Cosmology(
         Omega_c=0.3,

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -245,3 +245,33 @@ def test_luminosity_distance():
     dl_ccl = ccl.background.luminosity_distance(cosmo_ccl, a)
     dl_jax = bkgrd.luminosity_distance(cosmo_jax, a) / cosmo_jax.h
     assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)
+
+def test_distance_modulus():
+    cosmo_ccl = ccl.Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Neff=0,
+        transfer_function="eisenstein_hu",
+        matter_power_spectrum="linear",
+    )
+
+    cosmo_jax = Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+    )
+
+    # Test array of scale factors
+    a = np.linspace(0.01, 0.99)
+
+    dl_ccl = ccl.background.distance_modulus(cosmo_ccl, a)
+    dl_jax = bkgrd.distance_modulus(cosmo_jax, a) - 5*np.log10(cosmo_jax.h)
+    assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,7 +1,5 @@
-import jax.numpy as jnp
 import numpy as np
 import pyccl as ccl
-import pyccl.background
 from numpy.testing import assert_allclose
 
 import jax_cosmo.background as bkgrd
@@ -242,7 +240,7 @@ def test_luminosity_distance():
     # Test array of scale factors
     a = np.linspace(0.01, 1.0)
 
-    dl_ccl = ccl.background.luminosity_distance(cosmo_ccl, a)
+    dl_ccl = ccl.luminosity_distance(cosmo_ccl, a)
     dl_jax = bkgrd.luminosity_distance(cosmo_jax, a) / cosmo_jax.h
     assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)
 
@@ -273,6 +271,6 @@ def test_distance_modulus():
     # Test array of scale factors
     a = np.linspace(0.01, 0.99)
 
-    dl_ccl = ccl.background.distance_modulus(cosmo_ccl, a)
+    dl_ccl = ccl.distance_modulus(cosmo_ccl, a)
     dl_jax = bkgrd.distance_modulus(cosmo_jax, a) - 5*np.log10(cosmo_jax.h)
     assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 import numpy as np
 import pyccl as ccl
+import pyccl.background
 from numpy.testing import assert_allclose
 
 import jax_cosmo.background as bkgrd
@@ -213,3 +214,34 @@ def test_growth_gamma():
     gjax = bkgrd.growth_factor(cosmo_jax, a)
 
     assert_allclose(gccl, gjax, rtol=1e-2)
+
+
+def test_luminosity_distance():
+    cosmo_ccl = ccl.Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Neff=0,
+        transfer_function="eisenstein_hu",
+        matter_power_spectrum="linear",
+    )
+
+    cosmo_jax = Cosmology(
+        Omega_c=0.3,
+        Omega_b=0.05,
+        h=0.7,
+        sigma8=0.8,
+        n_s=0.96,
+        Omega_k=0.0,
+        w0=-1.0,
+        wa=0.0,
+    )
+
+    # Test array of scale factors
+    a = np.linspace(0.01, 1.0)
+
+    dl_ccl = ccl.background.luminosity_distance(cosmo_ccl, a)
+    dl_jax = bkgrd.luminosity_distance(cosmo_jax, a) / cosmo_jax.h
+    assert_allclose(dl_ccl, dl_jax, rtol=0.5e-2)


### PR DESCRIPTION
I'm new to open source so hopefully this is along the right lines/isn't duplicating existing effort - I'm using `jax_cosmo` in one of my projects and couldn't see these functions implemented, so thought I'd add them. 

This PR adds 2 new functions, `luminosity_distance` and `distance_modulus`, along with corresponding tests against their CCL counterparts.