### PR TITLE
fix error with DistrubutionNotFound and switch to PackageNotFoundError

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/jax_cosmo/__init__.py
+++ b/jax_cosmo/__init__.py
@@ -1,9 +1,9 @@
 # Cosmology in JAX
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 


### PR DESCRIPTION
This pull request updates how the package version is retrieved in `jax_cosmo/__init__.py` to use the modern `importlib.metadata` module instead of the deprecated `pkg_resources`. This change improves compatibility with newer Python versions and avoids unnecessary dependencies.

- Modernized version retrieval:
  * Replaced `pkg_resources.get_distribution` and `DistributionNotFound` with `importlib.metadata.version` and `PackageNotFoundError` in `jax_cosmo/__init__.py`.

This warning is now an error on python 3.10 

```
Traceback:
/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_spherical_painting_methods.py:25: in <module>
    import jax_cosmo as jc
/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/jax_cosmo/__init__.py:2: in <module>
    from pkg_resources import DistributionNotFound
E   ModuleNotFoundError: No module named 'pkg_resources'
```


Which blocs JaxPM CI => https://github.com/DifferentiableUniverseInitiative/JaxPM/actions/runs/22356291638/job/64696767811?pr=54