### PR TITLE
Tophat n_i(z) kernels with additional Gaussian smoothing to simulate LSST and Euclid tomographic redshift bins

### DIFF
--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -159,7 +159,8 @@ class gaussian_sigmoid_nz(redshift_distribution):
     
     Arguments:
     redshift_distribution
-    zbin_width: width of the tomographic redshift bins
+    zbin_lower: lower edge of the tomographic redshift bins
+    zbin_upper: upper edge of the tomographic redshift bins
     zbin_transition: transition scale where the sigmoid goes from 1 to 0
     bw: Bandwidth for the Gaussian kernel
     """

--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -8,6 +8,9 @@ from jax.tree_util import register_pytree_node_class
 from jax_cosmo.jax_utils import container
 from jax_cosmo.scipy.integrate import simps
 
+from jax.scipy.special import expit
+from jax.scipy.signal import convolve
+
 steradian_to_arcmin2 = 11818102.86004228
 
 __all__ = ["smail_nz", "kde_nz", "delta_nz"]
@@ -17,6 +20,7 @@ class redshift_distribution(container):
     def __init__(self, *args, gals_per_arcmin2=1.0, zmax=10.0, **kwargs):
         """Initialize the parameters of the redshift distribution"""
         self._norm = None
+        self._norm_integral_Npoints = 256
         self._gals_per_arcmin2 = gals_per_arcmin2
         super(redshift_distribution, self).__init__(*args, zmax=zmax, **kwargs)
 
@@ -28,7 +32,8 @@ class redshift_distribution(container):
     def __call__(self, z):
         """Computes the normalized n(z)"""
         if self._norm is None:
-            self._norm = simps(lambda t: self.pz_fn(t), 0.0, self.config["zmax"], 256)
+            self._norm = simps(lambda t: self.pz_fn(t), 0.0, self.config["zmax"],
+                    self._norm_integral_Npoints)
         return self.pz_fn(z) / self._norm
 
     @property
@@ -144,3 +149,32 @@ class systematic_shift(redshift_distribution):
     def pz_fn(self, z):
         parent_pz, bias = self.params[:2]
         return parent_pz.pz_fn(np.clip(z - bias, 0))
+
+
+@register_pytree_node_class
+class gaussian_sigmoid_nz(redshift_distribution):
+    """Defines a sigmoid redshift distribution with additional Gaussian smoothing.
+    
+    Arguments:
+    redshift_distribution
+    zbin_width: width of the tomographic redshift bins
+    zbin_transition: transition scale where the sigmoid goes from 1 to 0
+    gauss_mu: mean of the Gaussian smoothing kernel
+    gauss_sigma: std. devation of the Gaussian smoothing kernel
+    """
+    def _sigmoid_kernel(self, x, bin_width, bin_transition):
+        half_width = 0.5*bin_width
+        transition_width = half_width*bin_transition
+        x0 = half_width - transition_width
+        return expit((x+x0)/transition_width) \
+                - expit((x-x0)/transition_width)
+
+    def _gauss_kernel(self, a, mu, sigma):
+        return (((2*np.pi)*sigma**2)**(-.5)) * np.exp((-.5)*((a-mu)/sigma)**2)
+
+    def pz_fn(self, z):
+        parent_pz, zbin_width, zbin_transition, gauss_mu, gauss_sigma = self.params[:5]
+        x = np.linspace(0.0,self.config["zmax"],self._norm_integral_Npoints+1)
+        sigmoid_k = self._sigmoid_kernel(parent_pz.pz_fn(z), zbin_width, zbin_transition)
+        gauss_k = self._gauss_kernel(x, gauss_mu, gauss_sigma)
+        return convolve(sigmoid_k,gauss_k,mode='same')

--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -169,9 +169,9 @@ class gaussian_sigmoid_nz(redshift_distribution):
 
     def pz_fn(self, z):
         parent_pz, zbin_center, zbin_width, zbin_transition = self.params[:4]
-        x = np.linspace(0.,self.config["zmax"],self._norm_integral_Npoints+1)
+        x = np.linspace(zbin_center-0.5*zbin_width,zbin_center+0.5*zbin_width,self._norm_integral_Npoints+1)
         X = np.expand_dims(x, axis=-1)
         sigmoid_k = parent_pz.pz_fn(z)*self._sigmoid_kernel(x, zbin_center, zbin_width, zbin_transition)
-        gauss_k = self._gauss_kernel(self.config['bw'],X,z)
+        gauss_k = self._gauss_kernel(self.config['bw'],X-z,z)
         a = np.matmul(sigmoid_k,gauss_k)
         return a


### PR DESCRIPTION
We implement a `gaussian_sigmoid_nz` sub-class with methods to estimate `n_i(z)` using sigmoid+gaussian kernels. We aim to simulate the `n_i(z)` for LSST and Euclid tomographic bins, following [2104.01397](https://arxiv.org/abs/2104.01397) for LSST and [1910.09273](https://arxiv.org/abs/1910.09273) for Euclid. We figure it might be useful to others.