### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,5 @@ RUN pip install --no-cache-dir jaxlib==0.1.62+cuda110 \
                                              -f https://storage.googleapis.com/jax-releases/jax_releases.html
 
 WORKDIR /opt/jax_cosmo
-COPY . .
 
 CMD ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,6 @@ RUN pip install --no-cache-dir jaxlib==0.1.62+cuda110 \
                                              -f https://storage.googleapis.com/jax-releases/jax_releases.html
 
 WORKDIR /opt/jax_cosmo
+COPY . .
 
 CMD ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM tensorflow/tensorflow:2.4.0-gpu
+# This contains CUDA 11.0 and CUDNN 8.X.X
+# Could try using later versions
+
+# Basic dependencies
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get update && apt-get install -y wget pkg-config curl \
+        git cmake make swig && apt-get clean all
+RUN apt-get update && apt-get install -y libcfitsio-dev libfftw3-dev \
+        libgsl-dev libbz2-dev  && apt-get clean all
+
+# Install CCL manually
+RUN cd /opt \
+    && git clone https://github.com/LSSTDESC/CCL.git \
+    && cd CCL \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make \
+    && make install \
+    && cd .. \
+    && python setup.py install \
+    && rm -rf /opt/CCL
+
+# Install pytest for unit-testing
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir pytest setuptools astropy fitsio \
+        scipy matplotlib jupyter
+RUN pip install --no-cache-dir jax==0.2.10
+RUN pip install --no-cache-dir jaxlib==0.1.62+cuda110 \
+                                             -f https://storage.googleapis.com/jax-releases/jax_releases.html
+
+WORKDIR /opt/jax_cosmo
+COPY . .
+
+CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
Address #88 - it's using `tensorflow-gpu` as the base image (it doesn't work on arm64 processor at the moment). 

To build the docker image manually, run:

`docker build -t jax_cosmo .`

To execute jax_cosmo in a jupyter notebook within the docker image:

- Host machine: `docker run --rm -it -p 8888:8888 jax_cosmo`
- Inside the container: `jupyter notebook --ip 0.0.0.0 --port 8888 --no-browser --allow-root`
- Access the notebook on : `localhost:8888`
