### PR TITLE
Fixed small error in interpolate.py

### DIFF
--- a/jax_cosmo/scipy/interpolate.py
+++ b/jax_cosmo/scipy/interpolate.py
@@ -229,6 +229,7 @@ class InterpolatedUnivariateSpline(object):
         self._x = x
         self._y = y
         self._coefficients = coefficients
+        self._endpoints = endpoints
 
     # Operations for flattening/unflattening representation
     def tree_flatten(self):


### PR DESCRIPTION
The flattening method for the InterpolatedUnivariateSpline class uses self._endpoints which is never created in the __init__() method. I ran into this error when trying to flatten this class. A simple fix for me was to just add the one line "self._endpoints = endpoints" after "self._coefficients = coefficients".