### PR TITLE
Fix docstrings with latex symbols

### DIFF
--- a/jax_cosmo/background.py
+++ b/jax_cosmo/background.py
@@ -369,7 +369,7 @@ def angular_diameter_distance(cosmo, a):
 
 
 def growth_factor(cosmo, a):
-    """Compute linear growth factor D(a) at a given scale factor,
+    r"""Compute linear growth factor D(a) at a given scale factor,
     normalized such that D(a=1) = 1.
 
     Parameters
@@ -399,7 +399,7 @@ def growth_factor(cosmo, a):
 
 
 def growth_rate(cosmo, a):
-    """Compute growth rate dD/dlna at a given scale factor.
+    r"""Compute growth rate dD/dlna at a given scale factor.
 
     Parameters
     ----------

--- a/jax_cosmo/core.py
+++ b/jax_cosmo/core.py
@@ -12,7 +12,7 @@ __all__ = ["Cosmology"]
 @register_pytree_node_class
 class Cosmology:
     def __init__(self, Omega_c, Omega_b, h, n_s, sigma8, Omega_k, w0, wa, gamma=None):
-        """
+        r"""
         Cosmology object, stores primary and derived cosmological parameters.
 
         Parameters:

--- a/jax_cosmo/scipy/integrate.py
+++ b/jax_cosmo/scipy/integrate.py
@@ -161,7 +161,7 @@ def romb(function, a, b, args=(), divmax=6, return_error=False):
 
 
 def simps(f, a, b, N=128):
-    """Approximate the integral of f(x) from a to b by Simpson's rule.
+    r"""Approximate the integral of f(x) from a to b by Simpson's rule.
 
     Simpson's rule approximates the integral \int_a^b f(x) dx by the sum:
     (dx/3) \sum_{k=1}^{N/2} (f(x_{2i-2} + 4f(x_{2i-1}) + f(x_{2i}))


### PR DESCRIPTION
Some docstrings containing latex characters were not set as raw strings, which caused errors during package import.