### PR TITLE
Improve the EH transfer function by updating the zd and sh_d fits

### DIFF
--- a/jax_cosmo/transfer.py
+++ b/jax_cosmo/transfer.py
@@ -4,7 +4,7 @@ import jax.numpy as np
 import jax_cosmo.background as bkgrd
 import jax_cosmo.constants as const
 
-__all__ = ["Eisenstein_Hu", "Genetic_Algorithm"]
+__all__ = ["Eisenstein_Hu"]
 
 
 def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
@@ -36,7 +36,7 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     """
     #############################################
     # Quantities computed from 1998:EisensteinHu
-    # With the options to improve the redshift and sound horizon at drag epoch using fits from Aizpuru:2021vhd
+    # With the options to improve the redshift and sound horizon at drag epoch using fits from Aizpuru:2021vhd (arXiv:2106.00428)
     # Provides : - k_eq   : scale of the particle horizon at equality epoch
     #            - z_eq   : redshift of equality epoch
     #            - R_eq   : ratio of the baryon to photon momentum density
@@ -171,35 +171,3 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     else:
         raise NotImplementedError
     return res
-
-def Genetic_Algorithm(cosmo, k, type="massive_nu"):
-    """Computes the matter transfer function from Genetic Algorithm fits in arXiv:2106.00428.
-
-    Parameters
-    ----------
-    cosmo: Background
-      Background cosmology
-
-    k: array_like
-      Wave number in h Mpc^{-1}
-
-    type: str, optional
-      Type of transfer function. Either 'massless_nu' or 'massive_nu'
-      (def: 'massive_nu')
-
-    Returns
-    -------
-    T: array_like
-      Value of the transfer function at the requested wave number
-
-    Notes
-    -----
-    The GA transfer functions are computed using the GA-based fitting
-    formulae in :cite:`Orjuela-Quintana:2022nnq`
-
-    """
-    #############################################
-    # Quantities computed from Orjuela-Quintana:2022nnq and Aizpuru:2021vhd
-    # Provides :
-    #            - z_d    : redshift of drag epoch
-    #            - sh_d   : sound horizon at drag epoch

--- a/jax_cosmo/transfer.py
+++ b/jax_cosmo/transfer.py
@@ -59,6 +59,10 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     # z drag from Eq. (4)
     b1 = 0.313 * np.power(w_m, -0.419) * (1.0 + 0.607 * np.power(w_m, 0.674))
     b2 = 0.238 * np.power(w_m, 0.223)
+    # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
+    R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
+    # Ratio of the baryon to photon momentum density at z_eq Eq. (5), 1998:EisensteinHu
+    R_eq = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_eq)
     if type in ('eisenhu', 'eisenhu_osc'):
         # Fit for redshift of drag epoch in 1998:EisensteinHu
         z_d = (
@@ -81,17 +85,13 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
         # Fit for sound horizon at drag epoch in h^-1 Mpc, h*Eq (7), Aizpuru:2021vhd
         sh_d = cosmo.h / (aa1*np.power(w_b,aa2) + aa3*np.power(w_m,aa4) + aa5*np.power(w_b,aa6)*np.power(w_m,aa7))
     else:
-    # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
-    R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
-    # Ratio of the baryon to photon momentum density at z_eq Eq. (5), 1998:EisensteinHu
-    R_eq = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_eq)
-    # Sound horizon at drag epoch in h^-1 Mpc, Eq. (6), 1998:EisensteinHu
-    sh_d = (
-        2.0
-        / (3.0 * k_eq)
-        * np.sqrt(6.0 / R_eq)
-        * np.log((np.sqrt(1.0 + R_d) + np.sqrt(R_eq + R_d)) / (1.0 + np.sqrt(R_eq)))
-    )
+        # Sound horizon at drag epoch in h^-1 Mpc, Eq. (6), 1998:EisensteinHu
+        sh_d = (
+            2.0
+            / (3.0 * k_eq)
+            * np.sqrt(6.0 / R_eq)
+            * np.log((np.sqrt(1.0 + R_d) + np.sqrt(R_eq + R_d)) / (1.0 + np.sqrt(R_eq)))
+        )
     # Eq. (7) but in [hMpc^{-1}]
     k_silk = (
         1.6

--- a/jax_cosmo/transfer.py
+++ b/jax_cosmo/transfer.py
@@ -4,7 +4,7 @@ import jax.numpy as np
 import jax_cosmo.background as bkgrd
 import jax_cosmo.constants as const
 
-__all__ = ["Eisenstein_Hu"]
+__all__ = ["Eisenstein_Hu", "Genetic_Algorithm"]
 
 
 def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
@@ -30,12 +30,13 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     Notes
     -----
     The Eisenstein & Hu transfer functions are computed using the fitting
-    formulae of :cite:`1998:EisensteinHu`
+    formulae of :cite:`1998:EisensteinHu`.
+    [OPTIONAL] Improving the redshift and sound horizon at drag epoch using fits from :cite:`Aizpuru:2021vhd`
 
     """
     #############################################
     # Quantities computed from 1998:EisensteinHu
-    # With the options to improve the redshift and sound horizon at drag epoch using fits from arXiv:2106.00428
+    # With the options to improve the redshift and sound horizon at drag epoch using fits from Aizpuru:2021vhd
     # Provides : - k_eq   : scale of the particle horizon at equality epoch
     #            - z_eq   : redshift of equality epoch
     #            - R_eq   : ratio of the baryon to photon momentum density
@@ -67,21 +68,18 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
             * (1.0 + b1 * np.power(w_b, b2))
         )
     else:
-        # Fit for redshift of drag epoch in arXiv:2106.00428
-        z_d = (1291 * np.power(w_m,0.251)) / (1.0 + 0.659*np.power(w_m,0.828)) * (1.0 + b1*np.power(w_b,b2)) # Eq (A1), arXiv:2106.00428
+        # Fit for redshift of drag epoch in Aizpuru:2021vhd
+        z_d = (1.0 + 428.169*np.power(w_b,0.256459)*np.power(w_m,0.616388) + 925.56*np.power(w_m,0.751615) ) / np.power(w_m,0.714129) # Eq (A2), Aizpuru:2021vhd
     if type == 'einsenhu_sd':
-        aa1 = 0.0034917
-        aa2 = −19.972694
-        aa3 = 0.000336186
-        aa4 = 0.0000305
-        aa5 = 0.22752
-        aa6 = 0.00003142567
-        aa7 = 0.5453798
-        aa8 = 374.14994
-        aa9 = 4.022356899
-        # Fit for sound horizon at drag epoch in h^-1 Mpc, Eq (10), arXiv:2106.00428
-        sh_d = aa1 * np.exp(aa2 * np.power((aa3 + w_n),2)) / \
-        (aa4 * np.power(w_b,aa5) + aa6*np.power(w_m,aa7) + aa8 * np.power((w_b*w_m),aa9))
+        aa1 = 0.00785436
+        aa2 = 0.17708400
+        aa3 = 0.00912388
+        aa4 = 0.61871100
+        aa5 = 11.9611000
+        aa6 = 2.81343000
+        aa7 = 0.78471900
+        # Fit for sound horizon at drag epoch in h^-1 Mpc, h*Eq (7), Aizpuru:2021vhd
+        sh_d = cosmo.h / (aa1*np.power(w_b,aa2) + aa3*np.power(w_m,aa4) + aa5*np.power(w_b,aa6)*np.power(w_m,aa7))
     else:
     # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
     R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
@@ -173,3 +171,35 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     else:
         raise NotImplementedError
     return res
+
+def Genetic_Algorithm(cosmo, k, type="massive_nu"):
+    """Computes the matter transfer function from Genetic Algorithm fits in arXiv:2106.00428.
+
+    Parameters
+    ----------
+    cosmo: Background
+      Background cosmology
+
+    k: array_like
+      Wave number in h Mpc^{-1}
+
+    type: str, optional
+      Type of transfer function. Either 'massless_nu' or 'massive_nu'
+      (def: 'massive_nu')
+
+    Returns
+    -------
+    T: array_like
+      Value of the transfer function at the requested wave number
+
+    Notes
+    -----
+    The GA transfer functions are computed using the GA-based fitting
+    formulae in :cite:`Orjuela-Quintana:2022nnq`
+
+    """
+    #############################################
+    # Quantities computed from Orjuela-Quintana:2022nnq and Aizpuru:2021vhd
+    # Provides :
+    #            - z_d    : redshift of drag epoch
+    #            - sh_d   : sound horizon at drag epoch

--- a/jax_cosmo/transfer.py
+++ b/jax_cosmo/transfer.py
@@ -59,10 +59,6 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     # z drag from Eq. (4)
     b1 = 0.313 * np.power(w_m, -0.419) * (1.0 + 0.607 * np.power(w_m, 0.674))
     b2 = 0.238 * np.power(w_m, 0.223)
-    # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
-    R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
-    # Ratio of the baryon to photon momentum density at z_eq Eq. (5), 1998:EisensteinHu
-    R_eq = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_eq)
     if type in ('eisenhu', 'eisenhu_osc'):
         # Fit for redshift of drag epoch in 1998:EisensteinHu
         z_d = (
@@ -74,6 +70,10 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     else:
         # Fit for redshift of drag epoch in Aizpuru:2021vhd
         z_d = (1.0 + 428.169*np.power(w_b,0.256459)*np.power(w_m,0.616388) + 925.56*np.power(w_m,0.751615) ) / np.power(w_m,0.714129) # Eq (A2), Aizpuru:2021vhd
+    # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
+    R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
+    # Ratio of the baryon to photon momentum density at z_eq Eq. (5), 1998:EisensteinHu
+    R_eq = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_eq)
     if type == 'einsenhu_sd':
         aa1 = 0.00785436
         aa2 = 0.17708400

--- a/jax_cosmo/transfer.py
+++ b/jax_cosmo/transfer.py
@@ -7,7 +7,7 @@ import jax_cosmo.constants as const
 __all__ = ["Eisenstein_Hu"]
 
 
-def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
+def Eisenstein_Hu(cosmo, k, type="eisenhu_sd"):
     """Computes the Eisenstein & Hu matter transfer function.
 
     Parameters
@@ -19,8 +19,8 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
       Wave number in h Mpc^{-1}
 
     type: str, optional
-      Type of transfer function. Either 'eisenhu' or 'eisenhu_osc'
-      (def: 'eisenhu_osc')
+      Type of transfer function. Either 'eisenhu', 'eisenhu_osc', 'eisenhu_zd', or 'eisenhu_sd'
+      (def: 'eisenhu_sd')
 
     Returns
     -------
@@ -35,6 +35,7 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
     """
     #############################################
     # Quantities computed from 1998:EisensteinHu
+    # With the options to improve the redshift and sound horizon at drag epoch using fits from arXiv:2106.00428
     # Provides : - k_eq   : scale of the particle horizon at equality epoch
     #            - z_eq   : redshift of equality epoch
     #            - R_eq   : ratio of the baryon to photon momentum density
@@ -57,18 +58,36 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
     # z drag from Eq. (4)
     b1 = 0.313 * np.power(w_m, -0.419) * (1.0 + 0.607 * np.power(w_m, 0.674))
     b2 = 0.238 * np.power(w_m, 0.223)
-    z_d = (
-        1291.0
-        * np.power(w_m, 0.251)
-        / (1.0 + 0.659 * np.power(w_m, 0.828))
-        * (1.0 + b1 * np.power(w_b, b2))
-    )
-
-    # Ratio of the baryon to photon momentum density at z_d  Eq. (5)
+    if type in ('eisenhu', 'eisenhu_osc'):
+        # Fit for redshift of drag epoch in 1998:EisensteinHu
+        z_d = (
+            1291.0
+            * np.power(w_m, 0.251)
+            / (1.0 + 0.659 * np.power(w_m, 0.828))
+            * (1.0 + b1 * np.power(w_b, b2))
+        )
+    else:
+        # Fit for redshift of drag epoch in arXiv:2106.00428
+        z_d = (1291 * np.power(w_m,0.251)) / (1.0 + 0.659*np.power(w_m,0.828)) * (1.0 + b1*np.power(w_b,b2)) # Eq (A1), arXiv:2106.00428
+    if type == 'einsenhu_sd':
+        aa1 = 0.0034917
+        aa2 = −19.972694
+        aa3 = 0.000336186
+        aa4 = 0.0000305
+        aa5 = 0.22752
+        aa6 = 0.00003142567
+        aa7 = 0.5453798
+        aa8 = 374.14994
+        aa9 = 4.022356899
+        # Fit for sound horizon at drag epoch in h^-1 Mpc, Eq (10), arXiv:2106.00428
+        sh_d = aa1 * np.exp(aa2 * np.power((aa3 + w_n),2)) / \
+        (aa4 * np.power(w_b,aa5) + aa6*np.power(w_m,aa7) + aa8 * np.power((w_b*w_m),aa9))
+    else:
+    # Ratio of the baryon to photon momentum density at z_d  Eq. (5), 1998:EisensteinHu
     R_d = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_d)
-    # Ratio of the baryon to photon momentum density at z_eq Eq. (5)
+    # Ratio of the baryon to photon momentum density at z_eq Eq. (5), 1998:EisensteinHu
     R_eq = 31.5 * w_b / (T_2_7_sqr) ** 2 * (1.0e3 / z_eq)
-    # Sound horizon at drag epoch in h^-1 Mpc Eq. (6)
+    # Sound horizon at drag epoch in h^-1 Mpc, Eq. (6), 1998:EisensteinHu
     sh_d = (
         2.0
         / (3.0 * k_eq)
@@ -104,7 +123,7 @@ def Eisenstein_Hu(cosmo, k, type="eisenhu_osc"):
         C = 14.2 + 731.0 / (1.0 + 62.5 * q)
         res = L / (L + C * q * q)
 
-    elif type == "eisenhu_osc":
+    elif type in ("eisenhu_osc", "eisenhu_zd", "eisenhu_sd"):
         # Cold dark matter transfer function
 
         # EH98 (11, 12)


### PR DESCRIPTION
The sound horizon in EH 1998 fit is only accurate up to 2%. This is easily noticeable when one considers BAO quantities like `DA/sh_d`. This (in)accuracy further affects the transfer function.

The issue ultimately boils down to the fit for redshift at drag epoch, `z_d` given in EH 1998. So one can either improve on that, or directly on the sound horizon at drag epoch, `zh_d`. There are plenty literature on this, here I picked the `z_d` and `sh_d` fits from [arXiv:2106.00428](https://arxiv.org/abs/2106.00428), which should provide `sh_d` at sub-percent accuracy (within LCDM).