### PR TITLE
Adds the redshift distribution from Martinet et al. (2021)

### DIFF
--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -76,23 +76,24 @@ class smail_nz(redshift_distribution):
         a, b, z0 = self.params
         return z**a * np.exp(-((z / z0) ** b))
 
+
 @register_pytree_node_class
 class fu_nz(redshift_distribution):
     """Defines the redshift distribution from Fu et al. (2008), as used in Martinet et al. (2021)
-    
+
     Formula: n(z) = A * (z^a + z^(ab)) / (z^b + c)
-    
+
     Parameters:
     -----------
     a: float
         Shape parameter (0.4710 in Martinet et al. 2021)
-    b: float  
+    b: float
         Shape parameter (5.1843 in Martinet et al. 2021)
     c: float
         Shape parameter (0.7259 in Martinet et al. 2021)
     gals_per_arcmin2: float
         Number of galaxies per sq arcmin (30 in Martinet et al. 2021)
-    
+
     References:
     -----------
     Fu et al. (2008) - https://arxiv.org/abs/0712.0884
@@ -101,7 +102,7 @@ class fu_nz(redshift_distribution):
 
     def pz_fn(self, z):
         a, b, c = self.params
-        return (z**a + z**(a*b)) / (z**b + c)
+        return (z**a + z ** (a * b)) / (z**b + c)
 
 
 @register_pytree_node_class

--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -10,7 +10,7 @@ from jax_cosmo.scipy.integrate import simps
 
 steradian_to_arcmin2 = 11818102.86004228
 
-__all__ = ["smail_nz", "kde_nz", "delta_nz"]
+__all__ = ["smail_nz", "martinet_nz" "kde_nz", "delta_nz"]
 
 
 class redshift_distribution(container):
@@ -76,6 +76,25 @@ class smail_nz(redshift_distribution):
     def pz_fn(self, z):
         a, b, z0 = self.params
         return z**a * np.exp(-((z / z0) ** b))
+
+@register_pytree_node_class
+class martinet_nz(redshift_distribution):
+    """Defines a the distribution from Martinet et al. (eqn 10 2010.07376) with these arguments
+    Parameters:
+    -----------
+
+    a:
+
+    b:
+
+    c:
+
+    gals_per_arcmin2: number of galaxies per sq arcmin (30 in the original paper)
+    """
+
+    def pz_fn(self, z):
+        a, b, c = self.params
+        return (z**a + z**(a*b)) / (z**b + c)
 
 
 @register_pytree_node_class

--- a/jax_cosmo/redshift.py
+++ b/jax_cosmo/redshift.py
@@ -10,7 +10,7 @@ from jax_cosmo.scipy.integrate import simps
 
 steradian_to_arcmin2 = 11818102.86004228
 
-__all__ = ["smail_nz", "martinet_nz" "kde_nz", "delta_nz"]
+__all__ = ["smail_nz", "fu_nz", "kde_nz", "delta_nz"]
 
 
 class redshift_distribution(container):
@@ -78,18 +78,26 @@ class smail_nz(redshift_distribution):
         return z**a * np.exp(-((z / z0) ** b))
 
 @register_pytree_node_class
-class martinet_nz(redshift_distribution):
-    """Defines a the distribution from Martinet et al. (eqn 10 2010.07376) with these arguments
+class fu_nz(redshift_distribution):
+    """Defines the redshift distribution from Fu et al. (2008), as used in Martinet et al. (2021)
+    
+    Formula: n(z) = A * (z^a + z^(ab)) / (z^b + c)
+    
     Parameters:
     -----------
-
-    a:
-
-    b:
-
-    c:
-
-    gals_per_arcmin2: number of galaxies per sq arcmin (30 in the original paper)
+    a: float
+        Shape parameter (0.4710 in Martinet et al. 2021)
+    b: float  
+        Shape parameter (5.1843 in Martinet et al. 2021)
+    c: float
+        Shape parameter (0.7259 in Martinet et al. 2021)
+    gals_per_arcmin2: float
+        Number of galaxies per sq arcmin (30 in Martinet et al. 2021)
+    
+    References:
+    -----------
+    Fu et al. (2008) - https://arxiv.org/abs/0712.0884
+    Martinet et al. (2021) - https://arxiv.org/abs/2010.07376
     """
 
     def pz_fn(self, z):


### PR DESCRIPTION
Includes one additional function for the redshift distribution given in equation 10 of Martinet et al. (2021), [https://arxiv.org/pdf/2010.07376](https://arxiv.org/pdf/2010.07376). Untested as I didn't see any pre-existing tests for the redshift module.